### PR TITLE
Adds some smaller fixes and features

### DIFF
--- a/lib/Fhp/FinTs.php
+++ b/lib/Fhp/FinTs.php
@@ -148,22 +148,22 @@ class FinTs extends FinTsInternal
 		$dialog->syncDialog($this->tanMechanism, $this->tanMediaName);
 		$dialog->endDialog();
 		// $dialog->initDialog($this->tanMechanism, $this->tanMediaName);
-        $this->bankName = $dialog->getBankName();
+    	$this->bankName = $dialog->getBankName();
 
 		$message = $this->getNewMessage(
 			$dialog,
 			array(
-                new HKIDN(3, $this->bankCode, $this->username, $dialog->getSystemId()),
-                new HKVVB(4, 0, 0, HKVVB::LANG_DE, $this->productName, $this->productVersion),
-                $this->createHKTAN(5)
-            ),
+				new HKIDN(3, $this->bankCode, $this->username, $dialog->getSystemId()),
+				new HKVVB(4, 0, 0, HKVVB::LANG_DE, $this->productName, $this->productVersion),
+				$this->createHKTAN(5)
+			),
 			array(AbstractMessage::OPT_PINTAN_MECH => $this->getUsedPinTanMechanism($dialog))
 		);
 
 		$this->logger->info('');
 		$this->logger->info('HKVVB (ALL accounts) initialize');
 		
-        $response = $dialog->sendMessage($message, null, $tanCallback);
+		$response = $dialog->sendMessage($message, null, $tanCallback);
 		if ($response->isTANRequest()) {
 			return $response;
 		}
@@ -175,21 +175,21 @@ class FinTs extends FinTsInternal
 	{
 		$dialog = $response->getDialog();
 		$this->dialog = $dialog;
-        
-        if ($tan) {
+		
+		if ($tan) {
 			$response = $dialog->submitTAN($response, $this->getUsedPinTanMechanism($dialog), $tan);
 
-            $message = $this->getNewMessage(
-                $dialog,
-                array(
-                    new HKIDN(3, $this->bankCode, $this->username, $dialog->getSystemId()),
-                    new HKVVB(4, 0, 0, HKVVB::LANG_DE, $this->productName, $this->productVersion),
-                    $this->createHKTAN(5)
-                ),
-                array(AbstractMessage::OPT_PINTAN_MECH => $this->getUsedPinTanMechanism($dialog))
-            );
+			$message = $this->getNewMessage(
+				$dialog,
+				array(
+					new HKIDN(3, $this->bankCode, $this->username, $dialog->getSystemId()),
+					new HKVVB(4, 0, 0, HKVVB::LANG_DE, $this->productName, $this->productVersion),
+					$this->createHKTAN(5)
+				),
+				array(AbstractMessage::OPT_PINTAN_MECH => $this->getUsedPinTanMechanism($dialog))
+			);
 
-            $response = $dialog->sendMessage($message, null, $tanCallback);
+			$response = $dialog->sendMessage($message, null, $tanCallback);
 		}
 
 		$this->logger->info('HKVVB end');
@@ -212,7 +212,7 @@ class FinTs extends FinTsInternal
 		$dialog->syncDialog($this->tanMechanism, $this->tanMediaName);
 		$dialog->endDialog();
 		$dialog->initDialog($this->tanMechanism, $this->tanMediaName);
-        $this->bankName = $dialog->getBankName();
+		$this->bankName = $dialog->getBankName();
 
 		$message = $this->getNewMessage(
 			$dialog,

--- a/lib/Fhp/FinTs.php
+++ b/lib/Fhp/FinTs.php
@@ -148,7 +148,7 @@ class FinTs extends FinTsInternal
 		$dialog->syncDialog($this->tanMechanism, $this->tanMediaName);
 		$dialog->endDialog();
 		// $dialog->initDialog($this->tanMechanism, $this->tanMediaName);
-    	$this->bankName = $dialog->getBankName();
+		$this->bankName = $dialog->getBankName();
 
 		$message = $this->getNewMessage(
 			$dialog,

--- a/lib/Fhp/Model/StatementOfAccount/Transaction.php
+++ b/lib/Fhp/Model/StatementOfAccount/Transaction.php
@@ -78,6 +78,11 @@ class Transaction
 	protected $booked;
 
     /**
+     * @var int
+     */
+	protected $pn;
+
+    /**
      * Get booking date.
      *
      * @deprecated Use getBookingDate() instead
@@ -428,6 +433,27 @@ class Transaction
     {
         $this->name = (string) $name;
 
+        return $this;
+    }
+
+    /**
+     * Get primanota number
+     *
+     * @return int
+     */
+    public function getPN() {
+        return $this->pn;
+    }
+ 
+   /**
+     * Set primanota number
+     *
+     * @param int $nr
+     *
+     * @return $this
+     */
+    public function setPN($nr) {
+        $this->pn = (int) $nr;
         return $this;
     }
 }

--- a/lib/Fhp/Response/GetAccounts.php
+++ b/lib/Fhp/Response/GetAccounts.php
@@ -24,6 +24,8 @@ class GetAccounts extends Response
 
         foreach ($accounts as $account) {
             $accountParts = $this->splitSegment($account);
+            if (empty($accountParts[1]))
+                continue;
             $this->accounts[] = $this->createModelFromArray($accountParts);
         }
 

--- a/lib/Fhp/Response/GetStatementOfAccount.php
+++ b/lib/Fhp/Response/GetStatementOfAccount.php
@@ -92,6 +92,7 @@ class GetStatementOfAccount extends Response
                     $transaction->setAccountNumber($trx['description']['account_number']);
                     $transaction->setName($trx['description']['name']);
 					$transaction->setBooked($trx['booked']);
+                    $transaction->setPN($trx['description']['primanoten_nr']);
                     $statementModel->addTransaction($transaction);
                 }
             }

--- a/lib/Fhp/Response/GetStatementOfAccount.php
+++ b/lib/Fhp/Response/GetStatementOfAccount.php
@@ -91,7 +91,7 @@ class GetStatementOfAccount extends Response
                     $transaction->setBankCode($trx['description']['bank_code']);
                     $transaction->setAccountNumber($trx['description']['account_number']);
                     $transaction->setName($trx['description']['name']);
-					$transaction->setBooked($trx['booked']);
+                    $transaction->setBooked($trx['booked']);
                     $transaction->setPN($trx['description']['primanoten_nr']);
                     $statementModel->addTransaction($transaction);
                 }

--- a/lib/Fhp/Response/GetVariables.php
+++ b/lib/Fhp/Response/GetVariables.php
@@ -15,7 +15,24 @@ class GetVariables extends Response
 	{
 		$variables = new \stdClass();
 		$segments = $this->findSegments('HITANS');
-		$variables->tanModes = $this->parseTanModes($segments);
+		
+        $allTanModes = $this->parseTanModes($segments);
+        
+        $variables->tanModes = array();
+		foreach ($this->findSegments('HIRMS') as $segment) {
+            $segment = $this->splitSegment($segment);
+            foreach ($segment as $de)
+                if (substr($de, 0, 6) === "3920::") {
+                    $de = $this->splitDeg($de);
+                    $de = array_slice($de, 3);
+
+                    foreach ($de as $methodNr)
+                        if (array_key_exists($methodNr, $allTanModes))
+                            $variables->tanModes[$methodNr] = $allTanModes[$methodNr];
+                    break;
+                }
+        }
+
 		return $variables;
 	}
 

--- a/lib/Fhp/Response/GetVariables.php
+++ b/lib/Fhp/Response/GetVariables.php
@@ -16,22 +16,23 @@ class GetVariables extends Response
 		$variables = new \stdClass();
 		$segments = $this->findSegments('HITANS');
 		
-        $allTanModes = $this->parseTanModes($segments);
-        
-        $variables->tanModes = array();
+		$allTanModes = $this->parseTanModes($segments);
+		
+		$variables->tanModes = array();
 		foreach ($this->findSegments('HIRMS') as $segment) {
-            $segment = $this->splitSegment($segment);
-            foreach ($segment as $de)
-                if (substr($de, 0, 6) === "3920::") {
-                    $de = $this->splitDeg($de);
-                    $de = array_slice($de, 3);
+			$segment = $this->splitSegment($segment);
+			foreach ($segment as $de) {
+				if (substr($de, 0, 6) === "3920::") {
+					$de = $this->splitDeg($de);
+					$de = array_slice($de, 3);
 
-                    foreach ($de as $methodNr)
-                        if (array_key_exists($methodNr, $allTanModes))
-                            $variables->tanModes[$methodNr] = $allTanModes[$methodNr];
-                    break;
-                }
-        }
+					foreach ($de as $methodNr)
+						if (array_key_exists($methodNr, $allTanModes))
+							$variables->tanModes[$methodNr] = $allTanModes[$methodNr];
+					break;
+				}
+			}
+		}
 
 		return $variables;
 	}

--- a/lib/Fhp/Response/Response.php
+++ b/lib/Fhp/Response/Response.php
@@ -236,15 +236,15 @@ class Response
 			foreach ($segment as $de) {
 				$de = $this->splitDeg($de);
 				$result[$de[0]] = $de[2];
-                if (count($de) > 3) {
-                    $result[$de[0]] .= " (";
-                    for ($ii = 3; $ii < count($de); $ii++) {
-                        $result[$de[0]] .= $de[$ii];
-                        if ($ii !== count($de)-1)
-                            $result[$de[0]] .= ", ";
-                    }
-                    $result[$de[0]] .= ")";
-                }
+				if (count($de) > 3) {
+					$result[$de[0]] .= " (";
+					for ($ii = 3; $ii < count($de); $ii++) {
+						$result[$de[0]] .= $de[$ii];
+						if ($ii !== count($de)-1)
+							$result[$de[0]] .= ", ";
+					}
+					$result[$de[0]] .= ")";
+				}
 			}
 		}
 

--- a/lib/Fhp/Response/Response.php
+++ b/lib/Fhp/Response/Response.php
@@ -15,7 +15,8 @@ class Response
 {
 
 	const RESPONSE_CODE_STRONG_AUTH_NOT_REQUIRED = 3076;
-	const RESPONSE_CODE_STRONG_AUTH_REQUIRED = 9076;
+	const RESPONSE_CODE_SECURITY_CLEARANCE_REQUIRED = "0030";
+	// const RESPONSE_CODE_STRONG_AUTH_REQUIRED = 9076;
 	const RESPONSE_CODE_COMMAND_EXECUTED = "0020";
 
 	/** @var string */
@@ -57,11 +58,15 @@ class Response
 
 	public function isStrongAuthRequired()
 	{
-		if(array_key_exists(self::RESPONSE_CODE_COMMAND_EXECUTED, $this->getSegmentSummary())){
+		$msgArr = $this->getSegmentSummary() + $this->getMessageSummary();
+        if(array_key_exists(self::RESPONSE_CODE_SECURITY_CLEARANCE_REQUIRED, $msgArr)){
+			return true;
+		}
+        if(array_key_exists(self::RESPONSE_CODE_STRONG_AUTH_NOT_REQUIRED, $msgArr)){
 			return false;
 		}
-		
-		return !array_key_exists(self::RESPONSE_CODE_STRONG_AUTH_NOT_REQUIRED, $this->getSegmentSummary());
+
+		return !array_key_exists(self::RESPONSE_CODE_COMMAND_EXECUTED, $msgArr);
 	}
 
 	public function isTANRequest()
@@ -231,6 +236,15 @@ class Response
 			foreach ($segment as $de) {
 				$de = $this->splitDeg($de);
 				$result[$de[0]] = $de[2];
+                if (count($de) > 3) {
+                    $result[$de[0]] .= " (";
+                    for ($ii = 3; $ii < count($de); $ii++) {
+                        $result[$de[0]] .= $de[$ii];
+                        if ($ii !== count($de)-1)
+                            $result[$de[0]] .= ", ";
+                    }
+                    $result[$de[0]] .= ")";
+                }
 			}
 		}
 

--- a/lib/Fhp/Response/Response.php
+++ b/lib/Fhp/Response/Response.php
@@ -59,10 +59,10 @@ class Response
 	public function isStrongAuthRequired()
 	{
 		$msgArr = $this->getSegmentSummary() + $this->getMessageSummary();
-        if(array_key_exists(self::RESPONSE_CODE_SECURITY_CLEARANCE_REQUIRED, $msgArr)){
+		if(array_key_exists(self::RESPONSE_CODE_SECURITY_CLEARANCE_REQUIRED, $msgArr)){
 			return true;
 		}
-        if(array_key_exists(self::RESPONSE_CODE_STRONG_AUTH_NOT_REQUIRED, $msgArr)){
+		if(array_key_exists(self::RESPONSE_CODE_STRONG_AUTH_NOT_REQUIRED, $msgArr)){
 			return false;
 		}
 


### PR DESCRIPTION
- getAccounts(): fixed at least for DKB and flatex. Gives all accounts including credit cards, SEPA accounts and securities accounts.
- GetAccounts.getAccountsArray(): ignores accounts without id (avoids error in the case of flatex)
- GetStatementAccount.addFromArray() + Transaction.php: added primanota number for statements
- GetVariables.get(): adds only allowed TAN methods into the list of all TAN methods
- isStrongAuthRequired(): adapted the flags to p. 24 of specification and the fields 'HIRMS' and 'HIRMG' are used for checking (needed e.g. for flatex)
- getSummaryBySegment(): displays the array attached to the message
