### PR TITLE
Support parsing and serialization of binary blocks

### DIFF
--- a/lib/Fhp/Segment/BaseDescriptor.php
+++ b/lib/Fhp/Segment/BaseDescriptor.php
@@ -2,7 +2,7 @@
 
 namespace Fhp\Segment;
 
-use Fhp\Syntax\Delimiter;
+use Fhp\DataTypes\Bin;
 
 /**
  * Class BaseDescriptor
@@ -172,7 +172,9 @@ abstract class BaseDescriptor
         if (ElementDescriptor::isScalarType($typeName)) {
             return $typeName;
         }
-        if (strpos($typeName, '\\') === false) {
+        if ($typeName === 'Bin') {
+            $typeName = Bin::class;
+        } elseif (strpos($typeName, '\\') === false) {
             // Let's assume it's a relative type name, e.g. `X` mentioned in a file that starts with `namespace Fhp\Y`
             // would become `\Fhp\X\Y`.
             $typeName = $contextClass->getNamespaceName() . '\\' . $typeName;
@@ -180,7 +182,7 @@ abstract class BaseDescriptor
         try {
             return new \ReflectionClass($typeName);
         } catch (\ReflectionException $e) {
-            throw new \RuntimeException($e);
+            throw new \RuntimeException("$typeName not found in context of " . $contextClass->getName(), 0, $e);
         }
     }
 }

--- a/lib/Fhp/Segment/SegmentDescriptor.php
+++ b/lib/Fhp/Segment/SegmentDescriptor.php
@@ -51,7 +51,7 @@ class SegmentDescriptor extends BaseDescriptor
             if (preg_match('/^([A-Z]+)v([0-9]+)$/', $clazz->getShortName(), $match) !== 1) {
                 throw new \InvalidArgumentException("Invalid segment class name: $class");
             }
-            $this->kennung = $match[1];
+            $this->kennung = strval($match[1]);
             $this->version = intval($match[2]);
         } catch (\ReflectionException $e) {
             throw new \RuntimeException($e);

--- a/lib/Fhp/Syntax/Delimiter.php
+++ b/lib/Fhp/Syntax/Delimiter.php
@@ -8,4 +8,5 @@ abstract class Delimiter
     const SEGMENT = "'";
     const ELEMENT = "+";
     const GROUP = ":";
+    const BINARY = "@";
 }

--- a/lib/Fhp/Syntax/Parser.php
+++ b/lib/Fhp/Syntax/Parser.php
@@ -3,7 +3,6 @@
 
 namespace Fhp\Syntax;
 
-use Fhp\Syntax\Delimiter;
 use Fhp\Segment\BaseDeg;
 use Fhp\Segment\BaseSegment;
 use Fhp\Segment\DegDescriptor;
@@ -25,7 +24,8 @@ abstract class Parser
 {
     /**
      * The FinTs wire format specifies escaping with a question mark `?` for the syntax characters `+:'?@`. This
-     * function splits strings delimited by one of these while honoring escaping within.
+     * function splits strings delimited by one of these while honoring escaping and binary blocks marked with a
+     * `@<size>@` header within the string.
      *
      * @link: https://www.hbci-zka.de/dokumente/spezifikation_deutsch/fintsv3/FinTS_3.0_Formals_2017-10-06_final_version.pdf
      * Section H.1.3 "Entwertung"
@@ -39,10 +39,46 @@ abstract class Parser
         if (empty($str)) return array();
         // Since most of the $delimiters used in FinTs are also special characters in regexes, we need to escape.
         $delimiter = preg_quote($delimiter, '/');
-        // This regex uses a negated look-behind. Generally, the regex `(?<!foo)x` matches an `x` that is NOT preceded
-        // by `foo`. In this case, we want to match on the split $delimiter when it is not preceded by the escape
-        // character `?`, which we need to escape because it's a special character in regexes.
-        return preg_split("/(?<!\\?)$delimiter/", $str);
+        $nextBegin = 0;
+        $offset = 0;
+        $result = [];
+        while (true) {
+            // Walk to the next syntax character of interest and handle it respectively.
+            $ret = preg_match("/\\?|@([0-9]+)@|$delimiter/", $str, $match, PREG_OFFSET_CAPTURE, $offset);
+            if ($ret === false) {
+                throw new \RuntimeException("preg_match failed on $str");
+            }
+            if ($ret === 0) { // There is no more syntax character behind $offset.
+                $result[] = substr($str, $nextBegin);
+                break;
+            }
+            $matchedStr = $match[0][0]; // $match[0] refers to the entire matched string. [0] has the content
+            $matchedOffset = $match[0][1]; // and [1] has the offset within $str.
+            if ($matchedStr === '?') {
+                // It's an escape character, so we should ignore this character and the next one.
+                $offset = $matchedOffset + 2;
+                if ($offset > strlen($str)) {
+                    throw new \InvalidArgumentException("Input ends on unescaped escape character.");
+                }
+            } elseif ($matchedStr[0] === '@') {
+                // It's a block binary data, which we should skip entirely.
+                $binaryLength = $match[1][0]; // $match[1] refers to the first (and only) capture group in the regex.
+                if (!is_numeric($binaryLength)) throw new \AssertionError();
+                // Note: The FinTS specification says that the length of the binary block is given in bytes (not
+                // characters) and PHP's string functions like substr() or preg_match() also operate on byte offsets, so
+                // this is fine.
+                $offset = $matchedOffset + strlen($matchedStr) + intval($match[1][0]);
+                if ($offset > strlen($str)) {
+                    throw new \InvalidArgumentException("Incomplete binary block at offset $matchedOffset");
+                }
+            } else {
+                // The delimiter was matched, so output one splitted string and advance past the delimiter.
+                $result[] = substr($str, $nextBegin, $matchedOffset - $nextBegin);
+                $nextBegin = $matchedOffset + strlen($matchedStr);
+                $offset = $nextBegin;
+            }
+        }
+        return $result;
     }
 
     /**

--- a/lib/Fhp/Syntax/Serializer.php
+++ b/lib/Fhp/Syntax/Serializer.php
@@ -2,6 +2,7 @@
 
 namespace Fhp\Syntax;
 
+use Fhp\DataTypes\Bin;
 use Fhp\Segment\BaseDeg;
 use Fhp\Segment\BaseSegment;
 
@@ -95,9 +96,21 @@ abstract class Serializer
         return $serializedElements;
     }
 
+    /**
+     * @param mixed $value The value to be serialized.
+     * @param string|\ReflectionClass $type The type of the value.
+     * @return string The serialized value.
+     */
     private static function serializeElement($value, $type)
     {
-        return is_string($type) ? static::serializeDataElement($value, $type) : static::serializeDeg($value);
+        if (is_string($type)) {
+            return static::serializeDataElement($value, $type);
+        } elseif ($type->getName() === Bin::class) {
+            /** @var Bin $value */
+            return $value->toString();
+        } else {
+            return static::serializeDeg($value);
+        }
     }
 
     /**

--- a/lib/Tests/Fhp/Syntax/ParserTest.php
+++ b/lib/Tests/Fhp/Syntax/ParserTest.php
@@ -29,6 +29,25 @@ class ParserTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array('', '', '?+C'), Parser::splitEscapedString('+', '++?+C'));
     }
 
+    public function test_splitEscapedString_with_binaryBlock()
+    {
+        $this->assertEquals(array('A@4@xxxxD', 'EF'), Parser::splitEscapedString('+', 'A@4@xxxxD+EF'));
+        $this->assertEquals(array('A@4@++++D', 'EF'), Parser::splitEscapedString('+', 'A@4@++++D+EF'));
+        $this->assertEquals(array('A', '@1@x@0D', 'EF'), Parser::splitEscapedString('+', 'A+@1@x@0D+EF'));
+        $this->assertEquals(array('@4@xxxxD', 'EF'), Parser::splitEscapedString('+', '@4@xxxxD+EF'));
+        $this->assertEquals(array('A@4@xxxx', 'EF'), Parser::splitEscapedString('+', 'A@4@xxxx+EF'));
+        $this->assertEquals(array('@4@xxxx'), Parser::splitEscapedString('+', '@4@xxxx'));
+        $this->assertEquals(array('@4@++++'), Parser::splitEscapedString('+', '@4@++++'));
+    }
+
+    public function test_splitEscapedString_with_escaping_and_binaryBlock()
+    {
+        $this->assertEquals(array('A@4@xxxxD', '?+'), Parser::splitEscapedString('+', 'A@4@xxxxD+?+'));
+        $this->assertEquals(array('A@4@xxxx?+', 'EF'), Parser::splitEscapedString('+', 'A@4@xxxx?++EF'));
+        $this->assertEquals(array('?+@4@+xxxD', '?+'), Parser::splitEscapedString('+', '?+@4@+xxxD+?+'));
+        $this->assertEquals(array('?+@4@xxx+D', '?+'), Parser::splitEscapedString('+', '?+@4@xxx+D+?+'));
+    }
+
     public function test_unescape()
     {
         $this->assertEquals('ABC+DEF', Parser::unescape('ABC+DEF'));


### PR DESCRIPTION
This PR integrates the existing `Bin` type into the new `Parser`, and teaches the `splitEscapedString()` function to skip past nested syntax characters.

(Previously, the library used a [hack](https://github.com/nemiah/phpFinTS/blob/415847715b48d92810e1c486456605f78615455e/lib/Fhp/Response/Response.php#L426) to parse the binary field inside `HNVSD`, which relies on the fact that the binary field is the last field inside that segment, so that there will be two subsequent segment terminators `'`. This would not work with encryption, however.)