### PR TITLE
Support for booking_code and productName

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -1098,7 +1098,7 @@ This library is verified to work with following banks.
 - [ ] VB Nahetal eG
 - [ ] VB Nordmünsterland Mitte eG
 - [ ] VB RB eG, Neumünster
-- [ ] VB RheinAhrEifel eG.
+- [x] VB RheinAhrEifel eG.
 - [ ] VB Spelle-Freren eG
 - [ ] VB Südkirchen-Cap.-Nordkirchen
 - [ ] VB Vallendar-Niederwerth eG

--- a/Samples/statement_of_account.php
+++ b/Samples/statement_of_account.php
@@ -11,28 +11,42 @@ use Fhp\FinTs;
 use Fhp\Model\StatementOfAccount\Statement;
 use Fhp\Model\StatementOfAccount\Transaction;
 
-define('FHP_BANK_URL', '');                # HBCI / FinTS Url can be found here: https://www.hbci-zka.de/institute/institut_auswahl.htm (use the PIN/TAN URL)
-define('FHP_BANK_PORT', 443);              # HBCI / FinTS Port can be found here: https://www.hbci-zka.de/institute/institut_auswahl.htm
+// Register your application prior to begin at https://www.hbci-zka.de/register/prod_register.htm
+
+define('FHP_BANK_URL', '');                # HBCI / FinTS Url will be provided to you after registration (use the PIN/TAN URL)
+define('FHP_BANK_PORT', 443);              # static standard TCP port for HTTPS
 define('FHP_BANK_CODE', '');               # Your bank code / Bankleitzahl
 define('FHP_ONLINE_BANKING_USERNAME', ''); # Your online banking username / alias
 define('FHP_ONLINE_BANKING_PIN', '');      # Your online banking PIN (NOT! the pin of your bank card!)
+define('FHP_REGISTRATION_NO', '');         # The number you receive after registration / FinTS-Registrierungsnummer
+define('FHP_SOFTWARE_VERSION', '1.0');     # Your own Software product version
 
 $fints = new FinTs(
     FHP_BANK_URL,
     FHP_BANK_PORT,
     FHP_BANK_CODE,
     FHP_ONLINE_BANKING_USERNAME,
-    FHP_ONLINE_BANKING_PIN
+    FHP_ONLINE_BANKING_PIN,
+    null,
+    FHP_REGISTRATION_NO,
+    FHP_SOFTWARE_VERSION
 );
 
-$accounts = $fints->getSEPAAccounts();
+try {
 
-$oneAccount = $accounts[0];
-$from = new \DateTime('2016-01-01');
-$to   = new \DateTime();
-$soa = $fints->getStatementOfAccount($oneAccount, $from, $to);
+    $accounts = $fints->getSEPAAccounts();
 
-$fints->end();
+    $oneAccount = $accounts[0];
+    $from = new \DateTime('2016-01-01');
+    $to = new \DateTime();
+    $soa = $fints->getStatementOfAccount($oneAccount, $from, $to);
+
+    $fints->end();
+
+} catch (\Exception $ex) {
+    echo 'Sth. went wrong - ' . $ex->getMessage();
+    exit;
+}
 
 foreach ($soa->getStatements() as $statement) {
     echo $statement->getDate()->format('Y-m-d') . ': Start Saldo: ' . ($statement->getCreditDebit() == Statement::CD_DEBIT ? '-' : '') . $statement->getStartBalance() . PHP_EOL;

--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,9 @@
     }
   },
   "require": {
-    "php": ">=5.3.2",
-    "psr/log": "~1.0"
+    "php": ">=5.6",
+    "psr/log": "~1.0",
+    "ext-curl": "*"
   },
   "require-dev": {
   },

--- a/composer.lock
+++ b/composer.lock
@@ -4,67 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "707552f5326ab26bb17040c3259f02a5",
+    "content-hash": "3b467daa5a18639674ba145fbeeeaffa",
     "packages": [
         {
-            "name": "nemiah/php-sepa-xml",
-            "version": "dev-master",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/nemiah/phpSepaXml.git",
-                "reference": "55239189196c8b6ed16f3db9b52db1036600306e"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/nemiah/phpSepaXml/zipball/55239189196c8b6ed16f3db9b52db1036600306e",
-                "reference": "55239189196c8b6ed16f3db9b52db1036600306e",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.6.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "5.6.*"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "nemiah\\phpSepaXml\\": [
-                        "src/nemiah/phpSepaXml/"
-                    ]
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "LGPL-3.0"
-            ],
-            "authors": [
-                {
-                    "name": "Nena Furtmeier",
-                    "email": "support@furtmeier.it",
-                    "role": "Developer"
-                }
-            ],
-            "description": "Simple classes for creating SEPA transfer and direct debit xml files. No dependencies",
-            "homepage": "https://github.com/nemiah/phpSepaXml",
-            "keywords": [
-                "sepa",
-                "xml"
-            ],
-            "time": "2017-05-07 09:26:12"
-        },
-        {
             "name": "psr/log",
-            "version": "1.0.2",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/log.git",
-                "reference": "4ebe3a8bf773a19edfe0a84b6585ba3d401b724d"
+                "reference": "6c001f1daafa3a3ac1d8ff69ee4db8e799a654dd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/4ebe3a8bf773a19edfe0a84b6585ba3d401b724d",
-                "reference": "4ebe3a8bf773a19edfe0a84b6585ba3d401b724d",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/6c001f1daafa3a3ac1d8ff69ee4db8e799a654dd",
+                "reference": "6c001f1daafa3a3ac1d8ff69ee4db8e799a654dd",
                 "shasum": ""
             },
             "require": {
@@ -98,19 +51,18 @@
                 "psr",
                 "psr-3"
             ],
-            "time": "2016-10-10T12:19:37+00:00"
+            "time": "2018-11-20T15:27:04+00:00"
         }
     ],
     "packages-dev": [],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {
-        "nemiah/php-sepa-xml": 20
-    },
+    "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=5.3.2"
+        "php": ">=5.6",
+        "ext-curl": "*"
     },
     "platform-dev": []
 }

--- a/lib/Fhp/Connection.php
+++ b/lib/Fhp/Connection.php
@@ -43,6 +43,12 @@ class Connection
 	
     /**
      * Connection constructor.
+     *
+     * @param string $host
+     * @param int $port
+     * @param int $timeoutConnect
+     * @param int $timeoutResponse
+     * @throws CurlException
      */
     public function __construct($host, $port, $timeoutConnect = 15, $timeoutResponse = 30)
     {
@@ -63,6 +69,7 @@ class Connection
      *
      * @param AbstractMessage $message
      * @return string
+     * @throws CurlException
      */
     public function send(AbstractMessage $message)
     {

--- a/lib/Fhp/Dialog/Dialog.php
+++ b/lib/Fhp/Dialog/Dialog.php
@@ -84,6 +84,16 @@ class Dialog
     protected $hkkazVersion = 6;
 
     /**
+     * @var string
+     */
+    protected $productName;
+
+    /**
+     * @var string
+     */
+    protected $productVersion;
+
+    /**
      * Dialog constructor.
      *
      * @param Connection $connection
@@ -92,15 +102,26 @@ class Dialog
      * @param string $pin
      * @param string $systemId
      * @param LoggerInterface $logger
+     * @param string $productName
+     * @param string $productVersion
      */
-    public function __construct(Connection $connection, $bankCode, $username, $pin, $systemId, LoggerInterface $logger)
-    {
+    public function __construct(
+        Connection $connection,
+        $bankCode,
+        $username,
+        $pin, $systemId,
+        LoggerInterface $logger,
+        $productName,
+        $productVersion
+    ) {
         $this->connection = $connection;
         $this->bankCode = $bankCode;
         $this->username = $username;
         $this->pin = $pin;
         $this->systemId = $systemId;
         $this->logger = $logger;
+        $this->productName = $productName;
+        $this->productVersion = $productVersion;
     }
 
     /**
@@ -147,7 +168,7 @@ class Dialog
             }
 
             return $response;
-        } catch (CurlException $e) {
+        } catch (\Exception $e) {
             $this->logger->critical($e->getMessage());
             if ($e instanceof CurlException) {
                 $this->logger->debug(print_r($e->getCurlInfo(), true));
@@ -159,6 +180,7 @@ class Dialog
 
     /**
      * @param Response $response
+     * @throws \Exception
      */
     protected function handleResponse(Response $response)
     {
@@ -282,7 +304,14 @@ class Dialog
         $this->logger->info('');
         $this->logger->info('DIALOG initialize');
         $identification = new HKIDN(3, $this->bankCode, $this->username, $this->systemId);
-        $prepare        = new HKVVB(4, HKVVB::DEFAULT_BPD_VERSION, HKVVB::DEFAULT_UPD_VERSION, HKVVB::LANG_DEFAULT);
+        $prepare        = new HKVVB(
+            4,
+            HKVVB::DEFAULT_BPD_VERSION,
+            HKVVB::DEFAULT_UPD_VERSION,
+            HKVVB::LANG_DEFAULT,
+            $this->productName,
+            $this->productVersion
+        );
 
         $message = new Message(
             $this->bankCode,
@@ -314,6 +343,7 @@ class Dialog
     /**
      * Sends sync request.
      *
+     * @param boolean
      * @return string
      * @throws CurlException
      * @throws FailedRequestException
@@ -328,7 +358,14 @@ class Dialog
         $this->dialogId = 0;
 
         $identification = new HKIDN(3, $this->bankCode, $this->username, 0);
-        $prepare        = new HKVVB(4, HKVVB::DEFAULT_BPD_VERSION, HKVVB::DEFAULT_UPD_VERSION, HKVVB::LANG_DEFAULT);
+        $prepare        = new HKVVB(
+            4,
+            HKVVB::DEFAULT_BPD_VERSION,
+            HKVVB::DEFAULT_UPD_VERSION,
+            HKVVB::LANG_DEFAULT,
+            $this->productName,
+            $this->productVersion
+        );
         $sync           = new HKSYN(5);
 
         $syncMsg = new Message(

--- a/lib/Fhp/Dialog/Dialog.php
+++ b/lib/Fhp/Dialog/Dialog.php
@@ -303,6 +303,8 @@ class Dialog
     {
         $this->logger->info('');
         $this->logger->info('DIALOG initialize');
+        $this->logger->debug('Registered product:' . trim($this->productName . ' ' . $this->productVersion));
+
         $identification = new HKIDN(3, $this->bankCode, $this->username, $this->systemId);
         $prepare        = new HKVVB(
             4,

--- a/lib/Fhp/Dialog/Dialog.php
+++ b/lib/Fhp/Dialog/Dialog.php
@@ -303,7 +303,7 @@ class Dialog
     {
         $this->logger->info('');
         $this->logger->info('DIALOG initialize');
-        $this->logger->debug('Registered product:' . trim($this->productName . ' ' . $this->productVersion));
+        $this->logger->debug('Registered product: ' . trim($this->productName . ' ' . $this->productVersion));
 
         $identification = new HKIDN(3, $this->bankCode, $this->username, $this->systemId);
         $prepare        = new HKVVB(

--- a/lib/Fhp/FinTs.php
+++ b/lib/Fhp/FinTs.php
@@ -53,8 +53,13 @@ class FinTs extends FinTsInternal {
     protected $bankName;
 	/** @var int */
 	protected $tanMechanism;
-	
+    /** @var Dialog */
 	protected $dialog;
+    /** @var string */
+    protected $productName;
+    /** @var string */
+    protected $productVersion;
+
     /**
      * FinTs constructor.
      * @param string $server
@@ -63,6 +68,8 @@ class FinTs extends FinTsInternal {
      * @param string $username
      * @param string $pin
      * @param LoggerInterface|null $logger
+     * @param string $productName
+     * @param string $productVersion
      */
     public function __construct(
         $server,
@@ -70,7 +77,9 @@ class FinTs extends FinTsInternal {
         $bankCode,
         $username,
         $pin,
-        LoggerInterface $logger = null
+        LoggerInterface $logger = null,
+        $productName = '',
+        $productVersion = ''
     ) {
         $this->url = trim($server);
         $this->port = intval($port);
@@ -86,6 +95,9 @@ class FinTs extends FinTsInternal {
         // HBCI special chars.
         $this->username = self::escapeString($username);
         $this->pin = self::escapeString($pin);
+
+        if ($productName != '') $this->productName = self::escapeString($productName);
+        if ($productVersion != '') $this->productVersion = self::escapeString($productVersion);
 
         #$this->connection = new Connection($this->server, $this->port, $this->timeoutConnect, $this->timeoutResponse);
     }

--- a/lib/Fhp/FinTsInternal.php
+++ b/lib/Fhp/FinTsInternal.php
@@ -133,7 +133,9 @@ class FinTsInternal {
      * Helper method to retrieve a pre configured dialog object.
      * Factory for poor people :)
      *
+     * @param boolean
      * @return Dialog
+     * @throws \Exception
      */
     protected function getDialog($sync = true) {
 		if ($this->dialog)
@@ -148,9 +150,11 @@ class FinTsInternal {
             $this->username,
             $this->pin,
             $this->systemId,
-            $this->logger
+            $this->logger,
+            $this->productName,
+            $this->productName
         );
-		
+
 		if ($sync)
 	        $D->syncDialog(false);
 		

--- a/lib/Fhp/FinTsInternal.php
+++ b/lib/Fhp/FinTsInternal.php
@@ -152,7 +152,7 @@ class FinTsInternal {
             $this->systemId,
             $this->logger,
             $this->productName,
-            $this->productName
+            $this->productVersion
         );
 
 		if ($sync)

--- a/lib/Fhp/Model/StatementOfAccount/Transaction.php
+++ b/lib/Fhp/Model/StatementOfAccount/Transaction.php
@@ -34,6 +34,11 @@ class Transaction
     /**
      * @var string
      */
+    protected $bookingCode;
+
+    /**
+     * @var string
+     */
     protected $bookingText;
 
     /**
@@ -192,6 +197,30 @@ class Transaction
     public function setCreditDebit($creditDebit)
     {
         $this->creditDebit = $creditDebit;
+
+        return $this;
+    }
+
+    /**
+     * Get bookingCode
+     *
+     * @return string
+     */
+    public function getBookingCode()
+    {
+        return $this->bookingCode;
+    }
+
+    /**
+     * Set bookingCode
+     *
+     * @param string $bookingCode
+     *
+     * @return $this
+     */
+    public function setBookingCode($bookingCode)
+    {
+        $this->bookingCode = (string) $bookingCode;
 
         return $this;
     }

--- a/lib/Fhp/Response/GetStatementOfAccount.php
+++ b/lib/Fhp/Response/GetStatementOfAccount.php
@@ -83,6 +83,7 @@ class GetStatementOfAccount extends Response
                     $transaction->setValutaDate(new \DateTime($trx['valuta_date']));
                     $transaction->setCreditDebit($trx['credit_debit']);
                     $transaction->setAmount($trx['amount']);
+                    $transaction->setBookingCode($trx['booking_code']);
                     $transaction->setBookingText($trx['description']['booking_text']);
                     $transaction->setDescription1($trx['description']['description_1']);
                     $transaction->setDescription2($trx['description']['description_2']);

--- a/lib/Fhp/Response/GetStatementOfAccount.php
+++ b/lib/Fhp/Response/GetStatementOfAccount.php
@@ -77,13 +77,13 @@ class GetStatementOfAccount extends Response
 					foreach($replaceIn AS $k)
 						if(isset($trx['description'][$k]))
 							$trx['description'][$k] = str_replace ("@@", "", $trx['description'][$k]);
-					
+
                     $transaction = new Transaction();
                     $transaction->setBookingDate(new \DateTime($trx['booking_date']));
                     $transaction->setValutaDate(new \DateTime($trx['valuta_date']));
                     $transaction->setCreditDebit($trx['credit_debit']);
                     $transaction->setAmount($trx['amount']);
-                    $transaction->setBookingCode($trx['booking_code']);
+                    $transaction->setBookingCode($trx['description']['booking_code']);
                     $transaction->setBookingText($trx['description']['booking_text']);
                     $transaction->setDescription1($trx['description']['description_1']);
                     $transaction->setDescription2($trx['description']['description_2']);


### PR DESCRIPTION
Hi,
wir brauchten für unsere Buchhaltung den Geschäftsvorfall-Code aus dem Kontoauszug (booking_code im MT940). Dafür habe ich in der Klasse Fhp\Model\StatementOfAccount\Transaction einen getter/setter hinzugefügt.
Bei der Gelegenheit habe auch gleich eine Unterstützung für die Produkt-Registrierungsnummer eingebaut (Parameter 7 in der Fhp\FinTs Klasse) und die Minimum PHP-Version im Composer auf 5.6 erhöht.
Keine großen Sachen aber vielleicht nützlich...
Eine angepasste "Samples" Datei folgt noch.
Gruss, Markus