### PR TITLE
Add FinTsParser for properly documented splitting of escaped strings

### DIFF
--- a/lib/Fhp/Parser/FinTsParser.php
+++ b/lib/Fhp/Parser/FinTsParser.php
@@ -1,0 +1,37 @@
+<?php
+
+
+namespace Fhp\Parser;
+
+/**
+ * Class FinTsParser
+ *
+ * Helper functions for parsing the FinTs wire format.
+ *
+ * @package Fhp\Parser
+ */
+abstract class FinTsParser
+{
+
+    /**
+     * The FinTs wire format specifies escaping with a question mark `?` for the syntax characters `+:'?@`. This
+     * function splits strings delimited by one of these while honoring escaping within.
+     *
+     * @link: https://www.hbci-zka.de/dokumente/spezifikation_deutsch/fintsv3/FinTS_3.0_Formals_2017-10-06_final_version.pdf
+     * Section H.1.3 "Entwertung"
+     *
+     * @param string $delimiter The delimiter around which to split.
+     * @param string $str The raw string, usually a response from the server.
+     * @return string[] The splitted substrings. Note that escaped characters inside will still be escaped.
+     */
+    public static function splitEscapedString($delimiter, $str)
+    {
+        if (empty($str)) return array();
+        // Since most of the $delimiters used in FinTs are also special characters in regexes, we need to escape.
+        $delimiter = preg_quote($delimiter, '/');
+        // This regex uses a negated look-behind. Generally, the regex `(?<!foo)x` matches an `x` that is NOT preceded
+        // by `foo`. In this case, we want to match on the split $delimiter when it is not preceded by the escape
+        // character `?`, which we need to escape because it's a special character in regexes.
+        return preg_split("/(?<!\\?)$delimiter/", $str);
+    }
+}

--- a/lib/Fhp/Response/Response.php
+++ b/lib/Fhp/Response/Response.php
@@ -2,7 +2,9 @@
 
 namespace Fhp\Response;
 
+use Fhp\FinTs;
 use Fhp\Message\AbstractMessage;
+use Fhp\Parser\FinTsParser;
 use Fhp\Segment\AbstractSegment;
 use Fhp\Segment\NameMapping;
 
@@ -45,7 +47,7 @@ class Response
         $this->response = $this->unwrapEncryptedMsg($rawResponse);
 		
 		$rawResponse = preg_replace("/\@([0-9]*)\@HIRMG/", "@$1@'HIRMG", $rawResponse);
-        $this->segments = preg_split("#'(?=[A-Z]{4,}:\d|')#", $rawResponse);
+        $this->segments = FinTsParser::splitEscapedString("'", $rawResponse);
 
 		$this->dialog = $dialog;
 	}
@@ -360,8 +362,7 @@ class Response
     {
 		preg_match("@\<\?xml.+Document\>@", $segment, $matches);
 		$segment = preg_replace("@\<\?xml.+Document\>@", "EXTRACTEDXML", $segment);
-		
-        $parts = preg_split('/\+(?<!\?\+)/', $segment);
+		$parts = FinTsParser::splitEscapedString('+', $segment);
 
         foreach ($parts as &$part) {
 			if($fix)

--- a/lib/Tests/Fhp/Parser/FinTsParserTest.php
+++ b/lib/Tests/Fhp/Parser/FinTsParserTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Tests\Fhp\Parser;
+
+use Fhp\Parser\FinTsParser;
+
+class FinTsParserTest extends \PHPUnit_Framework_TestCase
+{
+    public function test_splitEscapedString_empty()
+    {
+        $this->assertEquals(array(), FinTsParser::splitEscapedString('+', ''));
+        $this->assertEquals(array('', ''), FinTsParser::splitEscapedString('+', '+'));
+    }
+
+    public function test_splitEscapedString_without_escaping()
+    {
+        $this->assertEquals(array('ABC', 'DEF'), FinTsParser::splitEscapedString('+', 'ABC+DEF'));
+        $this->assertEquals(array('ABC', '', 'DEF'), FinTsParser::splitEscapedString('+', 'ABC++DEF'));
+        $this->assertEquals(array('ABC', ''), FinTsParser::splitEscapedString('+', 'ABC+'));
+        $this->assertEquals(array('', '', 'ABC'), FinTsParser::splitEscapedString('+', '++ABC'));
+    }
+
+    public function test_splitEscapedString_with_escaping()
+    {
+
+        $this->assertEquals(array('A?+', 'DEF'), FinTsParser::splitEscapedString('+', 'A?++DEF'));
+        $this->assertEquals(array('?+C', '', 'D?+'), FinTsParser::splitEscapedString('+', '?+C++D?+'));
+        $this->assertEquals(array('ABC', '?+'), FinTsParser::splitEscapedString('+', 'ABC+?+'));
+        $this->assertEquals(array('', '', '?+C'), FinTsParser::splitEscapedString('+', '++?+C'));
+    }
+}


### PR DESCRIPTION
Response.php contained a correct but undocumented regex for splitting segments around pluses, and a hacky (probably broken) regex for splitting messages into segments around single quotes. This commit adds a documented implementation in a separate class that can deal with any delimiter, uses a slightly simpler regex and has a unit test.

Note: This is untested so far.