### PR TITLE
Add a Travis check against new tabs for indentation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: php
 install: composer install
 script:
+  - ./disallowtabs.sh
   - ./phplint.sh ./lib/
   - ./vendor/bin/phpunit
 php:

--- a/disallowtabs.sh
+++ b/disallowtabs.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+#
+# When this is run as part of a Travis test for a pull request, then it ensures that none of the added lines (compared
+# to the base branch of the pull request) use tabs for indentations.
+# Adapted from https://github.com/mrc/git-hook-library/blob/master/pre-commit.no-tabs
+
+# Abort if any of the inner commands (particularly the git commands) fails.
+set -e
+set -o pipefail
+
+if [ -z ${TRAVIS_PULL_REQUEST} ]; then
+    echo "Expected environment variable TRAVIS_PULL_REQUEST"
+    exit 2
+elif [ "${TRAVIS_PULL_REQUEST}" == "false" ]; then
+    echo "Not a Travis pull request, skipping."
+    exit 0
+fi
+
+# Make sure that we have a local copy of the relevant commits (otherwise git diff won't work).
+git remote set-branches --add origin ${TRAVIS_BRNACH}
+git fetch
+
+# Compute the diff from the PR's target branch to its HEAD commit.
+target_branch="origin/${TRAVIS_BRANCH}"
+the_diff=$(git diff "${target_branch}...HEAD")
+
+# Make sure that there are no tabs in the indentation part of added lines.
+if echo "${the_diff}" | egrep '^\+\s*	' >/dev/null; then
+    echo -e "\e[31mError: The changes contain a tab for indentation\e[0m, which is against this repo's policy."
+    echo "Target branch: origin/${TRAVIS_BRANCH}"
+    echo "Commit range: ${TRAVIS_COMMIT_RANGE}"
+    echo "The following tabs were detected:"
+    echo "${the_diff}" | egrep '^(\+\s*	|\+\+\+|@@)'
+    exit 1
+else
+    echo "No new tabs detected."
+fi


### PR DESCRIPTION
Checks all added lines in the `git diff` for any tab characters that occur in the indentation part (i.e. before the first real non-whitespace character), and fails the Travis run if any tabs are found. Note that the Travis run is marked as failed but continues to run all others checks, so that the tabs can be ignored in individual cases.

Suggestion: Indent all new code with 4 spaces. Whoever touches code in a certain place should re-indent at least the surrounding block if necessary, so that all code blocks are indented consistently.

Tested with [one PR](https://github.com/Philipp91/fints-hbci-php/pull/6) that contains new tabs ([Travis fails](https://github.com/Philipp91/fints-hbci-php/pull/6)) and [another PR](https://github.com/Philipp91/fints-hbci-php/pull/7) that replaces old tabs with spaces ([Travis succeeds](https://travis-ci.org/Philipp91/fints-hbci-php/jobs/591636659)).