### PR TITLE
Use default SSL version

### DIFF
--- a/lib/Fhp/Connection.php
+++ b/lib/Fhp/Connection.php
@@ -84,7 +84,6 @@ class Connection
 	private function connect(){
         $this->curlHandle = curl_init();
 
-        curl_setopt($this->curlHandle, CURLOPT_SSLVERSION, 1);
         curl_setopt($this->curlHandle, CURLOPT_SSL_VERIFYPEER, true);
         curl_setopt($this->curlHandle, CURLOPT_SSL_VERIFYHOST, 2);
         curl_setopt($this->curlHandle, CURLOPT_USERAGENT, "FHP-lib");


### PR DESCRIPTION
Max. SSL-Version should not be set to TLSv1.0.
Omitting the setting, curl will negotiate a suitable version.
This solves issue #75