### PR TITLE
Add support for anonymous segments

### DIFF
--- a/lib/Fhp/Segment/AnonymousSegment.php
+++ b/lib/Fhp/Segment/AnonymousSegment.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Fhp\Segment;
+
+/**
+ * Class AnonymousSegment
+ *
+ * A fallback for segments that were received from the server but are not implemented in this library.
+ *
+ * @package Fhp\Segment
+ */
+final class AnonymousSegment extends BaseSegment
+{
+    /**
+     * The type plus version of the segment, i.e. the class name of the class that would normally implement it.
+     * This is redundant with super::$segmentkopf, but it's useful to repeat here so that it shows up in a debugger.
+     * @var string
+     */
+    public $type;
+
+    /**
+     * Contains the data elements of the segment. Some of them can be scalar values (represented as strings), and others
+     * can be nested data element groups of strings.
+     *
+     * NOTE: This field is intentionally private and does not have a getter. Reading this field anywhere besides for
+     * debugging purposes (e.g. in an interactive debugger or with print_r()) is wrong, please create a concrete
+     * subclass of BaseSegment instead.
+     *
+     * @var string[]|string[][]
+     */
+    private $elements = [];
+
+    /**
+     * @param Segmentkopf $segmentkopf
+     * @param string[]|string[][] $elements
+     */
+    public function __construct($segmentkopf, $elements)
+    {
+        $this->segmentkopf = $segmentkopf;
+        $this->type = $segmentkopf->segmentkennung . 'v' . $segmentkopf->segmentversion;
+        $this->elements = $elements;
+    }
+
+    public function getDescriptor()
+    {
+        throw new \RuntimeException("AnonymousSegments do not have a descriptor");
+    }
+
+    public function validate()
+    {
+        // Do nothing, anonymous segments are always valid.
+    }
+
+    /**
+     * Just to override the super factory.
+     */
+    public static function createEmpty()
+    {
+        // Note: createEmpty() normally runs the constructor and then fills the Segmentkopf, but that is not possible
+        // for AnonymousSegment. Callers should just call the constructor itself.
+        throw new \RuntimeException("AnonymousSegment::createEmpty() is not allowed");
+    }
+}

--- a/lib/Fhp/Syntax/Parser.php
+++ b/lib/Fhp/Syntax/Parser.php
@@ -4,6 +4,7 @@
 namespace Fhp\Syntax;
 
 use Fhp\DataTypes\Bin;
+use Fhp\Segment\AnonymousSegment;
 use Fhp\Segment\BaseDeg;
 use Fhp\Segment\BaseSegment;
 use Fhp\Segment\DegDescriptor;
@@ -23,6 +24,9 @@ use Fhp\Segment\Segmentkopf;
  */
 abstract class Parser
 {
+    /** @var string Name of the PHP namespace under which all the segments are stored. */
+    const SEGMENT_NAMESPACE = 'Fhp\Segment';
+
     /**
      * The FinTs wire format specifies escaping with a question mark `?` for the syntax characters `+:'?@`. This
      * function splits strings delimited by one of these while honoring escaping and binary blocks marked with a
@@ -272,7 +276,7 @@ abstract class Parser
                 if ($elementDescriptor->optional) {
                     continue;
                 }
-                throw new \InvalidArgumentException("Missing field $elementDescriptor->field");
+                throw new \InvalidArgumentException("Missing field $type.$elementDescriptor->field");
             }
 
             if ($elementDescriptor->repeated === 0) {
@@ -291,6 +295,24 @@ abstract class Parser
             }
         }
         return $result;
+    }
+
+    /**
+     * @param string $rawSegment The serialized wire format for a single segment (segment delimiter must be present at
+     *     the end).
+     * @return AnonymousSegment The segment parsed as an anonymous segment.
+     */
+    public static function parseAnonymousSegment($rawSegment)
+    {
+        $rawElements = static::splitIntoSegmentElements($rawSegment);
+        return new AnonymousSegment(
+            Segmentkopf::parse(array_shift($rawElements)),
+            array_map(function ($rawElement) {
+                if (empty($rawElement)) return null;
+                $subElements = static::splitEscapedString(Delimiter::GROUP, $rawElement);
+                if (count($subElements) <= 1) return $rawElement; // Asume it's not repeated.
+                return $subElements;
+            }, $rawElements));
     }
 
     /**
@@ -325,5 +347,26 @@ abstract class Parser
         } else {
             return static::parseDeg($rawElement, $descriptor->type->name);
         }
+    }
+
+    /**
+     * @param string $rawSegment The serialized wire format for a single segment (segment delimiter must be present at
+     *     the end).
+     * @return BaseSegment The parsed segment, possibly an {@link AnonymousSegment}.
+     */
+    public static function detectAndParseSegment($rawSegment)
+    {
+        $firstElementDelimiter = strpos($rawSegment, Delimiter::ELEMENT);
+        if ($firstElementDelimiter === false) {
+            throw new \InvalidArgumentException("Invalid segment $rawSegment");
+        }
+        /** @var Segmentkopf $segmentkopf */
+        $segmentkopf = Segmentkopf::parse(substr($rawSegment, 0, $firstElementDelimiter));
+        $segmentType = static::SEGMENT_NAMESPACE . '\\' . $segmentkopf->segmentkennung . '\\'
+            . $segmentkopf->segmentkennung . 'v' . $segmentkopf->segmentversion;
+        if (class_exists($segmentType)) {
+            return static::parseSegment($rawSegment, $segmentType);
+        }
+        return static::parseAnonymousSegment($rawSegment);
     }
 }

--- a/lib/Fhp/Syntax/Serializer.php
+++ b/lib/Fhp/Syntax/Serializer.php
@@ -3,6 +3,7 @@
 namespace Fhp\Syntax;
 
 use Fhp\DataTypes\Bin;
+use Fhp\Segment\AnonymousSegment;
 use Fhp\Segment\BaseDeg;
 use Fhp\Segment\BaseSegment;
 
@@ -68,6 +69,9 @@ abstract class Serializer
      */
     public static function serializeSegment($segment)
     {
+        if ($segment instanceof AnonymousSegment) {
+            throw new \InvalidArgumentException("Cannot serialize anonymous segments");
+        }
         $serializedElements = static::serializeElements($segment);
         if (isset($serializedElements[0]) && $serializedElements[0] !== '') throw new \AssertionError();
         $serializedElements[0] = $segment->segmentkopf->serialize();

--- a/lib/Tests/Fhp/Segment/AnonymousSegmentTest.php
+++ b/lib/Tests/Fhp/Segment/AnonymousSegmentTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Tests\Fhp\Segment;
+
+
+use Fhp\Segment\AnonymousSegment;
+use Fhp\Syntax\Parser;
+
+class AnonymousSegmentTest extends \PHPUnit\Framework\TestCase
+{
+    const RAW_SEGMENT = "HNXXX:4:3+A++C:D:E+F+'";
+
+    private static function getElements($segment)
+    {
+        try {
+            $class = new \ReflectionClass(AnonymousSegment::class);
+            $property = $class->getProperty('elements');
+            $property->setAccessible(true);
+            return $property->getValue($segment);
+        } catch (\ReflectionException $e) {
+            throw new \RuntimeException($e);
+        }
+    }
+
+
+    public function test_parse()
+    {
+        $segment = Parser::parseAnonymousSegment(static::RAW_SEGMENT);
+        $this->assertEquals('HNXXX', $segment->getName());
+        $this->assertEquals('HNXXXv3', $segment->type);
+        $this->assertEquals(3, $segment->segmentkopf->segmentversion);
+        $this->assertEquals(['A', null, ['C', 'D', 'E'], 'F', null], static::getElements($segment));
+
+        $segment2 = Parser::detectAndParseSegment(static::RAW_SEGMENT);
+        $this->assertEquals($segment, $segment2);
+    }
+
+    public function test_parse_empty()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        Parser::parseAnonymousSegment('');
+    }
+
+    public function test_cannot_serialize()
+    {
+        $segment = Parser::parseAnonymousSegment(static::RAW_SEGMENT);
+        $this->expectException(\InvalidArgumentException::class);
+        $segment->serialize();
+    }
+}


### PR DESCRIPTION
Bank servers send segments in their responses that are not implemented in this library, and that do not need to be implemented either. In order for the parsing to succeed, unknown segments cannot be rejected. Instead of silently dropping them, this commit adds an AnonymousSegment class that holds their contents, which can be useful for debugging. 

Move the logic that detects the segment type from BaseSegment::parse() into the Parser where it belongs. Add a new AnonymousSegment class, which is returned from the Parser in case the parsed segment type is not explicitly implemented.