### PR TITLE
Fix #43 sicherheitsprofil

### DIFF
--- a/lib/Fhp/Dialog/Dialog.php
+++ b/lib/Fhp/Dialog/Dialog.php
@@ -356,12 +356,14 @@ class Dialog
 	/**
 	 * Initializes a dialog.
 	 *
-	 * @return string|null
+	 * @param int|null $tanMechanism
+	 * @param string|null $tanMediaName
+	 * @return string|null dialog id
 	 * @throws CurlException
 	 * @throws FailedRequestException
 	 * @throws \Exception
 	 */
-	public function initDialog($tanMediaName)
+	public function initDialog($tanMechanism = null, $tanMediaName = null)
 	{
 		$this->logger->info('');
 		$this->logger->info('DIALOG initialize');
@@ -377,6 +379,13 @@ class Dialog
 			$this->productVersion
 		);
 
+		$options = array();
+		if (null === $tanMechanism) {
+			$options[AbstractMessage::OPT_PINTAN_MECH] = array_keys($this->supportedTanMechanisms);
+		} else {
+			$options[AbstractMessage::OPT_PINTAN_MECH] = array($tanMechanism);
+		}
+
 		$message = new Message(
 			$this->bankCode,
 			$this->username,
@@ -389,7 +398,7 @@ class Dialog
 				$prepare,
 				new HKTAN(HKTAN::VERSION, 5, null, $tanMediaName)
 			),
-			array(AbstractMessage::OPT_PINTAN_MECH => array_keys($this->supportedTanMechanisms))
+			$options
 		);
 
 		#$this->logger->debug('Sending INIT message:');

--- a/lib/Fhp/FinTs.php
+++ b/lib/Fhp/FinTs.php
@@ -162,7 +162,7 @@ class FinTs extends FinTsInternal
 		#$dialog->endDialog(); //probably not required
 		$dialog->syncDialog($this->tanMechanism, $this->tanMediaName);
 		$dialog->endDialog();
-		$dialog->initDialog($this->tanMediaName);
+		$dialog->initDialog($this->tanMechanism, $this->tanMediaName);
 
 		$message = $this->getNewMessage(
 			$dialog,


### PR DESCRIPTION
Sorgt dafür, dass auch beim initDialog ein fixer tanMechanism genutzt wird, statt des ersten aus der Liste aller erlaubten tanMechanisms.
Damit sollte später z.B. bei getSepaAccounts keine Probleme mehr auftauchen, denn dieser nutzt bereits den fixen tanMechanism.