### PR TITLE
Fix Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,7 @@ language: php
 install: composer install
 script:
   - ./phplint.sh ./lib/
-  - phpunit
+  - ./vendor/bin/phpunit
 php:
-  - '5.4'
-  - '5.5'
-  - '5.6'
-  - '7.0'
-  - hhvm
-  - nightly
+  - '7.2'
+  - '7.3'

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,7 +8,6 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         syntaxCheck="false"
          bootstrap="./lib/Tests/TestInit.php"
 >
     <testsuites>


### PR DESCRIPTION
Remove deprecated syntaxCheck attribute from PhpUnit configuration. Make Travis use the PhpUnit version installed by Composer rather than the system-wide one. Update PHP versions to 7.2 and 7.3. Older versions (and nightly v8) are incompatible with PhpUnit 5.

Fixes https://github.com/nemiah/phpFinTS/issues/36