### PR TITLE
Include segment/DEG fields from super classes, add BaseGeschaeftsvorfallparameter

### DIFF
--- a/lib/Fhp/Segment/BaseGeschaeftsvorfallparameter.php
+++ b/lib/Fhp/Segment/BaseGeschaeftsvorfallparameter.php
@@ -1,0 +1,40 @@
+<?php /** @noinspection PhpUnused */
+
+
+namespace Fhp\Segment;
+
+/**
+ * Class BaseGeschaeftsvorfallparameter
+ *
+ * This is a base format for segments with various names, each of which describes a potential business transaction that
+ * the bank supports. The presence of the {@link BaseGeschaeftsvorfallparameter} instance in the BPD indicates that the
+ * type of transaction is supported, and depending on the particular transaction, it may contain further parameters,
+ * which are implemented in sub-classes of {@link BaseGeschaeftsvorfallparameter}. Note that the segment version of this
+ * segment matches the version of the potential request segment that we could send to the server.
+ *
+ * @link https://www.hbci-zka.de/dokumente/spezifikation_deutsch/fintsv3/FinTS_3.0_Formals_2017-10-06_final_version.pdf
+ * Section: D.6
+ *
+ * @package Fhp\Segment
+ */
+class BaseGeschaeftsvorfallparameter extends BaseSegment
+{
+    /**
+     * Maximum number of request segments of this kind that can be included in a single request message
+     * @var integer
+     */
+    public $maximaleAnzahlAuftraege;
+    /**
+     * Minimum number of signatures required for this kind of business transaction. Note that zero signatures is
+     * equivalent to an anonymous connection and one signature (the most common case) can be satisfied with PIN/TAN.
+     * @var integer
+     */
+    public $anzahlSignaturenMindestens;
+    /**
+     * Minimum cryptographic security required for this transaction type, where 0 means none.
+     * @var integer
+     */
+    public $sicherheitsklasse;
+
+    // NOTE: Parameters specific to the respective transaction type follow here and are implemented in sub-classes.
+}

--- a/lib/Fhp/Segment/HITANS/HITANSv1.php
+++ b/lib/Fhp/Segment/HITANS/HITANSv1.php
@@ -2,11 +2,12 @@
 
 namespace Fhp\Segment\HITANS;
 
-use Fhp\Segment\BaseSegment;
+use Fhp\Segment\BaseGeschaeftsvorfallparameter;
 
 /**
  * Class HITANSv1
  * Segment: Zwei-Schritt-TAN-Einreichung, Parameter (Version 1)
+ * Parameters for: HKTANv1
  * Bezugssegment: HKVVB
  * Sender: Kreditinstitut
  *
@@ -14,14 +15,8 @@ use Fhp\Segment\BaseSegment;
  *
  * @package Fhp\Segment\HITANS
  */
-class HITANSv1 extends BaseSegment implements HITANS
+class HITANSv1 extends BaseGeschaeftsvorfallparameter implements HITANS
 {
-    /** @var integer */
-    public $maximaleAnzahlAuftraege;
-    /** @var integer Allowed values: 0, 1, 2, 3 */
-    public $anzahlSignaturenMindestens;
-    /** @var integer Allowed values: 0, 1, 2, 3, 4 */
-    public $sicherheitsklasse;
     /** @var ParameterZweiSchrittTanEinreichungV1 */
     public $parameterZweiSchrittTanEinreichung;
 

--- a/lib/Fhp/Segment/HITANS/HITANSv2.php
+++ b/lib/Fhp/Segment/HITANS/HITANSv2.php
@@ -2,11 +2,12 @@
 
 namespace Fhp\Segment\HITANS;
 
-use Fhp\Segment\BaseSegment;
+use Fhp\Segment\BaseGeschaeftsvorfallparameter;
 
 /**
  * Class HITANSv2
  * Segment: Zwei-Schritt-TAN-Einreichung, Parameter (Version 2)
+ * Parameters for: HKTANv2
  * Bezugssegment: HKVVB
  * Sender: Kreditinstitut
  *
@@ -14,14 +15,8 @@ use Fhp\Segment\BaseSegment;
  *
  * @package Fhp\Segment\HITANS
  */
-class HITANSv2 extends BaseSegment implements HITANS
+class HITANSv2 extends BaseGeschaeftsvorfallparameter implements HITANS
 {
-    /** @var integer */
-    public $maximaleAnzahlAuftraege;
-    /** @var integer Allowed values: 0, 1, 2, 3 */
-    public $anzahlSignaturenMindestens;
-    /** @var integer Allowed values: 0, 1, 2, 3, 4 */
-    public $sicherheitsklasse;
     /** @var ParameterZweiSchrittTanEinreichungV2 */
     public $parameterZweiSchrittTanEinreichung;
 

--- a/lib/Fhp/Segment/HITANS/HITANSv3.php
+++ b/lib/Fhp/Segment/HITANS/HITANSv3.php
@@ -2,11 +2,12 @@
 
 namespace Fhp\Segment\HITANS;
 
-use Fhp\Segment\BaseSegment;
+use Fhp\Segment\BaseGeschaeftsvorfallparameter;
 
 /**
  * Class HITANSv3
  * Segment: Zwei-Schritt-TAN-Einreichung, Parameter (Version 3)
+ * Parameters for: HKTANv3
  * Bezugssegment: HKVVB
  * Sender: Kreditinstitut
  *
@@ -14,14 +15,8 @@ use Fhp\Segment\BaseSegment;
  *
  * @package Fhp\Segment\HITANS
  */
-class HITANSv3 extends BaseSegment implements HITANS
+class HITANSv3 extends BaseGeschaeftsvorfallparameter implements HITANS
 {
-    /** @var integer */
-    public $maximaleAnzahlAuftraege;
-    /** @var integer Allowed values: 0, 1, 2, 3 */
-    public $anzahlSignaturenMindestens;
-    /** @var integer Allowed values: 0, 1, 2, 3, 4 */
-    public $sicherheitsklasse;
     /** @var ParameterZweiSchrittTanEinreichungV3 */
     public $parameterZweiSchrittTanEinreichung;
 

--- a/lib/Fhp/Segment/HITANS/HITANSv4.php
+++ b/lib/Fhp/Segment/HITANS/HITANSv4.php
@@ -2,11 +2,12 @@
 
 namespace Fhp\Segment\HITANS;
 
-use Fhp\Segment\BaseSegment;
+use Fhp\Segment\BaseGeschaeftsvorfallparameter;
 
 /**
  * Class HITANSv4
  * Segment: Zwei-Schritt-TAN-Einreichung, Parameter (Version 4)
+ * Parameters for: HKTANv4
  * Bezugssegment: HKVVB
  * Sender: Kreditinstitut
  *
@@ -14,14 +15,8 @@ use Fhp\Segment\BaseSegment;
  *
  * @package Fhp\Segment\HITANS
  */
-class HITANSv4 extends BaseSegment implements HITANS
+class HITANSv4 extends BaseGeschaeftsvorfallparameter implements HITANS
 {
-    /** @var integer */
-    public $maximaleAnzahlAuftraege;
-    /** @var integer Allowed values: 0, 1, 2, 3 */
-    public $anzahlSignaturenMindestens;
-    /** @var integer Allowed values: 0, 1, 2, 3, 4 */
-    public $sicherheitsklasse;
     /** @var ParameterZweiSchrittTanEinreichungV4 */
     public $parameterZweiSchrittTanEinreichung;
 

--- a/lib/Fhp/Segment/HITANS/HITANSv5.php
+++ b/lib/Fhp/Segment/HITANS/HITANSv5.php
@@ -2,11 +2,12 @@
 
 namespace Fhp\Segment\HITANS;
 
-use Fhp\Segment\BaseSegment;
+use Fhp\Segment\BaseGeschaeftsvorfallparameter;
 
 /**
  * Class HITANSv5
  * Segment: Zwei-Schritt-TAN-Einreichung, Parameter (Version 5)
+ * Parameters for: HKTANv5
  * Bezugssegment: HKVVB
  * Sender: Kreditinstitut
  *
@@ -14,14 +15,8 @@ use Fhp\Segment\BaseSegment;
  *
  * @package Fhp\Segment\HITANS
  */
-class HITANSv5 extends BaseSegment implements HITANS
+class HITANSv5 extends BaseGeschaeftsvorfallparameter implements HITANS
 {
-    /** @var integer */
-    public $maximaleAnzahlAuftraege;
-    /** @var integer Allowed values: 0, 1, 2, 3 */
-    public $anzahlSignaturenMindestens;
-    /** @var integer Allowed values: 0, 1, 2, 3, 4 */
-    public $sicherheitsklasse;
     /** @var ParameterZweiSchrittTanEinreichungV5 */
     public $parameterZweiSchrittTanEinreichung;
 

--- a/lib/Fhp/Segment/HITANS/HITANSv6.php
+++ b/lib/Fhp/Segment/HITANS/HITANSv6.php
@@ -2,11 +2,12 @@
 
 namespace Fhp\Segment\HITANS;
 
-use Fhp\Segment\BaseSegment;
+use Fhp\Segment\BaseGeschaeftsvorfallparameter;
 
 /**
  * Class HITANSv6
  * Segment: Zwei-Schritt-TAN-Einreichung, Parameter (Version 6)
+ * Parameters for: HKTANv6
  * Bezugssegment: HKVVB
  * Sender: Kreditinstitut
  *
@@ -14,14 +15,8 @@ use Fhp\Segment\BaseSegment;
  *
  * @package Fhp\Segment\HITANS
  */
-class HITANSv6 extends BaseSegment implements HITANS
+class HITANSv6 extends BaseGeschaeftsvorfallparameter implements HITANS
 {
-    /** @var integer */
-    public $maximaleAnzahlAuftraege;
-    /** @var integer Allowed values: 0, 1, 2, 3 */
-    public $anzahlSignaturenMindestens;
-    /** @var integer Allowed values: 0, 1, 2, 3, 4 */
-    public $sicherheitsklasse;
     /** @var ParameterZweiSchrittTanEinreichungV6 */
     public $parameterZweiSchrittTanEinreichung;
 

--- a/lib/Fhp/Segment/SegmentDescriptor.php
+++ b/lib/Fhp/Segment/SegmentDescriptor.php
@@ -67,7 +67,5 @@ class SegmentDescriptor extends BaseDescriptor
         if ($obj->getName() !== $this->kennung) {
             throw new \InvalidArgumentException("Expected $this->kennung, got " . $obj->getName());
         }
-        DegDescriptor::get(Segmentkopf::class)->validateObject($obj->segmentkopf);
-
     }
 }

--- a/lib/Fhp/Syntax/Parser.php
+++ b/lib/Fhp/Syntax/Parser.php
@@ -254,25 +254,15 @@ abstract class Parser
     public static function parseSegment($rawSegment, $type)
     {
         $rawElements = static::splitIntoSegmentElements($rawSegment);
-        /** @var Segmentkopf $segmentkopf */
-        $segmentkopf = static::parseDeg($rawElements[0], Segmentkopf::class);
         $descriptor = SegmentDescriptor::get($type);
-        if ($segmentkopf->segmentkennung !== $descriptor->kennung) {
-            throw new \InvalidArgumentException("Invalid segment type $segmentkopf->segmentkennung for $type");
-        }
-        if ($segmentkopf->segmentversion !== $descriptor->version) {
-            throw new \InvalidArgumentException("Invalid version $segmentkopf->segmentversion for $type");
-        }
-
         $result = new $type();
-        $result->segmentkopf = $segmentkopf;
         // The iteration order guarantees that $index is strictly monotonically increasing, but there can be gaps.
         foreach ($descriptor->elements as $index => $elementDescriptor) {
             if (!isset($rawElements[$index]) || $rawElements[$index] === '') {
                 if ($elementDescriptor->optional) {
                     continue;
                 }
-                throw new \InvalidArgumentException("Missing field $elementDescriptor->field");
+                throw new \InvalidArgumentException("Missing field $type.$elementDescriptor->field");
             }
 
             if ($elementDescriptor->repeated === 0) {
@@ -289,6 +279,12 @@ abstract class Parser
                     }
                 }
             }
+        }
+        if ($result->segmentkopf->segmentkennung !== $descriptor->kennung) {
+            throw new \InvalidArgumentException("Invalid segment type $result->segmentkopf->segmentkennung for $type");
+        }
+        if ($result->segmentkopf->segmentversion !== $descriptor->version) {
+            throw new \InvalidArgumentException("Invalid version $result->segmentkopf->segmentversion for $type");
         }
         return $result;
     }

--- a/lib/Fhp/Syntax/Serializer.php
+++ b/lib/Fhp/Syntax/Serializer.php
@@ -69,8 +69,6 @@ abstract class Serializer
     public static function serializeSegment($segment)
     {
         $serializedElements = static::serializeElements($segment);
-        if (isset($serializedElements[0]) && $serializedElements[0] !== '') throw new \AssertionError();
-        $serializedElements[0] = $segment->segmentkopf->serialize();
         return implode(Delimiter::ELEMENT, $serializedElements) . Delimiter::SEGMENT;
     }
 
@@ -85,7 +83,7 @@ abstract class Serializer
         foreach ($obj->getDescriptor()->elements as $index => $elementDescriptor) {
             $value = $obj->{$elementDescriptor->field};
             if ($value === null) continue;
-            if (isset($serializedElements[$index])) throw new \AssertionError();
+            if (isset($serializedElements[$index])) throw new \AssertionError("Duplicate index $index");
             if ($elementDescriptor->repeated === 0) {
                 $serializedElements[$index] = static::serializeElement($value, $elementDescriptor->type);
             } else {

--- a/lib/Tests/Fhp/Segment/HITANSTest.php
+++ b/lib/Tests/Fhp/Segment/HITANSTest.php
@@ -115,4 +115,18 @@ class HITANSTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(HITANSv6::parse(static::REAL_DKB_RESPONSE[2]),
             BaseSegment::parse(static::REAL_DKB_RESPONSE[2]));
     }
+
+    public function test_validate_invalid_segmentkopf()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches("@Invalid int: LALA@");
+        HITANSv1::parse("HITANS:LALA:1:4+1+1+1+J:N:0:0:920:2:smsTAN:smsTAN:6:1:TAN-Nummer:3:1:J:J'");
+    }
+
+    public function test_validate_invalid_deg()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches("@Invalid bool: LALA@");
+        HITANSv1::parse("HITANS:165:1:4+1+1+1+J:N:0:0:920:2:smsTAN:smsTAN:6:1:TAN-Nummer:3:1:LALA:J'");
+    }
 }


### PR DESCRIPTION
This allows us to stop treating BaseSegment.segmentkopf as a special case in parsing/serialization.

Add a common BaseGeschaeftsvorfallparameter sub-class for the HIxyzS segments, which all have the same fields/structure but different segment identifiers.