### PR TITLE
Make Connection independent of AbstractMessage

### DIFF
--- a/lib/Fhp/Connection.php
+++ b/lib/Fhp/Connection.php
@@ -72,7 +72,7 @@ class Connection
         curl_setopt($this->curlHandle, CURLOPT_SSLVERSION, 1);
         curl_setopt($this->curlHandle, CURLOPT_SSL_VERIFYPEER, true);
         curl_setopt($this->curlHandle, CURLOPT_SSL_VERIFYHOST, 2);
-        curl_setopt($this->curlHandle, CURLOPT_USERAGENT, "FHP-lib");
+        curl_setopt($this->curlHandle, CURLOPT_USERAGENT, "phpFinTS");
         curl_setopt($this->curlHandle, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($this->curlHandle, CURLOPT_URL, $this->host);
         curl_setopt($this->curlHandle, CURLOPT_CONNECTTIMEOUT, $this->timeoutConnect);

--- a/lib/Fhp/Connection.php
+++ b/lib/Fhp/Connection.php
@@ -21,11 +21,6 @@ class Connection
     protected $curlHandle;
 
     /**
-     * @var mixed
-     */
-    protected $lastResponseInfo;
-	
-    /**
      * @var int
      */
 	protected $timeoutConnect = 15;
@@ -41,13 +36,12 @@ class Connection
      * @param string $host
      * @param int $timeoutConnect
      * @param int $timeoutResponse
-     * @throws CurlException
      */
     public function __construct($host, $timeoutConnect = 15, $timeoutResponse = 30)
     {
-        $this->host = (string) $host;
-		$this->timeoutConnect = (int) $timeoutConnect;
-		$this->timeoutResponse = (int) $timeoutResponse;
+        $this->host = $host;
+        $this->timeoutConnect = $timeoutConnect;
+        $this->timeoutResponse = $timeoutResponse;
     }
 
     /**
@@ -61,10 +55,6 @@ class Connection
     {
         return $this->sendCurl($message);
     }
-	
-	public function getCurlHandle(){
-		return $this->curlHandle;
-	}
 	
 	private function connect(){
         $this->curlHandle = curl_init();
@@ -96,32 +86,22 @@ class Connection
 		
         curl_setopt($this->curlHandle, CURLOPT_POSTFIELDS, base64_encode($message->toString()));
         $response = curl_exec($this->curlHandle);
-        $this->lastResponseInfo = curl_getinfo($this->curlHandle);
 
         if (false === $response) {
             throw new CurlException(
                 'Failed connection to ' . $this->host . ': ' . curl_error($this->curlHandle),
                 curl_errno($this->curlHandle),
                 null,
-                $this->lastResponseInfo
+                curl_getinfo($this->curlHandle)
             );
         }
 
         $statusCode = curl_getinfo($this->curlHandle, CURLINFO_HTTP_CODE);
-
         if ($statusCode < 200 || $statusCode > 299) {
-            throw new CurlException('Bad response with status code ' . $statusCode, 0, null, $this->lastResponseInfo);
+            throw new CurlException('Bad response with status code ' . $statusCode, 0, null,
+                curl_getinfo($this->curlHandle));
         }
 
         return base64_decode($response);
-    }
-
-    /**
-     * Gets curl info for last request / response.
-     *
-     * @return mixed
-     */
-    public function getLastResponseInfo() {
-        return $this->lastResponseInfo;
     }
 }

--- a/lib/Fhp/CurlException.php
+++ b/lib/Fhp/CurlException.php
@@ -9,7 +9,7 @@ namespace Fhp;
 class CurlException extends \Exception
 {
     /**
-     * @var mixed
+     * @var array
      */
     protected $curlInfo;
 
@@ -21,17 +21,16 @@ class CurlException extends \Exception
      * @param \Exception|null $previous
      * @param mixed $curlInfo
      */
-    public function __construct($message, $code = 0, \Exception $previous = null, $curlInfo = "")
+    public function __construct($message, $code = 0, \Exception $previous = null, $curlInfo = [])
     {
         parent::__construct($message, $code, $previous);
-
         $this->curlInfo = $curlInfo;
     }
 
     /**
      * Gets the curl info from request / response.
      *
-     * @return mixed
+     * @return array
      */
     public function getCurlInfo()
     {

--- a/lib/Fhp/Dialog/Dialog.php
+++ b/lib/Fhp/Dialog/Dialog.php
@@ -144,7 +144,7 @@ class Dialog
 			$message->setMessageNumber($this->messageNumber);
 			$message->setDialogId($this->dialogId);
 
-			$result = $this->connection->send($message);
+            $result = $this->connection->send($message->toString());
 			$this->messageNumber++;
 
 			$this->logger->debug('< '.$result);


### PR DESCRIPTION
Instead of accepting the request data as an AbstractMessage and returning the response as a string, Connection now handles both as raw strings. Besides being a cleaner abstraction layer, this also allows sending messages that do not inherit from AbstractMessage.

Also, change library name in `User-Agent` header to `"phpFinTS"` and clean up some unused code around those files.