### PR TITLE
Redesign segments, DEGs and how they are parsed/serialized #26

### DIFF
--- a/lib/Fhp/Segment/BaseDeg.php
+++ b/lib/Fhp/Segment/BaseDeg.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Fhp\Segment;
+
+use Fhp\Syntax\Parser;
+use Fhp\Syntax\Serializer;
+
+/**
+ * Class BaseDeg
+ *
+ * Base class for Data Element Groups (Datenelement-Gruppen; DEGs).
+ *
+ * @package Fhp\Segment
+ */
+abstract class BaseDeg
+{
+    /**
+     * Reference to the descriptor for this type of segment.
+     * @var DegDescriptor
+     */
+    private $descriptor;
+
+    public function __construct()
+    {
+        $this->descriptor = DegDescriptor::get(static::class);
+    }
+
+    public function getDescriptor()
+    {
+        return $this->descriptor;
+    }
+
+    /**
+     * @throws \InvalidArgumentException If any element in this DEG is invalid.
+     */
+    public function validate()
+    {
+        $this->descriptor->validateObject($this);
+    }
+
+    /**
+     * Short-hand for {@link Serializer#serializeDeg()}.
+     * @return string The HBCI wire format representation of this DEG, terminated by the segment delimiter.
+     */
+    public function serialize()
+    {
+        return Serializer::serializeDeg($this);
+    }
+
+    /**
+     * Convenience function for {@link Parser#parseGroup()}. This function should not be called on BaseDeg itself, but
+     * only on one of its sub-classes.
+     * @param string $rawElements The serialized wire format for a data element group.
+     * @return BaseDeg The parsed value.
+     */
+    public static function parse($rawElements)
+    {
+        return Parser::parseDeg($rawElements, static::class);
+    }
+}

--- a/lib/Fhp/Segment/BaseDescriptor.php
+++ b/lib/Fhp/Segment/BaseDescriptor.php
@@ -1,0 +1,186 @@
+<?php
+
+namespace Fhp\Segment;
+
+use Fhp\Syntax\Delimiter;
+
+/**
+ * Class BaseDescriptor
+ *
+ * Common functionality for segment/Deg descriptors.
+ *
+ * @package Fhp\Segment
+ */
+abstract class BaseDescriptor
+{
+    /** @var string Example: "Fhp\Segment\HITANSv1" (Segment) or "Fhp\Segment\Segmentkopf" (Deg) */
+    public $class;
+    /** @var integer Example: 1 */
+    public $version = 1;
+
+    /**
+     * Descriptors for the elements inside the segment/Deg in the order of the wire format. The indices in this array
+     * match the speficiation. In particular, the first index is 1 (not 0) and some indices may be missing if the
+     * documentation does not specify it (anymore).
+     * @var ElementDescriptor[]
+     */
+    public $elements;
+
+    /**
+     * @param \ReflectionClass $clazz
+     */
+    protected function __construct($clazz)
+    {
+        // Use reflection to map PHP class fields to elements in the segment/Deg.
+        $implicitIndex = true;
+        $nextIndex = $clazz->isSubclassOf(BaseSegment::class) ? 1 : 0; // Segments have implicit Segmentkopf.
+        foreach ($clazz->getProperties(\ReflectionProperty::IS_PUBLIC) as $property) {
+            if ($property->isStatic() || $property->getDeclaringClass()->name !== $clazz->name) {
+                // Skip static and super properties.
+                continue;
+            }
+
+            $docComment = $property->getDocComment();
+            if (!is_string($docComment)) {
+                throw new \InvalidArgumentException("Property $property must be annotated.");
+            }
+
+            $index = static::getIntAnnotation('Index', $docComment);
+            if ($index === null) {
+                if ($implicitIndex) {
+                    $index = $nextIndex;
+                } else {
+                    throw new \InvalidArgumentException("Property $property needs an explicit @Index");
+                }
+            } else {
+                // After one field was marked with an @Index, all subsequent fields need an explicit index too.
+                $implicitIndex = false;
+            }
+
+            $descriptor = new ElementDescriptor();
+            $descriptor->field = $property->getName();
+            $type = static::getVarAnnotation($docComment);
+            if (empty($type)) {
+                throw new \InvalidArgumentException("Need type on property $property");
+            }
+            $maxCount = static::getIntAnnotation('Max', $docComment);
+            if (substr($type, -5) === '|null') { // Nullable field
+                $descriptor->optional = true;
+                $type = substr($type, 0, -5);
+            }
+            if (substr($type, -2) === '[]') { // Array/repeated field
+                if ($maxCount === null) {
+                    throw new \InvalidArgumentException("Repeated property $property needs @Max() annotation");
+                }
+                $descriptor->repeated = $maxCount;
+                $type = substr($type, 0, -2);
+                // If a repeated field is followed by anything at all, there will be an empty entry for each possible
+                // repeated value (in extreme cases, there can be hundreds of consecutive `+`, for instance).
+                $nextIndex += $maxCount;
+            } elseif ($maxCount !== null) {
+                throw new \InvalidArgumentException("@Max() annotation not recognized on single $property");
+            } else {
+                $nextIndex++; // Singular field, so the index advances by 1.
+            }
+            $descriptor->type = static::resolveType($type, $clazz);
+            $this->elements[$index] = $descriptor;
+        }
+        ksort($this->elements); // Make sure elements are parsed in wire-format order.
+    }
+
+    /**
+     * @param object $obj The object to be validated.
+     * @throws \InvalidArgumentException If any of the fields in the given object is not valid according to the schema
+     *     defined by this descriptor.
+     */
+    public function validateObject($obj) {
+        if (!is_a($obj, $this->class)) {
+            throw new \InvalidArgumentException("Expected $this->class, got " . gettype($obj));
+        }
+        foreach ($this->elements as $elementDescriptor) {
+            $elementDescriptor->validateField($obj);
+        }
+    }
+
+    /**
+     * Looks for the annotation with the given name and extracts the content of the parentheses behind it. For instance,
+     * when called with the name "Index" and a docComment that contains {@}Index(15), this would return "15".
+     * @param string $name The name of the annotation.
+     * @param string $docComment The documentation string of a PHP field.
+     * @return string|null The content of the annotation, or null if absent.
+     */
+    private static function getAnnotation($name, $docComment)
+    {
+        $ret = preg_match("/@$name\\((.*?)\\)/", $docComment, $match);
+        if ($ret === false) {
+            throw new \RuntimeException("preg_match failed on $name");
+        }
+        return $ret === 1 ? $match[1] : null;
+    }
+
+    /**
+     * Same as above, with integer parsing.
+     * @param string $name The name of the annotation.
+     * @param string $docComment The documentation string of a PHP field.
+     * @return int|null The value of the annotation as an integer, or null if absent.
+     */
+    private static function getIntAnnotation($name, $docComment)
+    {
+        $val = static::getAnnotation($name, $docComment);
+        if ($val === null) {
+            return null;
+        }
+        if (!is_numeric($val)) {
+            throw new \InvalidArgumentException("Annotation $name has non-integer value $val");
+        }
+        return intval($val);
+    }
+
+    /**
+     * @param string $name The name of the annotation.
+     * @param string $docComment The documentation string of a PHP field.
+     * @return boolean Whether the annotation with the given name is present.
+     */
+    private static function getBoolAnnotation($name, $docComment)
+    {
+        return strpos("@$name", $docComment) !== false;
+    }
+
+    /**
+     * Separate parser for the {@}var` annotation because it does not use parentheses.
+     * @param string $docComment The documentation string of a PHP field.
+     * @return string|null The value of the {@}var annotation, or null if absent.
+     */
+    private static function getVarAnnotation($docComment)
+    {
+        $ret = preg_match("/@var ([^\\s]+)/", $docComment, $match);
+        if ($ret === false) {
+            throw new \RuntimeException("preg_match failed for @var");
+        }
+        return $ret === 1 ? $match[1] : null;
+    }
+
+    /**
+     * NOTE: This does *not* resolve `use` statements in the source file.
+     * @param string $typeName A type name (PHP class name, fully qualified or not) or a scalar type name.
+     * @param \ReflectionClass $contextClass The class where this type name was encountered, used for resolution of
+     *     classes in the same package.
+     * @return string|\ReflectionClass The class that the type name refers to, or the scalar type name as a string.
+     */
+    private static function resolveType($typeName, $contextClass)
+    {
+        if (ElementDescriptor::isScalarType($typeName)) {
+            return $typeName;
+        }
+        if (strpos($typeName, '\\') === false) {
+            // Let's assume it's a relative type name, e.g. `X` mentioned in a file that starts with `namespace Fhp\Y`
+            // would become `\Fhp\X\Y`.
+            $typeName = $contextClass->getNamespaceName() . '\\' . $typeName;
+        }
+        try {
+            return new \ReflectionClass($typeName);
+        } catch (\ReflectionException $e) {
+            throw new \RuntimeException($e);
+        }
+    }
+}

--- a/lib/Fhp/Segment/BaseSegment.php
+++ b/lib/Fhp/Segment/BaseSegment.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Fhp\Segment;
+
+use Fhp\Syntax\Parser;
+use Fhp\Syntax\Serializer;
+
+/**
+ * Class BaseSegment
+ *
+ * Base class for segments. Sub-classes names need to follow the format "<Kennung>v<Version>" where <Kennung> is the
+ * type of the segment (e.g. "HITANS") and <Version> is the numeric version. The *public* member fields of a sub-class
+ * determine the structure of the segment. The order matters for the wire format, whereas the field names are only used
+ * for documentation/readability purposes within this library. See {@link HITANSv1} for an example of a sub-class.
+ *
+ * @package Fhp\Segment
+ */
+abstract class BaseSegment implements SegmentInterface
+{
+
+    /**
+     * Reference to the descriptor for this type of segment.
+     * @var SegmentDescriptor
+     */
+    private $descriptor;
+
+    /**
+     * @var Segmentkopf
+     */
+    public $segmentkopf;
+
+    public function __construct()
+    {
+        $this->descriptor = SegmentDescriptor::get(static::class);
+    }
+
+    public function getDescriptor()
+    {
+        return $this->descriptor;
+    }
+
+    public function getName()
+    {
+        return $this->descriptor->kennung;
+    }
+
+    /**
+     * @throws \InvalidArgumentException If any element in this segment is invalid.
+     */
+    public function validate()
+    {
+        $this->descriptor->validateObject($this);
+    }
+
+    /**
+     * Short-hand for {@link Serializer#serializeSegment()}.
+     * @return string The HBCI wire format representation of this segment, terminated by the segment delimiter.
+     */
+    public function serialize()
+    {
+        return Serializer::serializeSegment($this);
+    }
+
+    // TODO Consider removing this along with SegmentInterface in future.
+    public function __toString()
+    {
+        return $this->serialize();
+    }
+
+    /**
+     * Convenience function for {@link Parser#parseSegment()}. This function should not be called on BaseSegment itself,
+     * but only on one of its sub-classes.
+     * @param string $rawSegment The serialized wire format for a single segment (segment delimiter may be present at
+     *     the end, or not).
+     * @return BaseSegment The parsed segment.
+     */
+    public static function parse($rawSegment)
+    {
+        if (static::class === BaseSegment::class) {
+            throw new \BadFunctionCallException("Do not call BaseSegment::parse() on the super class");
+        }
+        return Parser::parseSegment($rawSegment, static::class);
+    }
+
+}

--- a/lib/Fhp/Segment/Common/Btg.php
+++ b/lib/Fhp/Segment/Common/Btg.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Fhp\Segment\Common;
+
+use Fhp\Segment\BaseDeg;
+
+class Btg extends BaseDeg
+{
+    /** @var float */
+    public $wert;
+    /** @var string */
+    public $waehrung;
+}

--- a/lib/Fhp/Segment/DegDescriptor.php
+++ b/lib/Fhp/Segment/DegDescriptor.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Fhp\Segment;
+
+/**
+ * Class SegmentDescriptor
+ *
+ * Contains meta information about a data elemnt group, i.e. anything that can be statically known about a sub-class of
+ * {@link BaseDeg} through reflection.
+ *
+ * @package Fhp\Segment
+ */
+class DegDescriptor extends BaseDescriptor
+{
+
+    /** @var DegDescriptor[] */
+    private static $descriptors;
+
+    /**
+     * @param string $class The name of a sub-class of {@link BaseDeg}.
+     * @return DegDescriptor The descriptor for the class.
+     */
+    public static function get($class)
+    {
+        if (!isset(static::$descriptors[$class])) {
+            static::$descriptors[$class] = new DegDescriptor($class);
+        }
+        return static::$descriptors[$class];
+    }
+
+    /**
+     * Please use the factory above.
+     * @param string $class The name of a sub-class of {@link BaseDeg}.
+     */
+    protected function __construct($class)
+    {
+        $this->class = $class;
+        try {
+            $clazz = new \ReflectionClass($class);
+            if (!$clazz->isSubclassOf(BaseDeg::class)) {
+                throw new \InvalidArgumentException("Must inherit from BaseDeg: $class");
+            }
+            parent::__construct($clazz);
+
+            // Check if the name ends in V2 or so, implicitly assume V1.
+            if (preg_match('/^[A-Z]+[vV]([0-9]+)$/', $clazz->getShortName(), $match) === 1) {
+                $this->version = intval($match[1]);
+            }
+        } catch (\ReflectionException $e) {
+            throw new \RuntimeException($e);
+        }
+    }
+}

--- a/lib/Fhp/Segment/ElementDescriptor.php
+++ b/lib/Fhp/Segment/ElementDescriptor.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Fhp\Segment;
+
+/**
+ * Class ElementDescriptor
+ *
+ * Contains information about an element (aka. field) in a segment or Deg.
+ *
+ * Elements implicitly have version 1.
+ *
+ * @package Fhp\Segment
+ */
+class ElementDescriptor
+{
+    /**
+     * Name of the PHP field that this descriptor describes.
+     * @var string
+     */
+    public $field;
+
+    /**
+     * The plain type of the PHP field (without array or nullable suffix). This is either a string, for scalar types, or
+     * a \ReflectionClass for a sub-class of {@link BaseSegment} or {@link BaseDeg} for complex types.
+     * @var string|\ReflectionClass
+     */
+    public $type;
+
+    /**
+     * Whether the field must be present (at least once, if repeated) in every segment/Deg instance (false) or can be
+     * omitted (true). This is auto-detected from the nullable suffix `|null` in the PHP type.
+     * @var boolean
+     */
+    public $optional = false;
+
+    /**
+     * Whether the field can have multiple values (if so, this field contains the maximum number of allowed values) or
+     * not (if so, the value is zero). This is auto-detected from the array suffix `[]` in the PHP type.
+     * @var integer
+     */
+    public $repeated = 0;
+
+    /**
+     * @param object $obj The object whose $field will be validated.
+     * @throws \InvalidArgumentException If $obj->$field does not correspond to the schema in this descriptor.
+     */
+    public function validateField($obj)
+    {
+        if (!isset($obj->{$this->field})) {
+            if ($this->optional) return;
+            throw new \InvalidArgumentException("Missing field $this->field");
+        }
+        $value = $obj->{$this->field};
+        if ($this->repeated) {
+            if (!is_array($value)) {
+                throw new \InvalidArgumentException("Expected array value for repeated field $this->field");
+            }
+            foreach ($value as $item) {
+                $this->validateValue($item);
+            }
+        } else {
+            $this->validateValue($value);
+        }
+    }
+
+    /**
+     * Maps types declared in a {@}var comment to the return format of `gettype()`.
+     */
+    const TYPE_MAP = [
+        'int' => 'integer', 'integer' => 'integer',
+        'float' => 'double',
+        'bool' => 'boolean', 'boolean' => 'boolean',
+        'string' => 'string',
+    ];
+
+    /**
+     * @param string $type A potential PHP scalar type.
+     * @return boolean True if parseDataElement() would understand it.
+     */
+    public static function isScalarType($type)
+    {
+        return array_key_exists($type, static::TYPE_MAP);
+    }
+
+    /**
+     * @param mixed $value The (non-null) value to be validated.
+     * @throws \InvalidArgumentException If $value is not a valid $type.
+     */
+    public function validateValue($value)
+    {
+        if (is_string($this->type) && array_key_exists($this->type, static::TYPE_MAP)) {
+            $expectedType = static::TYPE_MAP[$this->type];
+            $actualType = gettype($value);
+            if ($actualType !== $expectedType) {
+                throw new \InvalidArgumentException("Expected $expectedType, got $actualType: $value");
+            }
+        } elseif ($this->type instanceof \ReflectionClass) {
+            if (!$this->type->isInstance($value)) {
+                throw new \InvalidArgumentException("Expected {$this->type->name}, got $value");
+            }
+            if ($value instanceof BaseSegment || $value instanceof BaseDeg) {
+                $value->validate();
+            } else {
+                throw new \AssertionError(); // Violates guarantees of what we put in $this->type.
+            }
+        } else {
+            throw new \InvalidArgumentException("Unsupported type: $this->type");
+        }
+    }
+}

--- a/lib/Fhp/Segment/HITANS/HITANSv1.php
+++ b/lib/Fhp/Segment/HITANS/HITANSv1.php
@@ -1,0 +1,27 @@
+<?php /** @noinspection PhpUnused */
+
+namespace Fhp\Segment\HITANS;
+
+use Fhp\Segment\BaseSegment;
+
+/**
+ * Class HITANSv1
+ * Segment: Zwei-Schritt-TAN-Einreichung, Parameter (Version 1)
+ * Bezugssegment: HKVVB
+ * Sender: Kreditinstitut
+ *
+ * @link: https://www.hbci-zka.de/dokumente/spezifikation_deutsch/archiv/FinTS_V3.0_2017-10-06-FV_RM.zip
+ *
+ * @package Fhp\Segment\HITANS
+ */
+class HITANSv1 extends BaseSegment
+{
+    /** @var integer */
+    public $maximaleAnzahlAuftraege;
+    /** @var integer Allowed values: 0, 1, 2, 3 */
+    public $anzahlSignaturenMindestens;
+    /** @var integer Allowed values: 0, 1, 2, 3, 4 */
+    public $sicherheitsklasse;
+    /** @var ParameterZweiSchrittTanEinreichungV1 */
+    public $parameterZweiSchrittTanEinreichung;
+}

--- a/lib/Fhp/Segment/HITANS/HITANSv3.php
+++ b/lib/Fhp/Segment/HITANS/HITANSv3.php
@@ -1,0 +1,27 @@
+<?php /** @noinspection PhpUnused */
+
+namespace Fhp\Segment\HITANS;
+
+use Fhp\Segment\BaseSegment;
+
+/**
+ * Class HITANSv3
+ * Segment: Zwei-Schritt-TAN-Einreichung, Parameter (Version 3)
+ * Bezugssegment: HKVVB
+ * Sender: Kreditinstitut
+ *
+ * @link: https://www.hbci-zka.de/dokumente/spezifikation_deutsch/archiv/FinTS_V3.0_2017-10-06-FV_RM.zip
+ *
+ * @package Fhp\Segment\HITANS
+ */
+class HITANSv3 extends BaseSegment
+{
+    /** @var integer */
+    public $maximaleAnzahlAuftraege;
+    /** @var integer Allowed values: 0, 1, 2, 3 */
+    public $anzahlSignaturenMindestens;
+    /** @var integer Allowed values: 0, 1, 2, 3, 4 */
+    public $sicherheitsklasse;
+    /** @var ParameterZweiSchrittTanEinreichungV3 */
+    public $parameterZweiSchrittTanEinreichung;
+}

--- a/lib/Fhp/Segment/HITANS/ParameterZweiSchrittTanEinreichungV1.php
+++ b/lib/Fhp/Segment/HITANS/ParameterZweiSchrittTanEinreichungV1.php
@@ -1,0 +1,29 @@
+<?php /** @noinspection PhpUnused */
+
+namespace Fhp\Segment\HITANS;
+
+use Fhp\Segment\BaseDeg;
+
+class ParameterZweiSchrittTanEinreichungV1 extends BaseDeg
+{
+    /** @var boolean */
+    public $einschrittVerfahrenErlaubt;
+    /** @var boolean */
+    public $mehrAlsEinTanPflichtigerAuftragProNachrichtErlaubt;
+    /**
+     * 0: Auftrags-Hashwert nicht unterstützt
+     * 1: RIPEMD-160
+     * 2: SHA-1
+     * @var integer
+     */
+    public $auftragsHashwertverfahren;
+    /**
+     * 0: Banken-Signatur von HITAN nicht erlaubt
+     * 1: RDH-1 (wird in FinTS V3.0 nicht verwendet)
+     * 2: RDH-2 (in FinTS V3.0)
+     * @var integer
+     */
+    public $sicherheitsprofilBankenSignatureBeiHitan;
+    /** @var VerfahrensparameterZweiSchrittVerfahrenV1[] @Max(98) */
+    public $verfahrensparameterZweiSchrittVerfahren;
+}

--- a/lib/Fhp/Segment/HITANS/ParameterZweiSchrittTanEinreichungV3.php
+++ b/lib/Fhp/Segment/HITANS/ParameterZweiSchrittTanEinreichungV3.php
@@ -1,0 +1,22 @@
+<?php /** @noinspection PhpUnused */
+
+namespace Fhp\Segment\HITANS;
+
+use Fhp\Segment\BaseDeg;
+
+class ParameterZweiSchrittTanEinreichungV3 extends BaseDeg
+{
+    /** @var boolean */
+    public $einschrittVerfahrenErlaubt;
+    /** @var boolean */
+    public $mehrAlsEinTanPflichtigerAuftragProNachrichtErlaubt;
+    /**
+     * 0: Auftrags-Hashwert nicht unterstützt
+     * 1: RIPEMD-160
+     * 2: SHA-1
+     * @var integer
+     */
+    public $auftragsHashwertverfahren;
+    /** @var VerfahrensparameterZweiSchrittVerfahrenV3[] @Max(98) */
+    public $verfahrensparameterZweiSchrittVerfahren;
+}

--- a/lib/Fhp/Segment/HITANS/VerfahrensparameterZweiSchrittVerfahrenV1.php
+++ b/lib/Fhp/Segment/HITANS/VerfahrensparameterZweiSchrittVerfahrenV1.php
@@ -1,0 +1,31 @@
+<?php /** @noinspection PhpUnused */
+
+namespace Fhp\Segment\HITANS;
+
+use Fhp\Segment\BaseDeg;
+
+class VerfahrensparameterZweiSchrittVerfahrenV1 extends BaseDeg
+{
+    /** @var integer Allowed values: 900 through 997 */
+    public $sicherheitsfunktion;
+    /** @var integer Allowed values: 1, 2, 3, 4; See specification for details */
+    public $tanProzess;
+    /** @var string */
+    public $technischeIdentifikationTanVerfahren;
+    /** @var string Max length: 30 */
+    public $nameDesZweiSchrittVerfahrens;
+    /** @var integer */
+    public $maximaleLaengeDesTanEingabewertes;
+    /** @var integer Allowed values: 1 = numerisch, 2 = alfanumerisch */
+    public $erlaubtesFormat;
+    /** @var string */
+    public $textZurBelegungDesRueckgabewertes;
+    /** @var integer Allowed values: 1 through 256 */
+    public $maximaleLaengeDesRueckgabewertes;
+    /** @var integer|null */
+    public $anzahlUnterstuetzterAktiverTanListen;
+    /** @var boolean */
+    public $mehrfachTanErlaubt;
+    /** @var boolean */
+    public $tanZeitversetztDialoguebergreifendErlaubt;
+}

--- a/lib/Fhp/Segment/HITANS/VerfahrensparameterZweiSchrittVerfahrenV3.php
+++ b/lib/Fhp/Segment/HITANS/VerfahrensparameterZweiSchrittVerfahrenV3.php
@@ -1,0 +1,51 @@
+<?php /** @noinspection PhpUnused */
+
+namespace Fhp\Segment\HITANS;
+
+use Fhp\Segment\BaseDeg;
+
+class VerfahrensparameterZweiSchrittVerfahrenV3 extends BaseDeg
+{
+    /** @var integer Allowed values: 900 through 997 */
+    public $sicherheitsfunktion;
+    /** @var integer Allowed values: 1, 2; See specification for details */
+    public $tanProzess;
+    /** @var string */
+    public $technischeIdentifikationTanVerfahren;
+    /** @var string Max length: 30 */
+    public $nameDesZweiSchrittVerfahrens;
+    /** @var integer */
+    public $maximaleLaengeDesTanEingabewertes;
+    /** @var integer Allowed values: 1 = numerisch, 2 = alfanumerisch */
+    public $erlaubtesFormat;
+    /** @var string */
+    public $textZurBelegungDesRueckgabewertes;
+    /** @var integer Allowed values: 1 through 256 */
+    public $maximaleLaengeDesRueckgabewertes;
+    /** @var integer|null */
+    public $anzahlUnterstuetzterAktiverTanListen;
+    /** @var boolean */
+    public $mehrfachTanErlaubt;
+    /**
+     * 1 TAN nicht zeitversetzt / dialogübergreifend erlaubt
+     * 2 TAN zeitversetzt / dialogübergreifend erlaubt
+     * 3 beide Verfahren unterstützt
+     * 4 nicht zutreffend
+     * @var integer
+     */
+    public $tanZeitUndDialogbezug;
+    /** @var integer Allowed values: 0 (cannot), 2 (must) */
+    public $tanListennummerErforderlich;
+    /** @var boolean */
+    public $auftragsstornoErlaubt;
+    /** @var boolean */
+    public $challengeKlasseErforderlich;
+    /** @var boolean */
+    public $challengeBetragErforderlich;
+    /** @var string Allowed values: 00 (cleartext PIN, no TAN), 01 (Schablone 01, encrypted PIN), 02 (reserved) */
+    public $initialisierungsmodus;
+    /** @var integer Allowed values: 0 (cannot), 2 (must) */
+    public $bezeichnungDesTanMediumsErforderlich;
+    /** @var integer|null */
+    public $anzahlUnterstuetzterAktiverTanMedien;
+}

--- a/lib/Fhp/Segment/HIUPD/ErlaubteGeschaeftsvorfaelleV1.php
+++ b/lib/Fhp/Segment/HIUPD/ErlaubteGeschaeftsvorfaelleV1.php
@@ -1,0 +1,27 @@
+<?php /** @noinspection PhpUnused */
+
+namespace Fhp\Segment\HIUPD;
+
+use Fhp\Segment\BaseDeg;
+
+/**
+ * Class ErlaubteGeschaeftsvorfaelleV1
+ *
+ * @link https://www.hbci-zka.de/dokumente/spezifikation_deutsch/archiv/HBCI_V2.x_FV.zip
+ * File: HBCI22 Final.pdf
+ * Section: V.3 "Kontoinformation" > Nr. 9
+ * @package Fhp\Segment\HIUPD
+ */
+class ErlaubteGeschaeftsvorfaelleV1 extends BaseDeg
+{
+    /** @var string References a segment type name (Segmentkennung) */
+    public $geschaeftsvorfall;
+    /** @var integer Allowed values: 0, 1, 2, 3 */
+    public $anzahlBenoetigterSignaturen;
+    /** @var string|null Allowed values: E, T, W, M, Z */
+    public $limitart;
+    /** @var \Fhp\Segment\Common\Btg|null */
+    public $limitbetrag;
+    /** @var integer|null If present, must be greater than 0 */
+    public $limitTage;
+}

--- a/lib/Fhp/Segment/HIUPD/HIUPDv4.php
+++ b/lib/Fhp/Segment/HIUPD/HIUPDv4.php
@@ -1,0 +1,37 @@
+<?php /** @noinspection PhpUnused */
+
+namespace Fhp\Segment\HIUPD;
+
+use Fhp\Segment\BaseSegment;
+
+/**
+ * Class HIUPDv4
+ * Segment: Kontoinformation (Version 4)
+ * Bezugssegment: HKVVB
+ * Sender: Kreditinstitut
+ *
+ * @link https://www.hbci-zka.de/dokumente/spezifikation_deutsch/archiv/HBCI_V2.x_FV.zip
+ * File: HBCI22 Final.pdf
+ * Section: V.3 "Kontoinformation"
+ *
+ * @package Fhp\Segment\HIUPD
+ */
+class HIUPDv4 extends BaseSegment
+{
+    /** @var KtvV3 */
+    public $kontoverbindung;
+    /** @var string */
+    public $kundenId;
+    /** @var string|null */
+    public $kontowaehrung;
+    /** @var string */
+    public $name1;
+    /** @var string|null */
+    public $name2;
+    /** @var string|null */
+    public $kontoproduktbezeichnung;
+    /** @var KontolimitV1|null */
+    public $kontolimit;
+    /** @var ErlaubteGeschaeftsvorfaelleV1[] @Max(98) */
+    public $erlaubteGeschaeftsvorfaelle;
+}

--- a/lib/Fhp/Segment/HIUPD/KontolimitV1.php
+++ b/lib/Fhp/Segment/HIUPD/KontolimitV1.php
@@ -1,0 +1,23 @@
+<?php /** @noinspection PhpUnused */
+
+namespace Fhp\Segment\HIUPD;
+
+use Fhp\Segment\BaseDeg;
+
+/**
+ * Class KontolimitV1
+ *
+ * @link https://www.hbci-zka.de/dokumente/spezifikation_deutsch/archiv/HBCI_V2.x_FV.zip
+ * File: HBCI22 Final.pdf
+ * Section: V.3 "Kontoinformation" > Nr. 8
+ * @package Fhp\Segment\HIUPD
+ */
+class KontolimitV1 extends BaseDeg
+{
+    /** @var string Allowed values: E, T, W, M, Z */
+    public $limitart;
+    /** @var \Fhp\Segment\Common\Btg */
+    public $limitbetrag;
+    /** @var integer|null If present, must be greater than 0 */
+    public $limitTage;
+}

--- a/lib/Fhp/Segment/HIUPD/KtvV3.php
+++ b/lib/Fhp/Segment/HIUPD/KtvV3.php
@@ -1,0 +1,29 @@
+<?php /** @noinspection PhpUnused */
+
+namespace Fhp\Segment\HIUPD;
+
+use Fhp\Segment\BaseDeg;
+
+/**
+ * Class KtvV1
+ *
+ * This is not explicitly specified as "version 3", but before this one there was a version without $unterkontomerkmal
+ * used in HBCI 2.0 and 2.1, whereas this is for HBCI 2.2.
+ *
+ * @link https://www.hbci-zka.de/dokumente/spezifikation_deutsch/archiv/HBCI_V2.x_FV.zip
+ * File: HBCI22 Final.pdf
+ * Section: II.5.3.3 "Kontoverbindung"
+ *
+ * @package Fhp\Segment\HIUPD
+ */
+class KtvV3 extends BaseDeg
+{
+    /** @var string */
+    public $kontonummer;
+    /** @var string|null */
+    public $unterkontomerkmal;
+    /** @var integer */
+    public $laenderkennzeichen;
+    /** @var string|null */
+    public $kreditinstitutionscode;
+}

--- a/lib/Fhp/Segment/SegmentDescriptor.php
+++ b/lib/Fhp/Segment/SegmentDescriptor.php
@@ -1,0 +1,73 @@
+<?php
+
+
+namespace Fhp\Segment;
+
+
+/**
+ * Class SegmentDescriptor
+ *
+ * Contains meta information about a segment, i.e. anything that can be statically known about a sub-class of
+ * {@link BaseSegment} through reflection.
+ *
+ * @package Fhp\Segment
+ */
+class SegmentDescriptor extends BaseDescriptor
+{
+
+    /** @var SegmentDescriptor[] */
+    private static $descriptors;
+
+    /**
+     * @param string $class The name of a sub-class of {@link BaseSegment}.
+     * @return SegmentDescriptor The descriptor for the class.
+     */
+    public static function get($class)
+    {
+        if (!isset(static::$descriptors[$class])) {
+            static::$descriptors[$class] = new SegmentDescriptor($class);
+        }
+        return static::$descriptors[$class];
+    }
+
+    /** @var string Example: "HITANS" */
+    public $kennung;
+
+    /**
+     * Please use the factory above.
+     * @param string $class The name of a sub-class of {@link BaseSegment}.
+     */
+    protected function __construct($class)
+    {
+        $this->class = $class;
+        try {
+            $clazz = new \ReflectionClass($class);
+            if (!$clazz->isSubclassOf(BaseSegment::class)) {
+                throw new \InvalidArgumentException("Must inherit from BaseSegment: $class");
+            }
+            parent::__construct($clazz);
+
+            // Parse the class name into segment type (Kennung) and version.
+            if (preg_match('/^([A-Z]+)v([0-9]+)$/', $clazz->getShortName(), $match) !== 1) {
+                throw new \InvalidArgumentException("Invalid segment class name: $class");
+            }
+            $this->kennung = $match[1];
+            $this->version = intval($match[2]);
+        } catch (\ReflectionException $e) {
+            throw new \RuntimeException($e);
+        }
+    }
+
+    public function validateObject($obj) // Override
+    {
+        parent::validateObject($obj);
+        if (!($obj instanceof BaseSegment)) {
+            throw new \InvalidArgumentException("Expected sub-class of BaseSegment, got " . gettype($obj));
+        }
+        if ($obj->getName() !== $this->kennung) {
+            throw new \InvalidArgumentException("Expected $this->kennung, got " . $obj->getName());
+        }
+        DegDescriptor::get(Segmentkopf::class)->validateObject($obj->segmentkopf);
+
+    }
+}

--- a/lib/Fhp/Segment/Segmentkopf.php
+++ b/lib/Fhp/Segment/Segmentkopf.php
@@ -1,0 +1,35 @@
+<?php
+
+
+namespace Fhp\Segment;
+
+
+class Segmentkopf extends BaseDeg
+{
+    /**
+     * The name/type of the segment, e.g. "HITANS", corresponding to {@link SegmentDescriptor#kennung}.
+     * Max length: 6
+     * @var string
+     */
+    public $segmentkennung;
+
+    /**
+     * A number to refer to the segment within a message. Similar to an index, but they don't technically have to be
+     * consecutive within a message.
+     * @var integer
+     */
+    public $segmentnummer;
+
+    /**
+     * Version of the segment, corresponding to {@link SegmentDescriptor#version}.
+     * @var integer
+     */
+    public $segmentversion;
+
+    /**
+     * Not allowed in requests, optionally present in responses.
+     * In a response message, this refers to the {@link #segmentnummer} of a segment in the request message.
+     * @var integer|null
+     */
+    public $bezugselement;
+}

--- a/lib/Fhp/Syntax/Delimiter.php
+++ b/lib/Fhp/Syntax/Delimiter.php
@@ -1,0 +1,11 @@
+<?php
+
+
+namespace Fhp\Syntax;
+
+abstract class Delimiter
+{
+    const SEGMENT = "'";
+    const ELEMENT = "+";
+    const GROUP = ":";
+}

--- a/lib/Fhp/Syntax/Parser.php
+++ b/lib/Fhp/Syntax/Parser.php
@@ -1,0 +1,235 @@
+<?php
+
+
+namespace Fhp\Syntax;
+
+use Fhp\Syntax\Delimiter;
+use Fhp\Segment\BaseDeg;
+use Fhp\Segment\BaseSegment;
+use Fhp\Segment\DegDescriptor;
+use Fhp\Segment\ElementDescriptor;
+use Fhp\Segment\SegmentDescriptor;
+use Fhp\Segment\Segmentkopf;
+
+/**
+ * Class Parser
+ *
+ * Parses the FinTS wire format (aka. syntax) into Messages, Segments, Data Element Groups (DEG) and Data Elements (DE).
+ *
+ * @link https://www.hbci-zka.de/dokumente/spezifikation_deutsch/fintsv3/FinTS_3.0_Formals_2017-10-06_final_version.pdf
+ * Section H.1 "Nachrichtensyntax"
+ *
+ * @package Fhp\Syntax
+ */
+abstract class Parser
+{
+    /**
+     * The FinTs wire format specifies escaping with a question mark `?` for the syntax characters `+:'?@`. This
+     * function splits strings delimited by one of these while honoring escaping within.
+     *
+     * @link: https://www.hbci-zka.de/dokumente/spezifikation_deutsch/fintsv3/FinTS_3.0_Formals_2017-10-06_final_version.pdf
+     * Section H.1.3 "Entwertung"
+     *
+     * @param string $delimiter The delimiter around which to split.
+     * @param string $str The raw string, usually a response from the server.
+     * @return string[] The splitted substrings. Note that escaped characters inside will still be escaped.
+     */
+    public static function splitEscapedString($delimiter, $str)
+    {
+        if (empty($str)) return array();
+        // Since most of the $delimiters used in FinTs are also special characters in regexes, we need to escape.
+        $delimiter = preg_quote($delimiter, '/');
+        // This regex uses a negated look-behind. Generally, the regex `(?<!foo)x` matches an `x` that is NOT preceded
+        // by `foo`. In this case, we want to match on the split $delimiter when it is not preceded by the escape
+        // character `?`, which we need to escape because it's a special character in regexes.
+        return preg_split("/(?<!\\?)$delimiter/", $str);
+    }
+
+    /**
+     * @param string $str The raw string, usually a response from the server.
+     * @return string The string with the escaping removed.
+     */
+    public static function unescape($str)
+    {
+        return preg_replace('/\?([+:\'?@])/', '$1', $str);
+    }
+
+    /**
+     * Parses a scalar value aka. "Datenelement" (DE).
+     *
+     * @link: https://www.hbci-zka.de/dokumente/spezifikation_deutsch/fintsv3/FinTS_3.0_Formals_2017-10-06_final_version.pdf
+     * Section B.4 Datenformate
+     *
+     * @param string $rawValue The raw value (wire format).
+     * @param string $type The PHP type that we need. This should support exactly the values for which
+     *     {@link ElementDescriptor#isScalarType()} returns true.
+     * @return mixed The parsed value of type $type.
+     */
+    public static function parseDataElement($rawValue, $type)
+    {
+        if ($type === 'int' || $type === 'integer') {
+            if (!is_numeric($rawValue)) {
+                throw new \InvalidArgumentException("Invalid int: $rawValue");
+            }
+            return intval($rawValue);
+        } elseif ($type === 'float') {
+            $rawValue = str_replace(',', '.', $rawValue, $numCommas);
+            if (!is_numeric($rawValue) || $numCommas !== 1) {
+                throw new \InvalidArgumentException("Invalid float: $rawValue");
+            }
+            return floatval($rawValue);
+        } elseif ($type === 'bool' || $type === 'boolean') {
+            if ($rawValue === 'J') return true;
+            if ($rawValue === 'N') return false;
+            throw new \InvalidArgumentException("Invalid bool: $rawValue");
+        } elseif ($type === 'string') {
+            return static::unescape($rawValue);
+        } else {
+            throw new \RuntimeException("Unsupported type $type");
+        }
+    }
+
+    /**
+     * @param string $rawElements The serialized wire format for a data element group.
+     * @param string $type The type (PHP class name) of the Deg to be parsed.
+     * @return BaseDeg The parsed value, of type
+     */
+    public static function parseDeg($rawElements, $type)
+    {
+        $rawElements = static::splitEscapedString(Delimiter::GROUP, $rawElements);
+        list($result, $offset) = static::parseDegElements($rawElements, $type);
+        if ($offset < count($rawElements)) {
+            throw new \InvalidArgumentException("Only read $offset elements: " . print_r($rawElements, true));
+        }
+        return $result;
+    }
+
+    /**
+     * @param string[] $rawElements The serialized wire format for a series of elements (already splitted). This array
+     *     will be modified in that the elements that were consumed are removed from the beginning.
+     * @param string $type The type (PHP class name) of the Deg to be parsed, defaults to the class on which
+     *     this function is called.
+     * @param integer $offset The position in $rawElements to be read next.
+     * @return array (BaseDeg, integer) The parsed value, which has the given $type, and the offset at which parsing
+     *     should continue. The difference between this returned offset and the $offset was passed in is the number of
+     *     elements that this function call consumed.
+     */
+    private static function parseDegElements($rawElements, $type, $offset = 0)
+    {
+        if ($type === null) $type = static::class;
+        $descriptor = DegDescriptor::get($type);
+        $result = new $type();
+        $expectedIndex = 0;
+        // The iteration order guarantees that $index is strictly monotonically increasing, but there can be gaps.
+        foreach ($descriptor->elements as $index => $elementDescriptor) {
+            $offset += ($index - $expectedIndex); // Adjust for skipped indices.
+            $numRepetitions = $elementDescriptor->repeated === 0 ? 1 : $elementDescriptor->repeated;
+            $expectedIndex += $numRepetitions; // Advance to next expected elementDescriptor index.
+
+            // Skip optional elements that are not present.
+            if (!isset($rawElements[$offset]) || $rawElements[$offset] === '') {
+                if ($elementDescriptor->optional) {
+                    $offset++;
+                    continue;
+                }
+                throw new \InvalidArgumentException("Missing field $elementDescriptor->field");
+            }
+
+            // Parse element (possibly multiple values recursively).
+            try {
+                for ($repetition = 0; $repetition < $numRepetitions; $repetition++) {
+                    if ($offset >= count($rawElements)) {
+                        break; // End of input reached
+                    }
+                    if (is_string($elementDescriptor->type)) { // Scalar type / DE
+                        if ($rawElements[$offset] === '' && $repetition >= 1) { // Skip empty repeated entries.
+                            $offset++;
+                            continue;
+                        }
+                        $value = static::parseDataElement($rawElements[$offset], $elementDescriptor->type);
+                        $offset++;
+                    } else { // Nested DEG, will consume a certain number of elements and adjust the $offset accordingly.
+                        list($value, $offset) =
+                            static::parseDegElements($rawElements, $elementDescriptor->type->name, $offset);
+                    }
+                    if ($elementDescriptor->repeated === 0) {
+                        $result->{$elementDescriptor->field} = $value;
+                    } else {
+                        $result->{$elementDescriptor->field}[] = $value;
+                    }
+                }
+            } catch (\InvalidArgumentException $e) {
+                throw new \InvalidArgumentException("Failed to parse $descriptor->class::$elementDescriptor->field: $e");
+            }
+        }
+        return array($result, $offset);
+    }
+
+    /**
+     * @param string $rawSegment The serialized wire format for a single segment (segment delimiter may be present at
+     *     the end, or not).
+     * @param string $type The type (PHP class name) of the segment to be parsed.
+     * @return BaseSegment The parsed segment of type $type.
+     */
+    public static function parseSegment($rawSegment, $type)
+    {
+        $descriptor = SegmentDescriptor::get($type);
+        if (substr($rawSegment, -1) === Delimiter::SEGMENT) {
+            $rawSegment = substr($rawSegment, 0, -1); // Strip segment delimiter at the end, if present.
+        }
+        $rawElements = static::splitEscapedString(Delimiter::ELEMENT, $rawSegment);
+        if (empty($rawElements)) {
+            throw new \InvalidArgumentException("Invalid segment: $rawSegment");
+        }
+
+        /** @var Segmentkopf $segmentkopf */
+        $segmentkopf = static::parseDeg($rawElements[0], Segmentkopf::class);
+        if ($segmentkopf->segmentkennung !== $descriptor->kennung) {
+            throw new \InvalidArgumentException("Invalid segment type $segmentkopf->segmentkennung for $type");
+        }
+        if ($segmentkopf->segmentversion !== $descriptor->version) {
+            throw new \InvalidArgumentException("Invalid version $segmentkopf->segmentversion for $type");
+        }
+
+        $result = new $type();
+        $result->segmentkopf = $segmentkopf;
+        // The iteration order guarantees that $index is strictly monotonically increasing, but there can be gaps.
+        foreach ($descriptor->elements as $index => $elementDescriptor) {
+            if (!isset($rawElements[$index]) || $rawElements[$index] === '') {
+                if ($elementDescriptor->optional) {
+                    continue;
+                }
+                throw new \InvalidArgumentException("Missing field $elementDescriptor->field");
+            }
+
+            if ($elementDescriptor->repeated === 0) {
+                $result->{$elementDescriptor->field} =
+                    static::parseSegmentElement($rawElements[$index], $elementDescriptor);
+            } else {
+                for ($repetition = 0; $repetition < $elementDescriptor->repeated; $repetition++) {
+                    if ($index + $repetition >= count($rawElements)) {
+                        break; // End of input reached.
+                    }
+                    if ($rawElements[$index + $repetition] !== '') { // Skip empty entries.
+                        $result->{$elementDescriptor->field}[$repetition] =
+                            static::parseSegmentElement($rawElements[$index + $repetition], $elementDescriptor);
+                    }
+                }
+            }
+        }
+        return $result;
+    }
+
+    /**
+     * @param string $rawElement The raw content (unparsed wire format) of an element, which can either be a single
+     *     Data Element (DE) or a group (DEG), as determined by the descriptor.
+     * @param ElementDescriptor $descriptor The descriptor that describes the expected format of the element.
+     * @return mixed The parsed value.
+     */
+    private static function parseSegmentElement($rawElement, $descriptor)
+    {
+        return is_string($descriptor->type)
+            ? static::parseDataElement($rawElement, $descriptor->type)
+            : static::parseDeg($rawElement, $descriptor->type->name);
+    }
+}

--- a/lib/Fhp/Syntax/Serializer.php
+++ b/lib/Fhp/Syntax/Serializer.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Fhp\Syntax;
+
+use Fhp\Segment\BaseDeg;
+use Fhp\Segment\BaseSegment;
+
+// Polyfill for PHP < 7.3
+if (!function_exists("array_key_last")) {
+    function array_key_last($array)
+    {
+        if (!is_array($array) || empty($array)) {
+            return NULL;
+        }
+        return array_keys($array)[count($array) - 1];
+    }
+}
+
+abstract class Serializer
+{
+
+    /**
+     * @param mixed $value A scalar (DE) value.
+     * @param string $type The PHP type of this value. This should support exactly the values for which
+     *     {@link ElementDescriptor#isScalarType()} returns true.
+     * @return string The HBCI wire format representation of the value.
+     */
+    public static function serializeDataElement($value, $type)
+    {
+        if ($type === 'int' || $type === 'integer' || $type === 'string') {
+            return strval($value);
+        } elseif ($type === 'float') {
+            // Format with fixed 2 decimal places (there has to be some limit, and the specification does not specify
+            // one), then trim zeros from the end.
+            return preg_replace('/0+$/', '', number_format($value, 2, ',', ''));
+        } elseif ($type === 'bool' || $type === 'boolean') {
+            return $value ? 'J' : 'N';
+        } else {
+            throw new \RuntimeException("Unsupported type $type");
+        }
+    }
+
+    /**
+     * @param BaseDeg $deg The data element group to be serialized.
+     * @return string The HBCI wire format representation of the DEG.
+     */
+    public static function serializeDeg($deg)
+    {
+        return implode(Delimiter::GROUP, Serializer::serializeElements($deg));
+    }
+
+    /**
+     * @param BaseSegment $segment The segment to be serialized.
+     * @return string The HBCI wire format representation of the segment, terminated by the segment delimiter.
+     */
+    public static function serializeSegment($segment)
+    {
+        $serializedElements = static::serializeElements($segment);
+        if (isset($serializedElements[0]) && $serializedElements[0] !== '') throw new \AssertionError();
+        $serializedElements[0] = $segment->segmentkopf->serialize();
+        return implode(Delimiter::ELEMENT, $serializedElements) . Delimiter::SEGMENT;
+    }
+
+    /**
+     * @param BaseSegment|BaseDeg $obj An object to be serialized.
+     * @return string[] A partial serialization of that object, namely an array with all of its elements serialized
+     *     independently, and at the right indices (i.e. the returned array may contain empty strings as gaps/buffers).
+     */
+    private static function serializeElements($obj)
+    {
+        $serializedElements = array();
+        foreach ($obj->getDescriptor()->elements as $index => $elementDescriptor) {
+            $value = $obj->{$elementDescriptor->field};
+            if ($value === null) continue;
+            if (isset($serializedElements[$index])) throw new \AssertionError();
+            if ($elementDescriptor->repeated === 0) {
+                $serializedElements[$index] = static::serializeElement($value, $elementDescriptor->type);
+            } else {
+                foreach ($value as $offset => $item) {
+                    $serializedElements[$index + $offset] = static::serializeElement($item, $elementDescriptor->type);
+                }
+            }
+        }
+        static::fillMissingKeys($serializedElements, '');
+        return $serializedElements;
+    }
+
+    private static function serializeElement($value, $type)
+    {
+        return is_string($type) ? static::serializeDataElement($value, $type) : static::serializeDeg($value);
+    }
+
+    /**
+     * Public for testing only.
+     * @param array $arr An array with numeric sorted keys, e.g. `[0 => 'a', 2 => 'b', 4 => 'c']`. After this function
+     *     returns, all missing keys (gaps) will be filled in with the $value, e.g. if `$value == 'X'` the result would
+     *     be `[0 => 'a', 1 => 'X', 2 => 'b', 3 => 'X', 4 => 'c'].
+     * @param mixed $value The value to fill in.
+     */
+    public static function fillMissingKeys(&$arr, $value)
+    {
+        if (empty($arr)) return;
+        $lastKey = array_key_last($arr);
+        if (!is_numeric($lastKey)) throw new \InvalidArgumentException("Keys must be numeric, got $lastKey");
+        for ($key = 0; $key < $lastKey; $key++) {
+            if (!array_key_exists($key, $arr)) {
+                $arr[$key] = $value;
+            }
+        }
+        ksort($arr);
+    }
+}

--- a/lib/Tests/Fhp/Segment/HITANSTest.php
+++ b/lib/Tests/Fhp/Segment/HITANSTest.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Tests\Fhp\Model;
+
+use Fhp\Segment\HITANS\HITANSv1;
+use Fhp\Segment\HITANS\HITANSv3;
+
+class HITANSTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Real response from DKB (Deutsche Kreditbank).
+     */
+    const REAL_DKB_RESPONSE = array(
+        "HITANS:165:1:4+1+1+1+J:N:0:0:920:2:smsTAN:smsTAN:6:1:TAN-Nummer:3:1:J:J:900:2:iTAN:iTAN:6:1:TAN-Nummer:3:1:J:J'",
+        "HITANS:166:3:4+1+1+1+J:N:0:910:2:HHD1.3.0:chipTAN manuell:6:1:TAN-Nummer:3:1:J:2:0:N:N:N:00:0:1:911:2:HHD1.3.2OPT:chipTAN optisch:6:1:TAN-Nummer:3:1:J:2:0:N:N:N:00:0:1:912:2:HHD1.3.2USB:chipTAN-USB:6:1:TAN-Nummer:3:1:J:2:0:N:N:N:00:0:1:913:2:Q1S:chipTAN-QR:6:1:TAN-Nummer:3:1:J:2:0:N:N:N:00:0:1:920:2:smsTAN:smsTAN:6:1:TAN-Nummer:3:1:J:2:0:N:N:N:00:2:5:921:2:TAN2go:TAN2go:6:1:TAN-Nummer:3:1:J:2:0:N:N:N:00:2:2:900:2:iTAN:iTAN:6:1:TAN-Nummer:3:1:J:2:0:N:N:N:00:0:0'",
+        "HITANS:167:6:4+1+1+1+J:N:0:910:2:HHD1.3.0:::chipTAN manuell:6:1:TAN-Nummer:3:J:2:N:0:0:N:N:00:0:N:1:911:2:HHD1.3.2OPT:HHDOPT1:1.3.2:chipTAN optisch:6:1:TAN-Nummer:3:J:2:N:0:0:N:N:00:0:N:1:912:2:HHD1.3.2USB:HHDUSB1:1.3.2:chipTAN-USB:6:1:TAN-Nummer:3:J:2:N:0:0:N:N:00:0:N:1:913:2:Q1S:Secoder_UC:1.2.0:chipTAN-QR:6:1:TAN-Nummer:3:J:2:N:0:0:N:N:00:0:N:1:920:2:smsTAN:::smsTAN:6:1:TAN-Nummer:3:J:2:N:0:0:N:N:00:2:N:5:921:2:TAN2go:::TAN2go:6:1:TAN-Nummer:3:J:2:N:0:0:N:N:00:2:N:2:900:2:iTAN:::iTAN:6:1:TAN-Nummer:3:J:2:N:0:0:N:N:00:0:N:0'",
+    );
+
+    public function test_parse_DKB_response_v1()
+    {
+        /** @var HITANSv1 $parsed */
+        $parsed = HITANSv1::parse(static::REAL_DKB_RESPONSE[0]);
+
+        $this->assertEquals(1, $parsed->maximaleAnzahlAuftraege);
+        $this->assertEquals(1, $parsed->anzahlSignaturenMindestens);
+        $this->assertEquals(1, $parsed->sicherheitsklasse);
+
+        $parsedParams = $parsed->parameterZweiSchrittTanEinreichung;
+        $this->assertEquals(true, $parsedParams->einschrittVerfahrenErlaubt);
+        $this->assertEquals(false, $parsedParams->mehrAlsEinTanPflichtigerAuftragProNachrichtErlaubt);
+        $this->assertEquals(0, $parsedParams->auftragsHashwertverfahren);
+        $this->assertEquals(0, $parsedParams->sicherheitsprofilBankenSignatureBeiHitan);
+        $this->assertCount(2, $parsedParams->verfahrensparameterZweiSchrittVerfahren);
+
+        $verfahren1 = $parsedParams->verfahrensparameterZweiSchrittVerfahren[0];
+        $this->assertEquals(920, $verfahren1->sicherheitsfunktion);
+        $this->assertEquals("smsTAN", $verfahren1->technischeIdentifikationTanVerfahren);
+        $this->assertEquals("TAN-Nummer", $verfahren1->textZurBelegungDesRueckgabewertes);
+        $this->assertEquals(true, $verfahren1->mehrfachTanErlaubt);
+
+        $verfahren1 = $parsedParams->verfahrensparameterZweiSchrittVerfahren[1];
+        $this->assertEquals(900, $verfahren1->sicherheitsfunktion);
+        $this->assertEquals("iTAN", $verfahren1->technischeIdentifikationTanVerfahren);
+        $this->assertEquals("TAN-Nummer", $verfahren1->textZurBelegungDesRueckgabewertes);
+        $this->assertEquals(true, $verfahren1->mehrfachTanErlaubt);
+    }
+
+    public function test_parse_DKB_response_v3_with_wrong_parser()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        HITANSv1::parse(static::REAL_DKB_RESPONSE[1]);
+    }
+
+    public function test_validate_DKB_response_v1()
+    {
+        /** @var HITANSv1 $parsed */
+        $parsed = HITANSv1::parse(static::REAL_DKB_RESPONSE[0]);
+        $parsed->validate(); // Should not throw.
+    }
+
+    public function test_serialize_DKB_response_v1()
+    {
+        $parsed = HITANSv1::parse(static::REAL_DKB_RESPONSE[0]);
+        $this->assertEquals(static::REAL_DKB_RESPONSE[0], $parsed->serialize());
+    }
+
+    public function test_parse_DKB_response_v3()
+    {
+        /** @var HITANSv3 $parsed */
+        $parsed = HITANSv3::parse(static::REAL_DKB_RESPONSE[1]);
+        $this->assertEquals(1, $parsed->maximaleAnzahlAuftraege);
+        $parsedParams = $parsed->parameterZweiSchrittTanEinreichung;
+        $this->assertEquals(true, $parsedParams->einschrittVerfahrenErlaubt);
+        $this->assertCount(7, $parsedParams->verfahrensparameterZweiSchrittVerfahren);
+        $this->assertEquals("HHD1.3.0", $parsedParams->verfahrensparameterZweiSchrittVerfahren[0]->technischeIdentifikationTanVerfahren);
+        $this->assertEquals("chipTAN manuell", $parsedParams->verfahrensparameterZweiSchrittVerfahren[0]->nameDesZweiSchrittVerfahrens);
+        $this->assertEquals("TAN2go", $parsedParams->verfahrensparameterZweiSchrittVerfahren[5]->technischeIdentifikationTanVerfahren);
+        $this->assertEquals("iTAN", $parsedParams->verfahrensparameterZweiSchrittVerfahren[6]->technischeIdentifikationTanVerfahren);
+        $this->assertEquals("00", $parsedParams->verfahrensparameterZweiSchrittVerfahren[6]->initialisierungsmodus);
+    }
+
+    public function test_validate_DKB_response_v3()
+    {
+        $parsed = HITANSv3::parse(static::REAL_DKB_RESPONSE[1]);
+        $parsed->validate(); // Should not throw.
+    }
+
+    public function test_serialize_DKB_response_v3()
+    {
+        $parsed = HITANSv3::parse(static::REAL_DKB_RESPONSE[1]);
+        $this->assertEquals(static::REAL_DKB_RESPONSE[1], $parsed->serialize());
+    }
+}

--- a/lib/Tests/Fhp/Segment/HIUPDTest.php
+++ b/lib/Tests/Fhp/Segment/HIUPDTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Tests\Fhp\Model;
+
+use Fhp\Segment\HIUPD\HIUPDv4;
+
+class HIUPDTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @link https://www.hbci-zka.de/dokumente/spezifikation_deutsch/archiv/HBCI_V2.x_FV.zip
+     * File: HBCI22 Final.pdf
+     * Search for: "HIUPD:"
+     */
+    const HBCI22_EXAMPLES = array(
+        // NOTE: These two examples are likely outdated in the document because the new $unterkontomerkmal field was
+        // added. So it's `::280` and not just `:280`. The first of these two examples occurs twice in the document,
+        // once in the correct format. Here both of them are "fixed" (hopefully).
+        "HIUPD:16:4:4+1234567::280:10020030+12345+DEM+Ernst Müller++Giro Spezial+T:2000,:DEM+HKPRO:1+HKSAK:1+HKISA:1+HKSSP:1+HKUEB:1+HKLAS:1+HKKAN:1+HKKAZ:1+HKSAL:1'",
+        "HIUPD:17:4:4+1234568::280:10020030+12345+DEM+Ernst Müller++Sparkonto 2000++HKPRO:1+HKSAK:0+HKISA:1+HKSSP:0+HKUEB:2:Z:1000,:DEM:7+HKKAN:1+HKKAZ:1+HKSAL:2'",
+    );
+
+    public function test_parse_HBCI22_example1()
+    {
+        /** @var HIUPDv4 $parsed */
+        $parsed = HIUPDv4::parse(static::HBCI22_EXAMPLES[0]);
+        $this->assertSame(16, $parsed->segmentkopf->segmentnummer);
+        $this->assertSame(4, $parsed->segmentkopf->segmentversion);
+        $this->assertSame('1234567', $parsed->kontoverbindung->kontonummer);
+        $this->assertNull($parsed->kontoverbindung->unterkontomerkmal);
+        $this->assertSame(280, $parsed->kontoverbindung->laenderkennzeichen);
+        $this->assertSame('10020030', $parsed->kontoverbindung->kreditinstitutionscode);
+        $this->assertSame('12345', $parsed->kundenId);
+        $this->assertSame('DEM', $parsed->kontowaehrung);
+        $this->assertSame('Ernst Müller', $parsed->name1);
+        $this->assertSame('Giro Spezial', $parsed->kontoproduktbezeichnung);
+
+        $this->assertSame('T', $parsed->kontolimit->limitart);
+        $this->assertSame(2000.0, $parsed->kontolimit->limitbetrag->wert);
+        $this->assertSame('DEM', $parsed->kontolimit->limitbetrag->waehrung);
+        $this->assertNull($parsed->kontolimit->limitTage);
+
+        $this->assertCount(9, $parsed->erlaubteGeschaeftsvorfaelle);
+    }
+
+    public function test_validate_HBCI22_example1()
+    {
+        /** @var HIUPDv4 $parsed */
+        $parsed = HIUPDv4::parse(static::HBCI22_EXAMPLES[0]);
+        $parsed->validate(); // Should not throw.
+    }
+
+    public function test_serialize_HBCI22_example1()
+    {
+        /** @var HIUPDv4 $parsed */
+        $parsed = HIUPDv4::parse(static::HBCI22_EXAMPLES[0]);
+        $this->assertEquals(static::HBCI22_EXAMPLES[0], $parsed->serialize());
+    }
+
+    public function test_parse_HBCI22_example2()
+    {
+        /** @var HIUPDv4 $parsed */
+        $parsed = HIUPDv4::parse(static::HBCI22_EXAMPLES[1]);
+        $this->assertSame('1234568', $parsed->kontoverbindung->kontonummer);
+        $this->assertSame('Sparkonto 2000', $parsed->kontoproduktbezeichnung);
+        $this->assertNull($parsed->kontolimit);
+
+        $this->assertCount(8, $parsed->erlaubteGeschaeftsvorfaelle);
+        $this->assertSame('HKUEB', $parsed->erlaubteGeschaeftsvorfaelle[4]->geschaeftsvorfall);
+        $this->assertSame(2, $parsed->erlaubteGeschaeftsvorfaelle[4]->anzahlBenoetigterSignaturen);
+        $this->assertSame('Z', $parsed->erlaubteGeschaeftsvorfaelle[4]->limitart);
+        $this->assertSame(1000.0, $parsed->erlaubteGeschaeftsvorfaelle[4]->limitbetrag->wert);
+        $this->assertSame('DEM', $parsed->erlaubteGeschaeftsvorfaelle[4]->limitbetrag->waehrung);
+        $this->assertSame(7, $parsed->erlaubteGeschaeftsvorfaelle[4]->limitTage);
+    }
+
+    public function test_validate_HBCI22_example2()
+    {
+        $parsed = HIUPDv4::parse(static::HBCI22_EXAMPLES[1]);
+        $parsed->validate(); // Should not throw.
+    }
+
+    public function test_serialize_HBCI22_example2()
+    {
+        $parsed = HIUPDv4::parse(static::HBCI22_EXAMPLES[1]);
+        $this->assertEquals(static::HBCI22_EXAMPLES[1], $parsed->serialize());
+    }
+}

--- a/lib/Tests/Fhp/Syntax/ParserTest.php
+++ b/lib/Tests/Fhp/Syntax/ParserTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Tests\Fhp\Syntax;
+
+use Fhp\Syntax\Parser;
+
+class ParserTest extends \PHPUnit_Framework_TestCase
+{
+    public function test_splitEscapedString_empty()
+    {
+        $this->assertEquals(array(), Parser::splitEscapedString('+', ''));
+        $this->assertEquals(array('', ''), Parser::splitEscapedString('+', '+'));
+    }
+
+    public function test_splitEscapedString_without_escaping()
+    {
+        $this->assertEquals(array('ABC', 'DEF'), Parser::splitEscapedString('+', 'ABC+DEF'));
+        $this->assertEquals(array('ABC', '', 'DEF'), Parser::splitEscapedString('+', 'ABC++DEF'));
+        $this->assertEquals(array('ABC', ''), Parser::splitEscapedString('+', 'ABC+'));
+        $this->assertEquals(array('', '', 'ABC'), Parser::splitEscapedString('+', '++ABC'));
+    }
+
+    public function test_splitEscapedString_with_escaping()
+    {
+
+        $this->assertEquals(array('A?+', 'DEF'), Parser::splitEscapedString('+', 'A?++DEF'));
+        $this->assertEquals(array('?+C', '', 'D?+'), Parser::splitEscapedString('+', '?+C++D?+'));
+        $this->assertEquals(array('ABC', '?+'), Parser::splitEscapedString('+', 'ABC+?+'));
+        $this->assertEquals(array('', '', '?+C'), Parser::splitEscapedString('+', '++?+C'));
+    }
+
+    public function test_unescape()
+    {
+        $this->assertEquals('ABC+DEF', Parser::unescape('ABC+DEF'));
+        $this->assertEquals('ABC+DEF', Parser::unescape('ABC?+DEF'));
+        $this->assertEquals('ABC?+DEF', Parser::unescape('ABC??+DEF'));
+        $this->assertEquals('ABC?DEF', Parser::unescape('ABC?DEF'));
+        $this->assertEquals('ABC:DEF', Parser::unescape('ABC?:DEF'));
+    }
+
+    public function test_parseDataElement()
+    {
+        $this->assertSame(15, Parser::parseDataElement('15', 'int'));
+        $this->assertSame(1000, Parser::parseDataElement('1000', 'integer'));
+        $this->assertSame(15.0, Parser::parseDataElement('15,', 'float'));
+        $this->assertSame(15.5, Parser::parseDataElement('15,5', 'float'));
+        $this->assertSame(0.0, Parser::parseDataElement('0,', 'float'));
+        $this->assertSame(true, Parser::parseDataElement('J', 'bool'));
+        $this->assertSame(false, Parser::parseDataElement('N', 'boolean'));
+        $this->assertSame("1000", Parser::parseDataElement('1000', 'string'));
+    }
+
+    public function test_parseDataElement_invalid_int()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        Parser::parseDataElement('lala', 'int');
+    }
+
+    public function test_parseDataElement_invalid_float_wrong_decimal_separator()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        Parser::parseDataElement('15.5', 'float');
+    }
+
+    public function test_parseDataElement_invalid_float_multiple_decimal_separator()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        Parser::parseDataElement('15,5,5', 'float');
+    }
+
+    public function test_parseDataElement_invalid_float_no_decimal_separator()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        Parser::parseDataElement('15', 'float');
+    }
+
+    // NOTE: Test coverage of DEGs and Segments is provided by tests in Test\Fhp\Segment.
+}

--- a/lib/Tests/Fhp/Syntax/SerializerTest.php
+++ b/lib/Tests/Fhp/Syntax/SerializerTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Tests\Fhp\Syntax;
+
+use Fhp\Syntax\Serializer;
+
+class SerializerTest extends \PHPUnit_Framework_TestCase
+{
+    public function test_serializeDataElement() 
+    {
+        $this->assertSame('15', Serializer::serializeDataElement(15, 'int'));
+        $this->assertSame('1000', Serializer::serializeDataElement(1000, 'integer'));
+        $this->assertSame('15,', Serializer::serializeDataElement(15.0, 'float'));
+        $this->assertSame('15,5', Serializer::serializeDataElement(15.5, 'float'));
+        $this->assertSame('0,', Serializer::serializeDataElement(0.0, 'float'));
+        $this->assertSame('J', Serializer::serializeDataElement(true, 'bool'));
+        $this->assertSame('N', Serializer::serializeDataElement(false, 'boolean'));
+        $this->assertSame('1000', Serializer::serializeDataElement("1000", 'string'));
+    }
+    
+    public function test_fillMissingKeys()
+    {
+        $arr = array(0 => 'a', 2 => 'b', 4 => 'c');
+        Serializer::fillMissingKeys($arr, 'X');
+        $this->assertEquals(array(0 => 'a', 1 => 'X', 2 => 'b', 3 => 'X', 4 => 'c'), $arr);
+    }
+}


### PR DESCRIPTION
Currently, half of the segments (the ones that the client sends to the bank) are implemented as individual classes (e.g. `HKTAN`), whose constructor immediately serializes them to an array structure, which can require [cumbersome code](https://github.com/nemiah/phpFinTS/blob/4ca6c4fdd69ba7c59edbce2404e14239a5601cd4/lib/Fhp/Segment/HKTAN.php#L29-L59) when multiple versions need to be supported. The other half of the segments (the ones that the bank sends as a response) are stored as plain unparsed strings inside the `Response` class and [parsed on-the-fly](https://github.com/nemiah/phpFinTS/blob/4ca6c4fdd69ba7c59edbce2404e14239a5601cd4/lib/Fhp/Response/GetVariables.php#L14-L17) with a series of helper functions (`findSegments()`, `splitSegment()`, `splitDeg()`).

This pull request is a proposal for a fundamentally different architecture. It currently implements this architecture up to the level of individual segments, but not yet messages. It is not yet integrated with existing code (so this PR is noop).

On a high level, all the serialization and parsing is done centrally in two symmetric classes, `Parser` and `Serializer`. Both of them use the same data structure, namely sub-classes of `BaseDeg` and `BaseSegment`. Those sub-classes consist merely of public member fields in the right order and with type annotations. With the help of some descriptor classes, which cache the information contained in those type annotations, the parser/serializer knows how to map those structures to the wire format.

Advantages:
- The design is consistently object-oriented: all structures are stored as objects with named fields rather than a mix of objects and nested arrays. This makes the code more understandable.
- Separation of concerns:
  - Logic for serialization and parsing with all the index magic is in a single place (the `Fhp\Syntax` module).
  - The HBCI specification can trivially be mapped to segment/deg classes: just declare the fields in the same order and with the same type as specified. No complicated thinking is required wrt. array indices and optional fields.
  - The HBCI API layer (the set of classes for segments and messages) has a clearly separated interface (the `Fhp\Segment` module) that can be unit-tested independently, based on messages received from real banks and from the specification examples. This makes the business logic code more readable, as it only references proper field names instead of indices that readers of the code need to look up in the specification.
- The memory data structure corresponds to specification (instead of the wire format):
  - The wire format can be changed, e.g. by adding support for XML (FinTs v4) in the future.
  - Interactive debuggers show named properties instead of just anonymous nested arrays and colon-separated strings.
- Multiple different versions of segments/DEGs are supported transparently without any `if` statements in the business logic. (Note: The message parser will automatically look up the right classes to instantiate, and offer lookup functions by segment name/class. When the need arises to read "any segment of type X, no matter what version", we can have `Xv1` and `Xv2` both implement a common interface `X`.)

Disadvantages:
- Boilerplate and unused code: There has to be a field declaration for every field inside every segment used by the library, vs. just accessing the ones that are actually used. (But the boilerplate is easy to create from the specification, and helps understand the code and debug outputs.)
- Stricter parsing: The parsing is less robust to mistakes by the bank's or our implementation, as it always parses and validates all fields, even if we don't care about those fields. (But failing early is a best practice, and could even point out hidden bugs.)
- Code complexity: Use of reflection and mapping indices to classes. (But this complexity is encapsulated in a few central classes, away from the business logic, and unit-tested independently.)
- Runtime overhead: Reflection, and always parsing everything. (Not really a concern nowadays.)

Migration plan:
The new design is modular, which means that each DEG and each segment can be used independently, with the wire format as the interface (`BaseSegment` implements `SegmentInterface`, and the old `Message` class contains the unparsed segments which the new parser accepts). My plan is to replace the old segment implementations one by one, starting with `HITANS`, for which we currently need parsing of multiple versions in order to support DKB. Once the new design proves beneficial in practice, I will implement the message layer on top, and eventually remove the old infrastructure (`AbstractSegment`, `Fhp\Deg` etc.). The interface of the user-facing classes in the `Fhp\Model` module will remain unchanged.

Please let me know what you think!