### PR TITLE
Reimplement GetVariables based on new segments layer

### DIFF
--- a/lib/Fhp/Response/GetVariables.php
+++ b/lib/Fhp/Response/GetVariables.php
@@ -2,7 +2,8 @@
 
 namespace Fhp\Response;
 
-use Fhp\Parser\Exception\MT940Exception;
+use Fhp\Segment\BaseSegment;
+use Fhp\Segment\HITANS\HITANS;
 
 /**
  * Class GetVariables
@@ -24,119 +25,16 @@ class GetVariables extends Response
 
 	private function parseTanModes($segments)
 	{
-		// extracted from https://www.hbci-zka.de/dokumente/spezifikation_deutsch/fintsv3/FinTS_3.0_Security_Sicherheitsverfahren_PINTAN_2018-02-23_final_version.pdf
-		// Zwei-Schritt-TAN-Einreichung, Parameter
-		//
-		// 1. Segmentkopf:
-		// Beispiel: HITANS:169:6:4
-		// 1.1. Segmentkennung (HITANS)
-		// 1.2. Segmentnummer
-		// 1.3. Segmentversion
-		// 1.4. Bezugssegment
-		// 2. Maximale Anzahl Aufträge (int(3))
-		// 3. Anzahl Signaturen mindestens (0, 1, 2, 3)
-		// 4. Sicherheitsklasse (0, 1, 2, 3, 4)
-		// 5. Parameter Zwei-Schritt-TAN Einreichung
-		// 5.1. Einschrittverfahren erlaubt [jn] (V1-V6)
-		// 5.2. Mehr als ein TANpflichtiger Auftrag pro Nachricht erlaubt [jn] (V1-V6)
-		// 5.3. AuftragsHashwertverfahren [code] (V1-V6)
-		// 5.4. Sicherheitsprofil Banken-Signatur bei HITAN [code] (V1)
-		// 5.4. Verfahrensparameter ZweiSchritt-Verfahren (V2-V6)
-		// 5.5. Verfahrensparameter ZweiSchritt-Verfahren (V1)
-		// Sparkasse has 5 elements but declares version 6
 		$result = array();
 		foreach ($segments as $segmentRaw) {
-			$segment = $this->splitSegment($segmentRaw);
-
-			$segmentHeader = $this->splitDeg($segment[0]);
-			$version = (int) $segmentHeader[2];  // 1.3
-
-			$paramsIndex = count($segment) - 1;
-			$params = $this->splitDeg($segment[$paramsIndex]);
-
-			// 5. Parameter Zwei-Schritt-TAN-Einreichung:
-			// 5.4/5.5 s. Verfahrensparameter Zwei-Schritt-Verfahren
-			// Beispiel: J:N:0:910:2:HHD1.3.0:::chipTAN manuell:6:1:TAN-Nummer:3:J:2:N:0:0:N:N:00:0:N:1:911:2:HHD1.3.2OPT:HHDOPT1:1.3.2:chipTAN optisch:6:1:TAN-Nummer:3:J:2:N:0:0:N:N:00:0:N:1:912:2:HHD1.3.2USB:HHDUSB1:1.3.2:chipTAN-USB:6:1:TAN-Nummer:3:J:2:N:0:0:N:N:00:0:N:1:913:2:Q1S:Secoder_UC:1.2.0:chipTAN-QR:6:1:TAN-Nummer:3:J:2:N:0:0:N:N:00:0:N:1:920:2:smsTAN:::smsTAN:6:1:TAN-Nummer:3:J:2:N:0:0:N:N:00:2:N:5:921:2:pushTAN:::pushTAN:6:1:TAN-Nummer:3:J:2:N:0:0:N:N:00:2:N:2:900:2:iTAN:::iTAN:6:1:TAN-Nummer:3:J:2:N:0:0:N:N:00:0:N:0"
-			// -> Version 6
-			// J:N:0: (-> $processParamsOffset = 4)
-			// 910:2:HHD1.3.0:::chipTAN manuell:6:1:TAN-Nummer:3:J:2:N:0:0:N:N:00:0:N:1:
-			// 911:2:HHD1.3.2OPT:HHDOPT1:1.3.2:chipTAN optisch:6:1:TAN-Nummer:3:J:2:N:0:0:N:N:00:0:N:1:
-			// 912:2:HHD1.3.2USB:HHDUSB1:1.3.2:chipTAN-USB:6:1:TAN-Nummer:3:J:2:N:0:0:N:N:00:0:N:1:
-			// 913:2:Q1S:Secoder_UC:1.2.0:chipTAN-QR:6:1:TAN-Nummer:3:J:2:N:0:0:N:N:00:0:N:1:
-			// 920:2:smsTAN:::smsTAN:6:1:TAN-Nummer:3:J:2:N:0:0:N:N:00:2:N:5:
-			// 921:2:pushTAN:::pushTAN:6:1:TAN-Nummer:3:J:2:N:0:0:N:N:00:2:N:2:
-			// 900:2:iTAN:::iTAN:6:1:TAN-Nummer:3:J:2:N:0:0:N:N:00:0:N:0"
-
-			$processParamsOffset = $this->getTanProcessParamsOffsetForVersion($version);
-			$processNameIndex = $this->getTanProcessNameIndexForVersion($version);
-			$processParamElementCount = $this->getTanProcessParamElementCountForVersion($version);
-			array_splice($params, 0, $processParamsOffset);
-
-			$paramCount = count($params);
-			if ($paramCount % $processParamElementCount === $processParamElementCount - 1) {
-				// From version 3 on, the last parameter is optional and may be omitted in the last group of HITANS parameters
-				// see https://github.com/nemiah/phpFinTS/pull/40#issuecomment-532362814
-				$paramCount++;
-			}
-
-			$paramBlockIterations = $paramCount / $processParamElementCount;
-			for ($i = 0; $i < $paramBlockIterations; $i++) {
-				$blockOffset = $i * $processParamElementCount;
-				$num = $params[$blockOffset]; // first element in block
-				$name = $params[$processNameIndex + $blockOffset];
-				$result[$num] = $name;
-			}
-		}
+            $hitans = BaseSegment::parse($segmentRaw);
+            if (!($hitans instanceof HITANS)) {
+                throw new \InvalidArgumentException("All HITANS segments must implement the HITANS interface");
+            }
+            foreach ($hitans->getParameterZweiSchrittTanEinreichung()->getVerfahrensparameterZweiSchrittVerfahren() as $verfahren) {
+                $result[$verfahren->getSicherheitsfunktion()] = $verfahren->getNameDesZweiSchrittVerfahrens();
+            }
+        }
 		return $result;
-	}
-
-	private function getTanProcessParamsOffsetForVersion($version)
-	{
-		switch ($version) {
-			case 1:
-				return 4;
-			case 2:
-			case 3:
-			case 4:
-			case 5:
-			case 6:
-				return 3;
-			default:
-				throw new MT940Exception('Unknown HITANS version ' . $version);
-		}
-	}
-	private function getTanProcessParamElementCountForVersion($version)
-	{
-		switch ($version) {
-			case 1:
-				return 11;
-				break;
-			case 2:
-				return 15;
-			case 3:
-				return 18;
-			case 4:
-			case 5:
-				return 22;
-			case 6:
-				return 21;
-			default:
-				throw new MT940Exception('Unknown HITANS version ' . $version);
-		}
-	}
-	private function getTanProcessNameIndexForVersion($version)
-	{
-		switch ($version) {
-			case 1:
-			case 2:
-			case 3:
-				return 3;
-			case 4:
-			case 5:
-			case 6:
-				return 5;
-			default:
-				throw new MT940Exception('Unknown HITANS version ' . $version);
-		}
 	}
 }

--- a/lib/Fhp/Response/GetVariables.php
+++ b/lib/Fhp/Response/GetVariables.php
@@ -22,7 +22,7 @@ class GetVariables extends Response
 		return $this->get()->tanModes;
 	}
 
-	public function parseTanModes($segments)
+	private function parseTanModes($segments)
 	{
 		// extracted from https://www.hbci-zka.de/dokumente/spezifikation_deutsch/fintsv3/FinTS_3.0_Security_Sicherheitsverfahren_PINTAN_2018-02-23_final_version.pdf
 		// Zwei-Schritt-TAN-Einreichung, Parameter

--- a/lib/Fhp/Segment/HITANS/HITANS.php
+++ b/lib/Fhp/Segment/HITANS/HITANS.php
@@ -1,0 +1,18 @@
+<?php
+
+
+namespace Fhp\Segment\HITANS;
+
+/**
+ * Interface HITANS
+ * Segment: Zwei-Schritt-TAN-Einreichung, Parameter
+ * Bezugssegment: HKVVB
+ * Sender: Kreditinstitut
+ *
+ * @package Fhp\Segment\HITANS
+ */
+interface HITANS
+{
+    /** @return ParameterZweiSchrittTanEinreichung */
+    public function getParameterZweiSchrittTanEinreichung();
+}

--- a/lib/Fhp/Segment/HITANS/HITANSv1.php
+++ b/lib/Fhp/Segment/HITANS/HITANSv1.php
@@ -14,7 +14,7 @@ use Fhp\Segment\BaseSegment;
  *
  * @package Fhp\Segment\HITANS
  */
-class HITANSv1 extends BaseSegment
+class HITANSv1 extends BaseSegment implements HITANS
 {
     /** @var integer */
     public $maximaleAnzahlAuftraege;
@@ -24,4 +24,10 @@ class HITANSv1 extends BaseSegment
     public $sicherheitsklasse;
     /** @var ParameterZweiSchrittTanEinreichungV1 */
     public $parameterZweiSchrittTanEinreichung;
+
+    /** @return ParameterZweiSchrittTanEinreichungV1 */
+    public function getParameterZweiSchrittTanEinreichung()
+    {
+        return $this->parameterZweiSchrittTanEinreichung;
+    }
 }

--- a/lib/Fhp/Segment/HITANS/HITANSv2.php
+++ b/lib/Fhp/Segment/HITANS/HITANSv2.php
@@ -1,0 +1,33 @@
+<?php /** @noinspection PhpUnused */
+
+namespace Fhp\Segment\HITANS;
+
+use Fhp\Segment\BaseSegment;
+
+/**
+ * Class HITANSv2
+ * Segment: Zwei-Schritt-TAN-Einreichung, Parameter (Version 2)
+ * Bezugssegment: HKVVB
+ * Sender: Kreditinstitut
+ *
+ * @link: https://www.hbci-zka.de/dokumente/spezifikation_deutsch/archiv/FinTS_V3.0_2017-10-06-FV_RM.zip
+ *
+ * @package Fhp\Segment\HITANS
+ */
+class HITANSv2 extends BaseSegment implements HITANS
+{
+    /** @var integer */
+    public $maximaleAnzahlAuftraege;
+    /** @var integer Allowed values: 0, 1, 2, 3 */
+    public $anzahlSignaturenMindestens;
+    /** @var integer Allowed values: 0, 1, 2, 3, 4 */
+    public $sicherheitsklasse;
+    /** @var ParameterZweiSchrittTanEinreichungV2 */
+    public $parameterZweiSchrittTanEinreichung;
+
+    /** @return ParameterZweiSchrittTanEinreichungV2 */
+    public function getParameterZweiSchrittTanEinreichung()
+    {
+        return $this->parameterZweiSchrittTanEinreichung;
+    }
+}

--- a/lib/Fhp/Segment/HITANS/HITANSv3.php
+++ b/lib/Fhp/Segment/HITANS/HITANSv3.php
@@ -14,7 +14,7 @@ use Fhp\Segment\BaseSegment;
  *
  * @package Fhp\Segment\HITANS
  */
-class HITANSv3 extends BaseSegment
+class HITANSv3 extends BaseSegment implements HITANS
 {
     /** @var integer */
     public $maximaleAnzahlAuftraege;
@@ -24,4 +24,10 @@ class HITANSv3 extends BaseSegment
     public $sicherheitsklasse;
     /** @var ParameterZweiSchrittTanEinreichungV3 */
     public $parameterZweiSchrittTanEinreichung;
+
+    /** @return ParameterZweiSchrittTanEinreichungV3 */
+    public function getParameterZweiSchrittTanEinreichung()
+    {
+        return $this->parameterZweiSchrittTanEinreichung;
+    }
 }

--- a/lib/Fhp/Segment/HITANS/HITANSv4.php
+++ b/lib/Fhp/Segment/HITANS/HITANSv4.php
@@ -1,0 +1,33 @@
+<?php /** @noinspection PhpUnused */
+
+namespace Fhp\Segment\HITANS;
+
+use Fhp\Segment\BaseSegment;
+
+/**
+ * Class HITANSv4
+ * Segment: Zwei-Schritt-TAN-Einreichung, Parameter (Version 4)
+ * Bezugssegment: HKVVB
+ * Sender: Kreditinstitut
+ *
+ * @link: https://www.hbci-zka.de/dokumente/spezifikation_deutsch/archiv/FinTS_V3.0_2017-10-06-FV_RM.zip
+ *
+ * @package Fhp\Segment\HITANS
+ */
+class HITANSv4 extends BaseSegment implements HITANS
+{
+    /** @var integer */
+    public $maximaleAnzahlAuftraege;
+    /** @var integer Allowed values: 0, 1, 2, 3 */
+    public $anzahlSignaturenMindestens;
+    /** @var integer Allowed values: 0, 1, 2, 3, 4 */
+    public $sicherheitsklasse;
+    /** @var ParameterZweiSchrittTanEinreichungV4 */
+    public $parameterZweiSchrittTanEinreichung;
+
+    /** @return ParameterZweiSchrittTanEinreichungV4 */
+    public function getParameterZweiSchrittTanEinreichung()
+    {
+        return $this->parameterZweiSchrittTanEinreichung;
+    }
+}

--- a/lib/Fhp/Segment/HITANS/HITANSv5.php
+++ b/lib/Fhp/Segment/HITANS/HITANSv5.php
@@ -1,0 +1,33 @@
+<?php /** @noinspection PhpUnused */
+
+namespace Fhp\Segment\HITANS;
+
+use Fhp\Segment\BaseSegment;
+
+/**
+ * Class HITANSv5
+ * Segment: Zwei-Schritt-TAN-Einreichung, Parameter (Version 5)
+ * Bezugssegment: HKVVB
+ * Sender: Kreditinstitut
+ *
+ * @link: https://www.hbci-zka.de/dokumente/spezifikation_deutsch/archiv/FinTS_V3.0_2017-10-06-FV_RM.zip
+ *
+ * @package Fhp\Segment\HITANS
+ */
+class HITANSv5 extends BaseSegment implements HITANS
+{
+    /** @var integer */
+    public $maximaleAnzahlAuftraege;
+    /** @var integer Allowed values: 0, 1, 2, 3 */
+    public $anzahlSignaturenMindestens;
+    /** @var integer Allowed values: 0, 1, 2, 3, 4 */
+    public $sicherheitsklasse;
+    /** @var ParameterZweiSchrittTanEinreichungV5 */
+    public $parameterZweiSchrittTanEinreichung;
+
+    /** @return ParameterZweiSchrittTanEinreichungV5 */
+    public function getParameterZweiSchrittTanEinreichung()
+    {
+        return $this->parameterZweiSchrittTanEinreichung;
+    }
+}

--- a/lib/Fhp/Segment/HITANS/HITANSv6.php
+++ b/lib/Fhp/Segment/HITANS/HITANSv6.php
@@ -1,0 +1,27 @@
+<?php /** @noinspection PhpUnused */
+
+namespace Fhp\Segment\HITANS;
+
+use Fhp\Segment\BaseSegment;
+
+/**
+ * Class HITANSv6
+ * Segment: Zwei-Schritt-TAN-Einreichung, Parameter (Version 6)
+ * Bezugssegment: HKVVB
+ * Sender: Kreditinstitut
+ *
+ * @link: https://www.hbci-zka.de/dokumente/spezifikation_deutsch/archiv/FinTS_V3.0_2017-10-06-FV_RM.zip
+ *
+ * @package Fhp\Segment\HITANS
+ */
+class HITANSv6 extends BaseSegment
+{
+    /** @var integer */
+    public $maximaleAnzahlAuftraege;
+    /** @var integer Allowed values: 0, 1, 2, 3 */
+    public $anzahlSignaturenMindestens;
+    /** @var integer Allowed values: 0, 1, 2, 3, 4 */
+    public $sicherheitsklasse;
+    /** @var ParameterZweiSchrittTanEinreichungV6 */
+    public $parameterZweiSchrittTanEinreichung;
+}

--- a/lib/Fhp/Segment/HITANS/HITANSv6.php
+++ b/lib/Fhp/Segment/HITANS/HITANSv6.php
@@ -14,7 +14,7 @@ use Fhp\Segment\BaseSegment;
  *
  * @package Fhp\Segment\HITANS
  */
-class HITANSv6 extends BaseSegment
+class HITANSv6 extends BaseSegment implements HITANS
 {
     /** @var integer */
     public $maximaleAnzahlAuftraege;
@@ -24,4 +24,10 @@ class HITANSv6 extends BaseSegment
     public $sicherheitsklasse;
     /** @var ParameterZweiSchrittTanEinreichungV6 */
     public $parameterZweiSchrittTanEinreichung;
+
+    /** @return ParameterZweiSchrittTanEinreichungV6 */
+    public function getParameterZweiSchrittTanEinreichung()
+    {
+        return $this->parameterZweiSchrittTanEinreichung;
+    }
 }

--- a/lib/Fhp/Segment/HITANS/ParameterZweiSchrittTanEinreichung.php
+++ b/lib/Fhp/Segment/HITANS/ParameterZweiSchrittTanEinreichung.php
@@ -1,0 +1,9 @@
+<?php /** @noinspection PhpUnused */
+
+namespace Fhp\Segment\HITANS;
+
+interface ParameterZweiSchrittTanEinreichung
+{
+    /** @return VerfahrensparameterZweiSchrittVerfahren[] */
+    public function getVerfahrensparameterZweiSchrittVerfahren();
+}

--- a/lib/Fhp/Segment/HITANS/ParameterZweiSchrittTanEinreichungV1.php
+++ b/lib/Fhp/Segment/HITANS/ParameterZweiSchrittTanEinreichungV1.php
@@ -4,7 +4,7 @@ namespace Fhp\Segment\HITANS;
 
 use Fhp\Segment\BaseDeg;
 
-class ParameterZweiSchrittTanEinreichungV1 extends BaseDeg
+class ParameterZweiSchrittTanEinreichungV1 extends BaseDeg implements ParameterZweiSchrittTanEinreichung
 {
     /** @var boolean */
     public $einschrittVerfahrenErlaubt;
@@ -26,4 +26,10 @@ class ParameterZweiSchrittTanEinreichungV1 extends BaseDeg
     public $sicherheitsprofilBankenSignatureBeiHitan;
     /** @var VerfahrensparameterZweiSchrittVerfahrenV1[] @Max(98) */
     public $verfahrensparameterZweiSchrittVerfahren;
+
+    /** @return VerfahrensparameterZweiSchrittVerfahrenV1[] */
+    public function getVerfahrensparameterZweiSchrittVerfahren()
+    {
+        return $this->verfahrensparameterZweiSchrittVerfahren;
+    }
 }

--- a/lib/Fhp/Segment/HITANS/ParameterZweiSchrittTanEinreichungV2.php
+++ b/lib/Fhp/Segment/HITANS/ParameterZweiSchrittTanEinreichungV2.php
@@ -1,0 +1,28 @@
+<?php /** @noinspection PhpUnused */
+
+namespace Fhp\Segment\HITANS;
+
+use Fhp\Segment\BaseDeg;
+
+class ParameterZweiSchrittTanEinreichungV2 extends BaseDeg implements ParameterZweiSchrittTanEinreichung
+{
+    /** @var boolean */
+    public $einschrittVerfahrenErlaubt;
+    /** @var boolean */
+    public $mehrAlsEinTanPflichtigerAuftragProNachrichtErlaubt;
+    /**
+     * 0: Auftrags-Hashwert nicht unterstützt
+     * 1: RIPEMD-160
+     * 2: SHA-1
+     * @var integer
+     */
+    public $auftragsHashwertverfahren;
+    /** @var VerfahrensparameterZweiSchrittVerfahrenV2[] @Max(98) */
+    public $verfahrensparameterZweiSchrittVerfahren;
+
+    /** @return VerfahrensparameterZweiSchrittVerfahrenV2[] */
+    public function getVerfahrensparameterZweiSchrittVerfahren()
+    {
+        return $this->verfahrensparameterZweiSchrittVerfahren;
+    }
+}

--- a/lib/Fhp/Segment/HITANS/ParameterZweiSchrittTanEinreichungV3.php
+++ b/lib/Fhp/Segment/HITANS/ParameterZweiSchrittTanEinreichungV3.php
@@ -4,7 +4,7 @@ namespace Fhp\Segment\HITANS;
 
 use Fhp\Segment\BaseDeg;
 
-class ParameterZweiSchrittTanEinreichungV3 extends BaseDeg
+class ParameterZweiSchrittTanEinreichungV3 extends BaseDeg implements ParameterZweiSchrittTanEinreichung
 {
     /** @var boolean */
     public $einschrittVerfahrenErlaubt;
@@ -19,4 +19,10 @@ class ParameterZweiSchrittTanEinreichungV3 extends BaseDeg
     public $auftragsHashwertverfahren;
     /** @var VerfahrensparameterZweiSchrittVerfahrenV3[] @Max(98) */
     public $verfahrensparameterZweiSchrittVerfahren;
+
+    /** @return VerfahrensparameterZweiSchrittVerfahrenV3[] */
+    public function getVerfahrensparameterZweiSchrittVerfahren()
+    {
+        return $this->verfahrensparameterZweiSchrittVerfahren;
+    }
 }

--- a/lib/Fhp/Segment/HITANS/ParameterZweiSchrittTanEinreichungV4.php
+++ b/lib/Fhp/Segment/HITANS/ParameterZweiSchrittTanEinreichungV4.php
@@ -1,0 +1,28 @@
+<?php /** @noinspection PhpUnused */
+
+namespace Fhp\Segment\HITANS;
+
+use Fhp\Segment\BaseDeg;
+
+class ParameterZweiSchrittTanEinreichungV4 extends BaseDeg implements ParameterZweiSchrittTanEinreichung
+{
+    /** @var boolean */
+    public $einschrittVerfahrenErlaubt;
+    /** @var boolean */
+    public $mehrAlsEinTanPflichtigerAuftragProNachrichtErlaubt;
+    /**
+     * 0: Auftrags-Hashwert nicht unterstützt
+     * 1: RIPEMD-160
+     * 2: SHA-1
+     * @var integer
+     */
+    public $auftragsHashwertverfahren;
+    /** @var VerfahrensparameterZweiSchrittVerfahrenV4[] @Max(98) */
+    public $verfahrensparameterZweiSchrittVerfahren;
+
+    /** @return VerfahrensparameterZweiSchrittVerfahrenV4[] */
+    public function getVerfahrensparameterZweiSchrittVerfahren()
+    {
+        return $this->verfahrensparameterZweiSchrittVerfahren;
+    }
+}

--- a/lib/Fhp/Segment/HITANS/ParameterZweiSchrittTanEinreichungV5.php
+++ b/lib/Fhp/Segment/HITANS/ParameterZweiSchrittTanEinreichungV5.php
@@ -1,0 +1,28 @@
+<?php /** @noinspection PhpUnused */
+
+namespace Fhp\Segment\HITANS;
+
+use Fhp\Segment\BaseDeg;
+
+class ParameterZweiSchrittTanEinreichungV5 extends BaseDeg implements ParameterZweiSchrittTanEinreichung
+{
+    /** @var boolean */
+    public $einschrittVerfahrenErlaubt;
+    /** @var boolean */
+    public $mehrAlsEinTanPflichtigerAuftragProNachrichtErlaubt;
+    /**
+     * 0: Auftrags-Hashwert nicht unterstützt
+     * 1: RIPEMD-160
+     * 2: SHA-1
+     * @var integer
+     */
+    public $auftragsHashwertverfahren;
+    /** @var VerfahrensparameterZweiSchrittVerfahrenV5[] @Max(98) */
+    public $verfahrensparameterZweiSchrittVerfahren;
+
+    /** @return VerfahrensparameterZweiSchrittVerfahrenV5[] */
+    public function getVerfahrensparameterZweiSchrittVerfahren()
+    {
+        return $this->verfahrensparameterZweiSchrittVerfahren;
+    }
+}

--- a/lib/Fhp/Segment/HITANS/ParameterZweiSchrittTanEinreichungV6.php
+++ b/lib/Fhp/Segment/HITANS/ParameterZweiSchrittTanEinreichungV6.php
@@ -1,0 +1,22 @@
+<?php /** @noinspection PhpUnused */
+
+namespace Fhp\Segment\HITANS;
+
+use Fhp\Segment\BaseDeg;
+
+class ParameterZweiSchrittTanEinreichungV6 extends BaseDeg
+{
+    /** @var boolean */
+    public $einschrittVerfahrenErlaubt;
+    /** @var boolean */
+    public $mehrAlsEinTanPflichtigerAuftragProNachrichtErlaubt;
+    /**
+     * 0: Auftrags-Hashwert nicht unterstützt
+     * 1: RIPEMD-160
+     * 2: SHA-1
+     * @var integer
+     */
+    public $auftragsHashwertverfahren;
+    /** @var VerfahrensparameterZweiSchrittVerfahrenV6[] @Max(98) */
+    public $verfahrensparameterZweiSchrittVerfahren;
+}

--- a/lib/Fhp/Segment/HITANS/ParameterZweiSchrittTanEinreichungV6.php
+++ b/lib/Fhp/Segment/HITANS/ParameterZweiSchrittTanEinreichungV6.php
@@ -4,7 +4,7 @@ namespace Fhp\Segment\HITANS;
 
 use Fhp\Segment\BaseDeg;
 
-class ParameterZweiSchrittTanEinreichungV6 extends BaseDeg
+class ParameterZweiSchrittTanEinreichungV6 extends BaseDeg implements ParameterZweiSchrittTanEinreichung
 {
     /** @var boolean */
     public $einschrittVerfahrenErlaubt;
@@ -19,4 +19,10 @@ class ParameterZweiSchrittTanEinreichungV6 extends BaseDeg
     public $auftragsHashwertverfahren;
     /** @var VerfahrensparameterZweiSchrittVerfahrenV6[] @Max(98) */
     public $verfahrensparameterZweiSchrittVerfahren;
+
+    /** @return VerfahrensparameterZweiSchrittVerfahrenV6[] */
+    public function getVerfahrensparameterZweiSchrittVerfahren()
+    {
+        return $this->verfahrensparameterZweiSchrittVerfahren;
+    }
 }

--- a/lib/Fhp/Segment/HITANS/VerfahrensparameterZweiSchrittVerfahren.php
+++ b/lib/Fhp/Segment/HITANS/VerfahrensparameterZweiSchrittVerfahren.php
@@ -1,0 +1,12 @@
+<?php /** @noinspection PhpUnused */
+
+namespace Fhp\Segment\HITANS;
+
+interface VerfahrensparameterZweiSchrittVerfahren
+{
+    /** @return integer */
+    public function getSicherheitsfunktion();
+
+    /** @return string */
+    public function getNameDesZweiSchrittVerfahrens();
+}

--- a/lib/Fhp/Segment/HITANS/VerfahrensparameterZweiSchrittVerfahrenV1.php
+++ b/lib/Fhp/Segment/HITANS/VerfahrensparameterZweiSchrittVerfahrenV1.php
@@ -4,7 +4,7 @@ namespace Fhp\Segment\HITANS;
 
 use Fhp\Segment\BaseDeg;
 
-class VerfahrensparameterZweiSchrittVerfahrenV1 extends BaseDeg
+class VerfahrensparameterZweiSchrittVerfahrenV1 extends BaseDeg implements VerfahrensparameterZweiSchrittVerfahren
 {
     /** @var integer Allowed values: 900 through 997 */
     public $sicherheitsfunktion;
@@ -28,4 +28,14 @@ class VerfahrensparameterZweiSchrittVerfahrenV1 extends BaseDeg
     public $mehrfachTanErlaubt;
     /** @var boolean */
     public $tanZeitversetztDialoguebergreifendErlaubt;
+
+    public function getSicherheitsfunktion()
+    {
+        return $this->sicherheitsfunktion;
+    }
+
+    public function getNameDesZweiSchrittVerfahrens()
+    {
+        return $this->nameDesZweiSchrittVerfahrens;
+    }
 }

--- a/lib/Fhp/Segment/HITANS/VerfahrensparameterZweiSchrittVerfahrenV2.php
+++ b/lib/Fhp/Segment/HITANS/VerfahrensparameterZweiSchrittVerfahrenV2.php
@@ -1,0 +1,55 @@
+<?php /** @noinspection PhpUnused */
+
+namespace Fhp\Segment\HITANS;
+
+use Fhp\Segment\BaseDeg;
+
+class VerfahrensparameterZweiSchrittVerfahrenV2 extends BaseDeg implements VerfahrensparameterZweiSchrittVerfahren
+{
+    /** @var integer Allowed values: 900 through 997 */
+    public $sicherheitsfunktion;
+    /** @var integer Allowed values: 1, 2, 3, 4; See specification for details */
+    public $tanProzess;
+    /** @var string */
+    public $technischeIdentifikationTanVerfahren;
+    /** @var string Max length: 30 */
+    public $nameDesZweiSchrittVerfahrens;
+    /** @var integer */
+    public $maximaleLaengeDesTanEingabewertes;
+    /** @var integer Allowed values: 1 = numerisch, 2 = alfanumerisch */
+    public $erlaubtesFormat;
+    /** @var string */
+    public $textZurBelegungDesRueckgabewertes;
+    /** @var integer Allowed values: 1 through 256 */
+    public $maximaleLaengeDesRueckgabewertes;
+    /** @var integer|null */
+    public $anzahlUnterstuetzterAktiverTanListen;
+    /** @var boolean */
+    public $mehrfachTanErlaubt;
+    /**
+     * 1 TAN nicht zeitversetzt / dialogübergreifend erlaubt
+     * 2 TAN zeitversetzt / dialogübergreifend erlaubt
+     * 3 beide Verfahren unterstützt
+     * 4 nicht zutreffend
+     * @var integer
+     */
+    public $tanZeitUndDialogbezug;
+    /** @var integer Allowed values: 0 (cannot), 2 (must) */
+    public $tanListennummerErforderlich;
+    /** @var boolean */
+    public $auftragsstornoErlaubt;
+    /** @var boolean */
+    public $challengeKlasseErforderlich;
+    /** @var boolean */
+    public $challengeBetragErforderlich;
+
+    public function getSicherheitsfunktion()
+    {
+        return $this->sicherheitsfunktion;
+    }
+
+    public function getNameDesZweiSchrittVerfahrens()
+    {
+        return $this->nameDesZweiSchrittVerfahrens;
+    }
+}

--- a/lib/Fhp/Segment/HITANS/VerfahrensparameterZweiSchrittVerfahrenV3.php
+++ b/lib/Fhp/Segment/HITANS/VerfahrensparameterZweiSchrittVerfahrenV3.php
@@ -4,7 +4,7 @@ namespace Fhp\Segment\HITANS;
 
 use Fhp\Segment\BaseDeg;
 
-class VerfahrensparameterZweiSchrittVerfahrenV3 extends BaseDeg
+class VerfahrensparameterZweiSchrittVerfahrenV3 extends BaseDeg implements VerfahrensparameterZweiSchrittVerfahren
 {
     /** @var integer Allowed values: 900 through 997 */
     public $sicherheitsfunktion;
@@ -48,4 +48,14 @@ class VerfahrensparameterZweiSchrittVerfahrenV3 extends BaseDeg
     public $bezeichnungDesTanMediumsErforderlich;
     /** @var integer|null */
     public $anzahlUnterstuetzterAktiverTanMedien;
+
+    public function getSicherheitsfunktion()
+    {
+        return $this->sicherheitsfunktion;
+    }
+
+    public function getNameDesZweiSchrittVerfahrens()
+    {
+        return $this->nameDesZweiSchrittVerfahrens;
+    }
 }

--- a/lib/Fhp/Segment/HITANS/VerfahrensparameterZweiSchrittVerfahrenV4.php
+++ b/lib/Fhp/Segment/HITANS/VerfahrensparameterZweiSchrittVerfahrenV4.php
@@ -1,0 +1,69 @@
+<?php /** @noinspection PhpUnused */
+
+namespace Fhp\Segment\HITANS;
+
+use Fhp\Segment\BaseDeg;
+
+class VerfahrensparameterZweiSchrittVerfahrenV4 extends BaseDeg implements VerfahrensparameterZweiSchrittVerfahren
+{
+    /** @var integer Allowed values: 900 through 997 */
+    public $sicherheitsfunktion;
+    /** @var integer Allowed values: 1, 2; See specification for details */
+    public $tanProzess;
+    /** @var string */
+    public $technischeIdentifikationTanVerfahren;
+    /** @var string|null Max length: 32 */
+    public $zkaTanVerfahren;
+    /** @var string|null Max length: 10 */
+    public $versionZkaTanVerfahren;
+    /** @var string Max length: 30 */
+    public $nameDesZweiSchrittVerfahrens;
+    /** @var integer */
+    public $maximaleLaengeDesTanEingabewertes;
+    /** @var integer Allowed values: 1 = numerisch, 2 = alfanumerisch */
+    public $erlaubtesFormat;
+    /** @var string */
+    public $textZurBelegungDesRueckgabewertes;
+    /** @var integer Allowed values: 1 through 256 */
+    public $maximaleLaengeDesRueckgabewertes;
+    /** @var integer|null */
+    public $anzahlUnterstuetzterAktiverTanListen;
+    /** @var boolean */
+    public $mehrfachTanErlaubt;
+    /**
+     * 1 TAN nicht zeitversetzt / dialogübergreifend erlaubt
+     * 2 TAN zeitversetzt / dialogübergreifend erlaubt
+     * 3 beide Verfahren unterstützt
+     * 4 nicht zutreffend
+     * @var integer
+     */
+    public $tanZeitUndDialogbezug;
+    /** @var integer Allowed values: 0 (cannot), 2 (must) */
+    public $tanListennummerErforderlich;
+    /** @var boolean */
+    public $auftragsstornoErlaubt;
+    /** @var boolean */
+    public $smsAbbuchungskontoErforderlich;
+    /** @var boolean */
+    public $challengeKlasseErforderlich;
+    /** @var boolean */
+    public $challengeBetragErforderlich;
+    /** @var boolean */
+    public $challengeStrukturiert;
+    /** @var string Allowed values: 00 (cleartext PIN, no TAN), 01 (Schablone 01, encrypted PIN), 02 (reserved) */
+    public $initialisierungsmodus;
+    /** @var integer Allowed values: 0 (cannot), 2 (must) */
+    public $bezeichnungDesTanMediumsErforderlich;
+    /** @var integer|null */
+    public $anzahlUnterstuetzterAktiverTanMedien;
+
+    public function getSicherheitsfunktion()
+    {
+        return $this->sicherheitsfunktion;
+    }
+
+    public function getNameDesZweiSchrittVerfahrens()
+    {
+        return $this->nameDesZweiSchrittVerfahrens;
+    }
+}

--- a/lib/Fhp/Segment/HITANS/VerfahrensparameterZweiSchrittVerfahrenV5.php
+++ b/lib/Fhp/Segment/HITANS/VerfahrensparameterZweiSchrittVerfahrenV5.php
@@ -1,0 +1,69 @@
+<?php /** @noinspection PhpUnused */
+
+namespace Fhp\Segment\HITANS;
+
+use Fhp\Segment\BaseDeg;
+
+class VerfahrensparameterZweiSchrittVerfahrenV5 extends BaseDeg implements VerfahrensparameterZweiSchrittVerfahren
+{
+    /** @var integer Allowed values: 900 through 997 */
+    public $sicherheitsfunktion;
+    /** @var integer Allowed values: 1, 2; See specification for details */
+    public $tanProzess;
+    /** @var string */
+    public $technischeIdentifikationTanVerfahren;
+    /** @var string|null Max length: 32 */
+    public $zkaTanVerfahren;
+    /** @var string|null Max length: 10 */
+    public $versionZkaTanVerfahren;
+    /** @var string Max length: 30 */
+    public $nameDesZweiSchrittVerfahrens;
+    /** @var integer */
+    public $maximaleLaengeDesTanEingabewertes;
+    /** @var integer Allowed values: 1 = numerisch, 2 = alfanumerisch */
+    public $erlaubtesFormat;
+    /** @var string */
+    public $textZurBelegungDesRueckgabewertes;
+    /** @var integer Allowed values: 1 through 256 */
+    public $maximaleLaengeDesRueckgabewertes;
+    /** @var integer|null */
+    public $anzahlUnterstuetzterAktiverTanListen;
+    /** @var boolean */
+    public $mehrfachTanErlaubt;
+    /**
+     * 1 TAN nicht zeitversetzt / dialogübergreifend erlaubt
+     * 2 TAN zeitversetzt / dialogübergreifend erlaubt
+     * 3 beide Verfahren unterstützt
+     * 4 nicht zutreffend
+     * @var integer
+     */
+    public $tanZeitUndDialogbezug;
+    /** @var integer Allowed values: 0 (cannot), 2 (must) */
+    public $tanListennummerErforderlich;
+    /** @var boolean */
+    public $auftragsstornoErlaubt;
+    /** @var integer Allowed values: 0 (cannot), 2 (must) */
+    public $smsAbbuchungskontoErforderlich;
+    /** @var integer Allowed values: 0 (cannot), 2 (must) */
+    public $auftraggeberkontoErforderlich;
+    /** @var boolean */
+    public $challengeKlasseErforderlich;
+    /** @var boolean */
+    public $challengeStrukturiert;
+    /** @var string Allowed values: 00 (cleartext PIN, no TAN), 01 (Schablone 01, encrypted PIN), 02 (reserved) */
+    public $initialisierungsmodus;
+    /** @var integer Allowed values: 0 (cannot), 2 (must) */
+    public $bezeichnungDesTanMediumsErforderlich;
+    /** @var integer|null */
+    public $anzahlUnterstuetzterAktiverTanMedien;
+
+    public function getSicherheitsfunktion()
+    {
+        return $this->sicherheitsfunktion;
+    }
+
+    public function getNameDesZweiSchrittVerfahrens()
+    {
+        return $this->nameDesZweiSchrittVerfahrens;
+    }
+}

--- a/lib/Fhp/Segment/HITANS/VerfahrensparameterZweiSchrittVerfahrenV6.php
+++ b/lib/Fhp/Segment/HITANS/VerfahrensparameterZweiSchrittVerfahrenV6.php
@@ -4,7 +4,7 @@ namespace Fhp\Segment\HITANS;
 
 use Fhp\Segment\BaseDeg;
 
-class VerfahrensparameterZweiSchrittVerfahrenV6 extends BaseDeg
+class VerfahrensparameterZweiSchrittVerfahrenV6 extends BaseDeg implements VerfahrensparameterZweiSchrittVerfahren
 {
     /** @var integer Allowed values: 900 through 997 */
     public $sicherheitsfunktion;
@@ -54,4 +54,14 @@ class VerfahrensparameterZweiSchrittVerfahrenV6 extends BaseDeg
     public $antwortHhdUcErforderlich;
     /** @var integer|null */
     public $anzahlUnterstuetzterAktiverTanMedien;
+
+    public function getSicherheitsfunktion()
+    {
+        return $this->sicherheitsfunktion;
+    }
+
+    public function getNameDesZweiSchrittVerfahrens()
+    {
+        return $this->nameDesZweiSchrittVerfahrens;
+    }
 }

--- a/lib/Fhp/Segment/HITANS/VerfahrensparameterZweiSchrittVerfahrenV6.php
+++ b/lib/Fhp/Segment/HITANS/VerfahrensparameterZweiSchrittVerfahrenV6.php
@@ -1,0 +1,57 @@
+<?php /** @noinspection PhpUnused */
+
+namespace Fhp\Segment\HITANS;
+
+use Fhp\Segment\BaseDeg;
+
+class VerfahrensparameterZweiSchrittVerfahrenV6 extends BaseDeg
+{
+    /** @var integer Allowed values: 900 through 997 */
+    public $sicherheitsfunktion;
+    /** @var integer Allowed values: 1, 2; See specification for details */
+    public $tanProzess;
+    /** @var string */
+    public $technischeIdentifikationTanVerfahren;
+    /** @var string|null Max length: 32 */
+    public $zkaTanVerfahren;
+    /** @var string|null Max length: 10 */
+    public $versionZkaTanVerfahren;
+    /** @var string Max length: 30 */
+    public $nameDesZweiSchrittVerfahrens;
+    /** @var integer */
+    public $maximaleLaengeDesTanEingabewertes;
+    /** @var integer Allowed values: 1 = numerisch, 2 = alfanumerisch */
+    public $erlaubtesFormat;
+    /** @var string */
+    public $textZurBelegungDesRueckgabewertes;
+    /** @var integer Allowed values: 1 through 256 */
+    public $maximaleLaengeDesRueckgabewertes;
+    /** @var boolean */
+    public $mehrfachTanErlaubt;
+    /**
+     * 1 TAN nicht zeitversetzt / dialogübergreifend erlaubt
+     * 2 TAN zeitversetzt / dialogübergreifend erlaubt
+     * 3 beide Verfahren unterstützt
+     * 4 nicht zutreffend
+     * @var integer
+     */
+    public $tanZeitUndDialogbezug;
+    /** @var boolean */
+    public $auftragsstornoErlaubt;
+    /** @var integer Allowed values: 0 (cannot), 2 (must) */
+    public $smsAbbuchungskontoErforderlich;
+    /** @var integer Allowed values: 0 (cannot), 2 (must) */
+    public $auftraggeberkontoErforderlich;
+    /** @var boolean */
+    public $challengeKlasseErforderlich;
+    /** @var boolean */
+    public $challengeStrukturiert;
+    /** @var string Allowed values: 00 (cleartext PIN, no TAN), 01 (Schablone 01, encrypted PIN), 02 (reserved) */
+    public $initialisierungsmodus;
+    /** @var integer Allowed values: 0 (cannot), 2 (must) */
+    public $bezeichnungDesTanMediumsErforderlich;
+    /** @var boolean */
+    public $antwortHhdUcErforderlich;
+    /** @var integer|null */
+    public $anzahlUnterstuetzterAktiverTanMedien;
+}

--- a/lib/Fhp/Syntax/Serializer.php
+++ b/lib/Fhp/Syntax/Serializer.php
@@ -20,6 +20,16 @@ abstract class Serializer
 {
 
     /**
+     * Escapes syntax characters (delimiters).
+     * @param string $str The unescaped string.
+     * @return string The escaped string in wire format.
+     */
+    public static function escape($str)
+    {
+        return preg_replace('/([+:\'?@])/', '?$1', $str);
+    }
+
+    /**
      * @param mixed $value A scalar (DE) value.
      * @param string $type The PHP type of this value. This should support exactly the values for which
      *     {@link ElementDescriptor#isScalarType()} returns true.
@@ -28,7 +38,7 @@ abstract class Serializer
     public static function serializeDataElement($value, $type)
     {
         if ($type === 'int' || $type === 'integer' || $type === 'string') {
-            return strval($value);
+            return static::escape(strval($value));
         } elseif ($type === 'float') {
             // Format with fixed 2 decimal places (there has to be some limit, and the specification does not specify
             // one), then trim zeros from the end.

--- a/lib/Tests/Fhp/ResponseTest/GetVariablesTest.php
+++ b/lib/Tests/Fhp/ResponseTest/GetVariablesTest.php
@@ -10,10 +10,10 @@ class GetVariablesTest extends \PHPUnit_Framework_TestCase
 	public function testParseTanModesSparkasse()
 	{
 		$segments = array(
-			'HITANS:169:6:4+1+1+1+J:N:0:910:2:HHD1.3.0:::chipTAN manuell:6:1:TAN-Nummer:3:J:2:N:0:0:N:N:00:0:N:1:911:2:HHD1.3.2OPT:HHDOPT1:1.3.2:chipTAN optisch:6:1:TAN-Nummer:3:J:2:N:0:0:N:N:00:0:N:1:912:2:HHD1.3.2USB:HHDUSB1:1.3.2:chipTAN-USB:6:1:TAN-Nummer:3:J:2:N:0:0:N:N:00:0:N:1:913:2:Q1S:Secoder_UC:1.2.0:chipTAN-QR:6:1:TAN-Nummer:3:J:2:N:0:0:N:N:00:0:N:1:920:2:smsTAN:::smsTAN:6:1:TAN-Nummer:3:J:2:N:0:0:N:N:00:2:N:5:921:2:pushTAN:::pushTAN:6:1:TAN-Nummer:3:J:2:N:0:0:N:N:00:2:N:2:900:2:iTAN:::iTAN:6:1:TAN-Nummer:3:J:2:N:0:0:N:N:00:0:N:0'
+			"HITANS:169:6:4+1+1+1+J:N:0:910:2:HHD1.3.0:::chipTAN manuell:6:1:TAN-Nummer:3:J:2:N:0:0:N:N:00:0:N:1:911:2:HHD1.3.2OPT:HHDOPT1:1.3.2:chipTAN optisch:6:1:TAN-Nummer:3:J:2:N:0:0:N:N:00:0:N:1:912:2:HHD1.3.2USB:HHDUSB1:1.3.2:chipTAN-USB:6:1:TAN-Nummer:3:J:2:N:0:0:N:N:00:0:N:1:913:2:Q1S:Secoder_UC:1.2.0:chipTAN-QR:6:1:TAN-Nummer:3:J:2:N:0:0:N:N:00:0:N:1:920:2:smsTAN:::smsTAN:6:1:TAN-Nummer:3:J:2:N:0:0:N:N:00:2:N:5:921:2:pushTAN:::pushTAN:6:1:TAN-Nummer:3:J:2:N:0:0:N:N:00:2:N:2:900:2:iTAN:::iTAN:6:1:TAN-Nummer:3:J:2:N:0:0:N:N:00:0:N:0'",
 		);
-		$gv = new GetVariables(null, null);
-		$modes = $gv->parseTanModes($segments);
+		$gv = new GetVariables(implode($segments), null);
+		$modes = $gv->getSupportedTanMechanisms();
 		$this->assertEquals($modes[910], 'chipTAN manuell');
 		$this->assertEquals($modes[911], 'chipTAN optisch');
 		$this->assertEquals($modes[912], 'chipTAN-USB');
@@ -27,10 +27,10 @@ class GetVariablesTest extends \PHPUnit_Framework_TestCase
 	{
 		// see https://github.com/nemiah/phpFinTS/pull/40#issuecomment-532362814
 		$segments = array(
-			'HITANS:169:6:4+1+1+1+J:N:0:910:2:HHD1.3.0:::chipTAN manuell:6:1:TAN-Nummer:3:J:2:N:0:0:N:N:00:0:N:1:911:2:HHD1.3.2OPT:HHDOPT1:1.3.2:chipTAN optisch:6:1:TAN-Nummer:3:J:2:N:0:0:N:N:00:0:N:1:912:2:HHD1.3.2USB:HHDUSB1:1.3.2:chipTAN-USB:6:1:TAN-Nummer:3:J:2:N:0:0:N:N:00:0:N:1:913:2:Q1S:Secoder_UC:1.2.0:chipTAN-QR:6:1:TAN-Nummer:3:J:2:N:0:0:N:N:00:0:N:1:920:2:smsTAN:::smsTAN:6:1:TAN-Nummer:3:J:2:N:0:0:N:N:00:2:N:5:921:2:pushTAN:::pushTAN:6:1:TAN-Nummer:3:J:2:N:0:0:N:N:00:2:N:2:900:2:iTAN:::iTAN:6:1:TAN-Nummer:3:J:2:N:0:0:N:N:00:0:N'
+			"HITANS:169:6:4+1+1+1+J:N:0:910:2:HHD1.3.0:::chipTAN manuell:6:1:TAN-Nummer:3:J:2:N:0:0:N:N:00:0:N:1:911:2:HHD1.3.2OPT:HHDOPT1:1.3.2:chipTAN optisch:6:1:TAN-Nummer:3:J:2:N:0:0:N:N:00:0:N:1:912:2:HHD1.3.2USB:HHDUSB1:1.3.2:chipTAN-USB:6:1:TAN-Nummer:3:J:2:N:0:0:N:N:00:0:N:1:913:2:Q1S:Secoder_UC:1.2.0:chipTAN-QR:6:1:TAN-Nummer:3:J:2:N:0:0:N:N:00:0:N:1:920:2:smsTAN:::smsTAN:6:1:TAN-Nummer:3:J:2:N:0:0:N:N:00:2:N:5:921:2:pushTAN:::pushTAN:6:1:TAN-Nummer:3:J:2:N:0:0:N:N:00:2:N:2:900:2:iTAN:::iTAN:6:1:TAN-Nummer:3:J:2:N:0:0:N:N:00:0:N'",
 		);
-		$gv = new GetVariables(null, null);
-		$modes = $gv->parseTanModes($segments);
+		$gv = new GetVariables(implode($segments), null);
+        $modes = $gv->getSupportedTanMechanisms();
 		$this->assertEquals($modes[910], 'chipTAN manuell');
 		$this->assertEquals($modes[911], 'chipTAN optisch');
 		$this->assertEquals($modes[912], 'chipTAN-USB');
@@ -44,12 +44,12 @@ class GetVariablesTest extends \PHPUnit_Framework_TestCase
 	{
 		// postbank provides different versions - maybe we just use the highest one?
 		$segments = array(
-			'HITANS:14:4:4+1+1+0+N:N:0:901:2:mobileTAN:mobileTAN::mobileTAN:6:2:mobileTAN:999:0:N:1:0:N:N:N:N:J:00:2:9:910:2:HHD1.3.2OPT:HHDOPT1:1.3.2:chipTAN optisch HHD1.3.2:6:1:Challenge:999:0:N:1:0:N:N:N:N:J:00:2:9:911:2:HHD1.3.2:HHD:1.3.2:chipTAN manuell HHD1.3.2:6:1:Challenge:999:0:N:1:0:N:N:N:N:J:00:2:9:920:2:BestSign:BestSign::BestSign:6:2:BestSign:999:0:N:1:0:N:N:N:N:J:00:2:9:930:2:mobileTAN:mobileTAN::mobileTAN:6:2:mobileTAN:999:0:N:1:0:N:N:N:N:J:00:2:9',
-			'HITANS:15:5:4+1+1+0+N:N:0:901:2:mobileTAN:mobileTAN::mobileTAN:6:2:mobileTAN:999:0:N:1:0:N:0:2:N:J:00:2:9:910:2:HHD1.3.2OPT:HHDOPT1:1.3.2:chipTAN optisch HHD1.3.2:6:1:Challenge:999:0:N:1:0:N:0:2:N:J:00:2:9:911:2:HHD1.3.2:HHD:1.3.2:chipTAN manuell HHD1.3.2:6:1:Challenge:999:0:N:1:0:N:0:2:N:J:00:2:9:912:2:HHD1.4OPT:HHDOPT1:1.4:chipTAN optisch HHD1.4:6:1:Challenge:999:0:N:1:0:N:0:2:N:J:00:2:9:913:2:HHD1.4:HHD:1.4:chipTAN manuell HHD1.4:6:1:Challenge:999:0:N:1:0:N:0:2:N:J:00:2:9:920:2:BestSign:BestSign::BestSign:6:2:BestSign:999:0:N:1:0:N:0:2:N:J:00:2:9:930:2:mobileTAN:mobileTAN::mobileTAN:6:2:mobileTAN:999:0:N:1:0:N:0:2:N:J:00:2:9',
-			'HITANS:16:6:4+1+1+0+N:N:0:901:2:mobileTAN:mobileTAN::mobileTAN:6:2:mobileTAN:999:N:1:N:0:2:N:J:00:2:N:9:910:2:HHD1.3.2OPT:HHDOPT1:1.3.2:chipTAN optisch HHD1.3.2:6:1:Challenge:999:N:1:N:0:2:N:J:00:2:N:9:911:2:HHD1.3.2:HHD:1.3.2:chipTAN manuell HHD1.3.2:6:1:Challenge:999:N:1:N:0:2:N:J:00:2:N:9:912:2:HHD1.4OPT:HHDOPT1:1.4:chipTAN optisch HHD1.4:6:1:Challenge:999:N:1:N:0:2:N:J:00:2:N:9:913:2:HHD1.4:HHD:1.4:chipTAN manuell HHD1.4:6:1:Challenge:999:N:1:N:0:2:N:J:00:2:N:9:920:2:BestSign:BestSign::BestSign:6:2:BestSign:999:N:1:N:0:2:N:J:00:2:N:9:930:2:mobileTAN:mobileTAN::mobileTAN:6:2:mobileTAN:999:N:1:N:0:2:N:J:00:2:N:9'
+			"HITANS:14:4:4+1+1+0+N:N:0:901:2:mobileTAN:mobileTAN::mobileTAN:6:2:mobileTAN:999:0:N:1:0:N:N:N:N:J:00:2:9:910:2:HHD1.3.2OPT:HHDOPT1:1.3.2:chipTAN optisch HHD1.3.2:6:1:Challenge:999:0:N:1:0:N:N:N:N:J:00:2:9:911:2:HHD1.3.2:HHD:1.3.2:chipTAN manuell HHD1.3.2:6:1:Challenge:999:0:N:1:0:N:N:N:N:J:00:2:9:920:2:BestSign:BestSign::BestSign:6:2:BestSign:999:0:N:1:0:N:N:N:N:J:00:2:9:930:2:mobileTAN:mobileTAN::mobileTAN:6:2:mobileTAN:999:0:N:1:0:N:N:N:N:J:00:2:9'",
+			"HITANS:15:5:4+1+1+0+N:N:0:901:2:mobileTAN:mobileTAN::mobileTAN:6:2:mobileTAN:999:0:N:1:0:N:0:2:N:J:00:2:9:910:2:HHD1.3.2OPT:HHDOPT1:1.3.2:chipTAN optisch HHD1.3.2:6:1:Challenge:999:0:N:1:0:N:0:2:N:J:00:2:9:911:2:HHD1.3.2:HHD:1.3.2:chipTAN manuell HHD1.3.2:6:1:Challenge:999:0:N:1:0:N:0:2:N:J:00:2:9:912:2:HHD1.4OPT:HHDOPT1:1.4:chipTAN optisch HHD1.4:6:1:Challenge:999:0:N:1:0:N:0:2:N:J:00:2:9:913:2:HHD1.4:HHD:1.4:chipTAN manuell HHD1.4:6:1:Challenge:999:0:N:1:0:N:0:2:N:J:00:2:9:920:2:BestSign:BestSign::BestSign:6:2:BestSign:999:0:N:1:0:N:0:2:N:J:00:2:9:930:2:mobileTAN:mobileTAN::mobileTAN:6:2:mobileTAN:999:0:N:1:0:N:0:2:N:J:00:2:9'",
+			"HITANS:16:6:4+1+1+0+N:N:0:901:2:mobileTAN:mobileTAN::mobileTAN:6:2:mobileTAN:999:N:1:N:0:2:N:J:00:2:N:9:910:2:HHD1.3.2OPT:HHDOPT1:1.3.2:chipTAN optisch HHD1.3.2:6:1:Challenge:999:N:1:N:0:2:N:J:00:2:N:9:911:2:HHD1.3.2:HHD:1.3.2:chipTAN manuell HHD1.3.2:6:1:Challenge:999:N:1:N:0:2:N:J:00:2:N:9:912:2:HHD1.4OPT:HHDOPT1:1.4:chipTAN optisch HHD1.4:6:1:Challenge:999:N:1:N:0:2:N:J:00:2:N:9:913:2:HHD1.4:HHD:1.4:chipTAN manuell HHD1.4:6:1:Challenge:999:N:1:N:0:2:N:J:00:2:N:9:920:2:BestSign:BestSign::BestSign:6:2:BestSign:999:N:1:N:0:2:N:J:00:2:N:9:930:2:mobileTAN:mobileTAN::mobileTAN:6:2:mobileTAN:999:N:1:N:0:2:N:J:00:2:N:9'",
 		);
-		$gv = new GetVariables(null, null);
-		$modes = $gv->parseTanModes($segments);
+		$gv = new GetVariables(implode($segments), null);
+        $modes = $gv->getSupportedTanMechanisms();
 		$this->assertEquals($modes[901], 'mobileTAN');
 		$this->assertEquals($modes[910], 'chipTAN optisch HHD1.3.2');
 		$this->assertEquals($modes[911], 'chipTAN manuell HHD1.3.2');
@@ -61,8 +61,8 @@ class GetVariablesTest extends \PHPUnit_Framework_TestCase
 
 	public function testParseTanModesDKB()
 	{
-		$gv = new GetVariables(null, null);
-		$modes = $gv->parseTanModes(HITANSTest::REAL_DKB_RESPONSE);
+		$gv = new GetVariables(implode(HITANSTest::REAL_DKB_RESPONSE), null);
+        $modes = $gv->getSupportedTanMechanisms();
 		$this->assertEquals($modes[920], "smsTAN");
 		$this->assertEquals($modes[900], "iTAN");
 		$this->assertEquals($modes[910], "chipTAN manuell");

--- a/lib/Tests/Fhp/ResponseTest/GetVariablesTest.php
+++ b/lib/Tests/Fhp/ResponseTest/GetVariablesTest.php
@@ -3,7 +3,7 @@
 namespace Fhp\ResponseTest;
 
 use Fhp\Response\GetVariables;
-use Tests\Fhp\Model\HITANSTest;
+use Tests\Fhp\Segment\HITANSTest;
 
 class GetVariablesTest extends \PHPUnit_Framework_TestCase
 {

--- a/lib/Tests/Fhp/Segment/HITANSTest.php
+++ b/lib/Tests/Fhp/Segment/HITANSTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Fhp\Model;
+namespace Tests\Fhp\Segment;
 
 use Fhp\Segment\BaseSegment;
 use Fhp\Segment\HITANS\HITANSv1;

--- a/lib/Tests/Fhp/Segment/HITANSTest.php
+++ b/lib/Tests/Fhp/Segment/HITANSTest.php
@@ -4,6 +4,7 @@ namespace Tests\Fhp\Model;
 
 use Fhp\Segment\HITANS\HITANSv1;
 use Fhp\Segment\HITANS\HITANSv3;
+use Fhp\Segment\HITANS\HITANSv6;
 
 class HITANSTest extends \PHPUnit_Framework_TestCase
 {
@@ -89,5 +90,20 @@ class HITANSTest extends \PHPUnit_Framework_TestCase
     {
         $parsed = HITANSv3::parse(static::REAL_DKB_RESPONSE[1]);
         $this->assertEquals(static::REAL_DKB_RESPONSE[1], $parsed->serialize());
+    }
+
+    public function test_parse_DKB_response_v6()
+    {
+        /** @var HITANSv6 $parsed */
+        $parsed = HITANSv6::parse(static::REAL_DKB_RESPONSE[2]);
+        $this->assertEquals(1, $parsed->maximaleAnzahlAuftraege);
+        $parsedParams = $parsed->parameterZweiSchrittTanEinreichung;
+        $this->assertEquals(true, $parsedParams->einschrittVerfahrenErlaubt);
+        $this->assertCount(7, $parsedParams->verfahrensparameterZweiSchrittVerfahren);
+        $this->assertEquals("HHD1.3.0", $parsedParams->verfahrensparameterZweiSchrittVerfahren[0]->technischeIdentifikationTanVerfahren);
+        $this->assertEquals("chipTAN manuell", $parsedParams->verfahrensparameterZweiSchrittVerfahren[0]->nameDesZweiSchrittVerfahrens);
+        $this->assertEquals("TAN2go", $parsedParams->verfahrensparameterZweiSchrittVerfahren[5]->technischeIdentifikationTanVerfahren);
+        $this->assertEquals("iTAN", $parsedParams->verfahrensparameterZweiSchrittVerfahren[6]->technischeIdentifikationTanVerfahren);
+        $this->assertEquals("00", $parsedParams->verfahrensparameterZweiSchrittVerfahren[6]->initialisierungsmodus);
     }
 }

--- a/lib/Tests/Fhp/Segment/HITANSTest.php
+++ b/lib/Tests/Fhp/Segment/HITANSTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Fhp\Model;
 
+use Fhp\Segment\BaseSegment;
 use Fhp\Segment\HITANS\HITANSv1;
 use Fhp\Segment\HITANS\HITANSv3;
 use Fhp\Segment\HITANS\HITANSv6;
@@ -105,5 +106,15 @@ class HITANSTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals("TAN2go", $parsedParams->verfahrensparameterZweiSchrittVerfahren[5]->technischeIdentifikationTanVerfahren);
         $this->assertEquals("iTAN", $parsedParams->verfahrensparameterZweiSchrittVerfahren[6]->technischeIdentifikationTanVerfahren);
         $this->assertEquals("00", $parsedParams->verfahrensparameterZweiSchrittVerfahren[6]->initialisierungsmodus);
+    }
+
+    public function test_segmentVersion_detection()
+    {
+        $this->assertEquals(HITANSv1::parse(static::REAL_DKB_RESPONSE[0]),
+            BaseSegment::parse(static::REAL_DKB_RESPONSE[0]));
+        $this->assertEquals(HITANSv3::parse(static::REAL_DKB_RESPONSE[1]),
+            BaseSegment::parse(static::REAL_DKB_RESPONSE[1]));
+        $this->assertEquals(HITANSv6::parse(static::REAL_DKB_RESPONSE[2]),
+            BaseSegment::parse(static::REAL_DKB_RESPONSE[2]));
     }
 }

--- a/lib/Tests/Fhp/Segment/HIUPDTest.php
+++ b/lib/Tests/Fhp/Segment/HIUPDTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Fhp\Model;
+namespace Tests\Fhp\Segment;
 
 use Fhp\Segment\HIUPD\HIUPDv4;
 

--- a/lib/Tests/Fhp/Syntax/SerializerTest.php
+++ b/lib/Tests/Fhp/Syntax/SerializerTest.php
@@ -6,7 +6,15 @@ use Fhp\Syntax\Serializer;
 
 class SerializerTest extends \PHPUnit_Framework_TestCase
 {
-    public function test_serializeDataElement() 
+    public function test_escape()
+    {
+        $this->assertEquals('ABC?+DEF', Serializer::escape('ABC+DEF'));
+        $this->assertEquals('ABC???+DEF', Serializer::escape('ABC?+DEF'));
+        $this->assertEquals('ABC??DEF', Serializer::escape('ABC?DEF'));
+        $this->assertEquals('ABC?:DEF', Serializer::escape('ABC:DEF'));
+    }
+
+    public function test_serializeDataElement()
     {
         $this->assertSame('15', Serializer::serializeDataElement(15, 'int'));
         $this->assertSame('1000', Serializer::serializeDataElement(1000, 'integer'));
@@ -16,8 +24,9 @@ class SerializerTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('J', Serializer::serializeDataElement(true, 'bool'));
         $this->assertSame('N', Serializer::serializeDataElement(false, 'boolean'));
         $this->assertSame('1000', Serializer::serializeDataElement("1000", 'string'));
+        $this->assertSame('5?:5', Serializer::serializeDataElement("5:5", 'string'));
     }
-    
+
     public function test_fillMissingKeys()
     {
         $arr = array(0 => 'a', 2 => 'b', 4 => 'c');


### PR DESCRIPTION
This PR adds flexible parsing for `HITANS` segments version 1 through 6 and exposes the parsed segments with a common interface. This allows reimplementing `GetVariables:parseTanModes()` (which is a business logic layer function) without any interspersed parsing logic. If necessary, the common interface allows adding other `HITANS` versions without much thinking or danger of breaking other ones. The unit test remains unchanged besides plumbing.

@roben I'd appreciate your review, as you are probably most familiar with how `HITANS` works across the various banks. I'm not sure if your unit tests cover all the special cases that you considered when implementing the code. In particular, I see a comment about Sparkasse declaring version 6 and you suspecting that they send version 5, yet the unit tests still works with my `HITANSv6` class -- I haven't even implemented `HITANSv5`.