### PR TITLE
Remove port number as parameter from FinTs and Connection

### DIFF
--- a/Samples/accounts.php
+++ b/Samples/accounts.php
@@ -19,7 +19,6 @@ use Fhp\FinTs;
 file_put_contents(__DIR__."/accounts.log", "");
 
 define('FHP_BANK_URL', '');                # HBCI / FinTS Url can be found here: https://www.hbci-zka.de/institute/institut_auswahl.htm (use the PIN/TAN URL)
-define('FHP_BANK_PORT', 443);              # HBCI / FinTS Port can be found here: https://www.hbci-zka.de/institute/institut_auswahl.htm
 define('FHP_BANK_CODE', '');               # Your bank code / Bankleitzahl
 define('FHP_ONLINE_BANKING_USERNAME', ''); # Your online banking username / alias
 define('FHP_ONLINE_BANKING_PIN', '');      # Your online banking PIN (NOT! the pin of your bank card!)
@@ -28,7 +27,6 @@ define('FHP_SOFTWARE_VERSION', '1.0');     # Your own Software product version
 
 $fints = new FinTs(
     FHP_BANK_URL,
-    FHP_BANK_PORT,
     FHP_BANK_CODE,
     FHP_ONLINE_BANKING_USERNAME,
     FHP_ONLINE_BANKING_PIN,

--- a/Samples/directDebit.php
+++ b/Samples/directDebit.php
@@ -55,7 +55,6 @@ $sepaDD->addDebitor(new SEPADebitor(array( //this is who you want to get money f
 use Fhp\FinTs;
 
 define('FHP_BANK_URL', '');                # HBCI / FinTS Url can be found here: https://www.hbci-zka.de/institute/institut_auswahl.htm (use the PIN/TAN URL)
-define('FHP_BANK_PORT', 443);              # HBCI / FinTS Port can be found here: https://www.hbci-zka.de/institute/institut_auswahl.htm
 define('FHP_BANK_CODE', '');               # Your bank code / Bankleitzahl
 define('FHP_ONLINE_BANKING_USERNAME', ''); # Your online banking username / alias
 define('FHP_ONLINE_BANKING_PIN', '');      # Your online banking PIN (NOT! the pin of your bank card!)
@@ -64,7 +63,6 @@ define('FHP_SOFTWARE_VERSION', '1.0');     # Your own Software product version
 
 $fints = new FinTs(
     FHP_BANK_URL,
-    FHP_BANK_PORT,
     FHP_BANK_CODE,
     FHP_ONLINE_BANKING_USERNAME,
     FHP_ONLINE_BANKING_PIN,

--- a/Samples/saldo.php
+++ b/Samples/saldo.php
@@ -21,7 +21,6 @@ use Fhp\Model\StatementOfAccount\Statement;
 use Fhp\Model\StatementOfAccount\Transaction;
 
 define('FHP_BANK_URL', '');                 # HBCI / FinTS Url can be found here: https://www.hbci-zka.de/institute/institut_auswahl.htm (use the PIN/TAN URL)
-define('FHP_BANK_PORT', 443);               # HBCI / FinTS Port can be found here: https://www.hbci-zka.de/institute/institut_auswahl.htm
 define('FHP_BANK_CODE', '');                # Your bank code / Bankleitzahl
 define('FHP_ONLINE_BANKING_USERNAME', '');  # Your online banking username / alias
 define('FHP_ONLINE_BANKING_PIN', '');       # Your online banking PIN (NOT! the pin of your bank card!)
@@ -30,7 +29,6 @@ define('FHP_SOFTWARE_VERSION', '1.0');     # Your own Software product version
 
 $fints = new FinTs(
     FHP_BANK_URL,
-    FHP_BANK_PORT,
     FHP_BANK_CODE,
     FHP_ONLINE_BANKING_USERNAME,
     FHP_ONLINE_BANKING_PIN,

--- a/Samples/standingOrderDelete.php
+++ b/Samples/standingOrderDelete.php
@@ -18,14 +18,12 @@ use Fhp\FinTs;
 file_put_contents(__DIR__."/standingOrderDelete.log", "");
 
 define('FHP_BANK_URL', '');                # HBCI / FinTS Url can be found here: https://www.hbci-zka.de/institute/institut_auswahl.htm (use the PIN/TAN URL)
-define('FHP_BANK_PORT', 443);              # HBCI / FinTS Port can be found here: https://www.hbci-zka.de/institute/institut_auswahl.htm
 define('FHP_BANK_CODE', '');               # Your bank code / Bankleitzahl
 define('FHP_ONLINE_BANKING_USERNAME', ''); # Your online banking username / alias
 define('FHP_ONLINE_BANKING_PIN', '');      # Your online banking PIN (NOT! the pin of your bank card!)
 
 $fints = new FinTs(
     FHP_BANK_URL,
-    FHP_BANK_PORT,
     FHP_BANK_CODE,
     FHP_ONLINE_BANKING_USERNAME,
     FHP_ONLINE_BANKING_PIN,

--- a/Samples/standingOrders.php
+++ b/Samples/standingOrders.php
@@ -18,7 +18,6 @@ use Fhp\FinTs;
 file_put_contents(__DIR__."/standingOrders.log", "");
 
 define('FHP_BANK_URL', '');                # HBCI / FinTS Url can be found here: https://www.hbci-zka.de/institute/institut_auswahl.htm (use the PIN/TAN URL)
-define('FHP_BANK_PORT', 443);              # HBCI / FinTS Port can be found here: https://www.hbci-zka.de/institute/institut_auswahl.htm
 define('FHP_BANK_CODE', '');               # Your bank code / Bankleitzahl
 define('FHP_ONLINE_BANKING_USERNAME', ''); # Your online banking username / alias
 define('FHP_ONLINE_BANKING_PIN', '');      # Your online banking PIN (NOT! the pin of your bank card!)
@@ -27,7 +26,6 @@ define('FHP_SOFTWARE_VERSION', '1.0');     # Your own Software product version
 
 $fints = new FinTs(
     FHP_BANK_URL,
-    FHP_BANK_PORT,
     FHP_BANK_CODE,
     FHP_ONLINE_BANKING_USERNAME,
     FHP_ONLINE_BANKING_PIN,

--- a/Samples/statement_of_account.php
+++ b/Samples/statement_of_account.php
@@ -22,7 +22,6 @@ use Fhp\Model\StatementOfAccount\Transaction;
 // Register your application prior to begin at https://www.hbci-zka.de/register/prod_register.htm
 
 define('FHP_BANK_URL', '');                # HBCI / FinTS Url will be provided to you after registration (use the PIN/TAN URL)
-define('FHP_BANK_PORT', 443);              # static standard TCP port for HTTPS
 define('FHP_BANK_CODE', '');               # Your bank code / Bankleitzahl
 define('FHP_ONLINE_BANKING_USERNAME', ''); # Your online banking username / alias
 define('FHP_ONLINE_BANKING_PIN', '');      # Your online banking PIN (NOT! the pin of your bank card!)
@@ -31,7 +30,6 @@ define('FHP_SOFTWARE_VERSION', '1.0');     # Your own Software product version
 
 $fints = new FinTs(
     FHP_BANK_URL,
-    FHP_BANK_PORT,
     FHP_BANK_CODE,
     FHP_ONLINE_BANKING_USERNAME,
     FHP_ONLINE_BANKING_PIN,
@@ -72,7 +70,6 @@ try {
 
 		$fints = new FinTs(
 			FHP_BANK_URL,
-			FHP_BANK_PORT,
 			FHP_BANK_CODE,
 			FHP_ONLINE_BANKING_USERNAME,
 			FHP_ONLINE_BANKING_PIN,

--- a/Samples/transfer.php
+++ b/Samples/transfer.php
@@ -49,7 +49,6 @@ $sepaDD->addCreditor(new SEPACreditor(array( //this is who you want to send mone
 use Fhp\FinTs;
 
 define('FHP_BANK_URL', '');                # HBCI / FinTS Url can be found here: https://www.hbci-zka.de/institute/institut_auswahl.htm (use the PIN/TAN URL)
-define('FHP_BANK_PORT', 443);              # HBCI / FinTS Port can be found here: https://www.hbci-zka.de/institute/institut_auswahl.htm
 define('FHP_BANK_CODE', '');               # Your bank code / Bankleitzahl
 define('FHP_ONLINE_BANKING_USERNAME', ''); # Your online banking username / alias
 define('FHP_ONLINE_BANKING_PIN', '');      # Your online banking PIN (NOT! the pin of your bank card!)
@@ -58,7 +57,6 @@ define('FHP_SOFTWARE_VERSION', '1.0');     # Your own Software product version
 
 $fints = new FinTs(
     FHP_BANK_URL,
-    FHP_BANK_PORT,
     FHP_BANK_CODE,
     FHP_ONLINE_BANKING_USERNAME,
     FHP_ONLINE_BANKING_PIN,
@@ -85,7 +83,6 @@ print_r($transfer);
 
 $fints = new FinTs(
     FHP_BANK_URL,
-    FHP_BANK_PORT,
     FHP_BANK_CODE,
     FHP_ONLINE_BANKING_USERNAME,
     FHP_ONLINE_BANKING_PIN,
@@ -116,7 +113,6 @@ $unserialized = unserialize($serialized);
 
 $fints = new FinTs(
     FHP_BANK_URL,
-    FHP_BANK_PORT,
     FHP_BANK_CODE,
     FHP_ONLINE_BANKING_USERNAME,
     FHP_ONLINE_BANKING_PIN,

--- a/Samples/variables.php
+++ b/Samples/variables.php
@@ -17,7 +17,6 @@ class testLogger extends Psr\Log\AbstractLogger {
 use Fhp\FinTs;
 
 define('FHP_BANK_URL', '');                 # HBCI / FinTS Url can be found here: https://www.hbci-zka.de/institute/institut_auswahl.htm (use the PIN/TAN URL)
-define('FHP_BANK_PORT', 443);               # HBCI / FinTS Port can be found here: https://www.hbci-zka.de/institute/institut_auswahl.htm
 define('FHP_BANK_CODE', '');                # Your bank code / Bankleitzahl
 define('FHP_ONLINE_BANKING_USERNAME', '');  # Your online banking username / alias
 define('FHP_ONLINE_BANKING_PIN', '');       # Your online banking PIN (NOT! the pin of your bank card!)
@@ -26,7 +25,6 @@ define('FHP_SOFTWARE_VERSION', '1.0');     # Your own Software product version
 
 $fints = new FinTs(
     FHP_BANK_URL,
-    FHP_BANK_PORT,
     FHP_BANK_CODE,
     FHP_ONLINE_BANKING_USERNAME,
     FHP_ONLINE_BANKING_PIN,

--- a/lib/Fhp/Connection.php
+++ b/lib/Fhp/Connection.php
@@ -16,11 +16,6 @@ class Connection
     protected $host;
 
     /**
-     * @var int
-     */
-    protected $port;
-
-    /**
      * @var resource
      */
     protected $curlHandle;
@@ -44,22 +39,15 @@ class Connection
      * Connection constructor.
      *
      * @param string $host
-     * @param int $port
      * @param int $timeoutConnect
      * @param int $timeoutResponse
      * @throws CurlException
      */
-    public function __construct($host, $port, $timeoutConnect = 15, $timeoutResponse = 30)
+    public function __construct($host, $timeoutConnect = 15, $timeoutResponse = 30)
     {
-        if (!is_integer($port) || (int) $port <= 0) 
-            throw new CurlException('Invalid port number');
-
         $this->host = (string) $host;
-        $this->port = (int) $port;
 		$this->timeoutConnect = (int) $timeoutConnect;
 		$this->timeoutResponse = (int) $timeoutResponse;
-		
-        #$this->adapter = new Curl($server, $port, $timeout);
     }
 
     /**

--- a/lib/Fhp/FinTs.php
+++ b/lib/Fhp/FinTs.php
@@ -69,7 +69,6 @@ class FinTs extends FinTsInternal
 	/**
 	 * FinTs constructor.
 	 * @param string $server
-	 * @param int $port
 	 * @param string $bankCode
 	 * @param string $username
 	 * @param string $pin
@@ -79,7 +78,6 @@ class FinTs extends FinTsInternal
 	 */
 	public function __construct(
 		$server,
-		$port,
 		$bankCode,
 		$username,
 		$pin,
@@ -94,7 +92,6 @@ class FinTs extends FinTsInternal
 			throw new Exception ("Product version required!");
 		
 		$this->url = trim($server);
-		$this->port = intval($port);
 		$this->logger = null == $logger ? new NullLogger() : $logger;
 
 		// escaping of bank code not really needed here as it should
@@ -114,8 +111,6 @@ class FinTs extends FinTsInternal
 		if ($productVersion != '') {
 			$this->productVersion = self::escapeString($productVersion);
 		}
-
-		#$this->connection = new Connection($this->server, $this->port, $this->timeoutConnect, $this->timeoutResponse);
 	}
 
 	/**
@@ -306,8 +301,8 @@ class FinTs extends FinTsInternal
 		$this->logger->info('End date  : ' . $to->format('Y-m-d'));
 
 		$dialog = $this->getDialog();
-		#$dialog->syncDialog();
-		#$dialog->initDialog();
+        #$dialog->syncDialog();
+        #$dialog->initDialog();
 
 		$message = $this->createStateOfAccountMessage($dialog, $account, $from, $to, null);
 		$response = $dialog->sendMessage($message, $this->getUsedPinTanMechanism($dialog), $tanCallback, $interval);
@@ -721,7 +716,7 @@ class FinTs extends FinTsInternal
         }
 
         if ($this->connection === null) {
-            $this->connection = new Connection($this->url, $this->port, $this->timeoutConnect, $this->timeoutResponse);
+            $this->connection = new Connection($this->url, $this->timeoutConnect, $this->timeoutResponse);
         }
 
         $dialog = new Dialog(

--- a/lib/Fhp/FinTsInternal.php
+++ b/lib/Fhp/FinTsInternal.php
@@ -25,8 +25,6 @@ use Fhp\Segment\HKCAZ;
 abstract class FinTsInternal
 {
     protected $url;
-    /** @var int */
-    protected $port;
     /** @var  Connection */
     protected $connection = null;
     /** @var int */


### PR DESCRIPTION
This is a breaking change for the FinTs interface (constructor).

The port was not used anywhere, just being passed around. If the need should ever arise in future to customize the port, it should become part of the URL parameter.