### PR TITLE
Correctly end dialogs after sync

### DIFF
--- a/lib/Fhp/Dialog/Dialog.php
+++ b/lib/Fhp/Dialog/Dialog.php
@@ -412,7 +412,7 @@ class Dialog
      * @throws FailedRequestException
      * @throws \Exception
      */
-    public function syncDialog($endDialog = true, $sendHKTan = true, $tanMechanism = null)
+    public function syncDialog($sendHKTan = true, $tanMechanism = null)
     {
 		
         $this->logger->info('');
@@ -490,10 +490,6 @@ class Dialog
         $this->logger->info('Received system id: ' . $response->getSystemId());
         $this->logger->info('Received dialog id: ' . $response->getDialogId());
         $this->logger->info('Supported TAN mechanisms: ' . implode(', ', $this->supportedTanMechanisms));
-
-		if($endDialog)
-		    $this->endDialog();
-
         $this->logger->info('SYNC end');
 		
         return $response;

--- a/lib/Fhp/FinTs.php
+++ b/lib/Fhp/FinTs.php
@@ -174,6 +174,7 @@ class FinTs extends FinTsInternal {
 			return;
 		
 		$this->dialog->endDialog();
+		$this->dialog = null;
 	}
 	
     /**

--- a/lib/Fhp/FinTs.php
+++ b/lib/Fhp/FinTs.php
@@ -127,6 +127,7 @@ class FinTs extends FinTsInternal {
     public function getAccounts() {
         $dialog = $this->getDialog(false);
         $result = $dialog->syncDialog();
+        $this->end();
         $this->bankName = $dialog->getBankName();
         $accounts = new GetAccounts($result);
 
@@ -142,7 +143,8 @@ class FinTs extends FinTsInternal {
     public function getSEPAAccounts() {
         $dialog = $this->getDialog(false);#, $this->tanMechanism);
 		#$dialog->endDialog(); //probably not required
-		$dialog->syncDialog(true, true, $this->tanMechanism);
+		$dialog->syncDialog(true, $this->tanMechanism);
+		$dialog->endDialog();
         $dialog->initDialog();
 
         $message = $this->getNewMessage(
@@ -163,7 +165,8 @@ class FinTs extends FinTsInternal {
 
 	public function getVariables(){
         $dialog = $this->getDialog(false);
-		$result = $dialog->syncDialog(true, false);
+		$result = $dialog->syncDialog(false);
+		$this->end();
 		
 		$R = new GetVariables($result->rawResponse);
 		return $R->get();
@@ -183,9 +186,10 @@ class FinTs extends FinTsInternal {
      * @return string
      */
     public function getBankName() {
-        if (null == $this->bankName) 
+        if (null == $this->bankName) {
             $this->getDialog()->syncDialog();
-        
+            $this->end();
+        }
 
         return $this->bankName;
     }

--- a/lib/Fhp/FinTsInternal.php
+++ b/lib/Fhp/FinTsInternal.php
@@ -159,7 +159,7 @@ class FinTsInternal {
         );
 
 		if ($sync)
-	        $D->syncDialog(false);
+	        $D->syncDialog();
 		
 		$this->dialog = $D;
 		


### PR DESCRIPTION
Discussion: https://github.com/nemiah/phpFinTS/issues/20#issuecomment-531487455

Clear `$this->dialog` in `FinTs::end()`. Continuing any communication on a closed dialog results in errors, obviously. Clearing it will tell `getDialog()` to initialize a new dialog.

In order to make sure that `FinTs::end()` is actually called, the `Dialog::syncDialog()` cannot (or rather: should not) implicitly end the dialog, so remove that functionality and instead call `FinTs::end()` at the respective call sites.

Note: I tried _not_ ending the dialog after calls like `getVariables()`, but apparently sending additional messages on the same dialog (e.g. fetching account statements) does not work.