### PR TITLE
Implement Model\TanMode interface

### DIFF
--- a/lib/Fhp/Model/TanMode.php
+++ b/lib/Fhp/Model/TanMode.php
@@ -1,0 +1,70 @@
+<?php /** @noinspection PhpUnused */
+
+namespace Fhp\Model;
+
+/**
+ * Interface TanMode
+ *
+ * For two-step authentication, users need to enter a TAN, which can be obtained in various ways (SMS, TAN generator
+ * device, and so on). Users regularly have multiple ways to obtain a TAN even for a single bank, so they will need to
+ * choose how they want to receive/generate the TAN. Each {@link TanMode} describes one of these options.
+ *
+ * @package Fhp\Model
+ */
+interface TanMode
+{
+    /**
+     * The dummy ID for the single-step TAN mode.
+     */
+    const SINGLE_STEP_ID = 999;
+
+    /**
+     * Only digits are allowed, i.e. [0-9]+
+     */
+    const FORMAT_NUMERICAL = 1;
+    /**
+     * Digits and characters are allowed, i.e. any ISO 8859 characters (incl. [äöüß]) but not \r or \n.
+     */
+    const FORMAT_ALPHANUMERICAL = 2;
+
+    /**
+     * @return integer The ID of this TanMode. This is what the application needs to persist when it wants to remember
+     *     the users decision for future transactions.
+     */
+    public function getId();
+
+    /**
+     * @return string A user-readable name, e.g. for display in a list.
+     */
+    public function getName();
+
+    /**
+     * @return string A user-readable label for the text field that displays the challenge to the user.
+     */
+    public function getChallengeLabel();
+
+    /**
+     * @return integer The maximum length of the challenge. The application can use this to appropriately resize the
+     *     text field that displays the challenge to the user.
+     */
+    public function getMaxChallengeLength();
+
+    /**
+     * @return integer The maximum length of TANs entered in this mode. The application can use this to restrict the TAN
+     *     input field or to do client-side validation.
+     */
+    public function getMaxTanLength();
+
+    /**
+     * @return integer The allowed TAN format. See the FORMAT_* constants above. The application can use this to
+     *     restrict the TAN input field or to do client-side validation.
+     */
+    public function getTanFormat();
+
+    /**
+     * @return boolean If true, there are potentially multiple TAN devices (e.g. multiple mobile phones) associated with
+     *     this TanMode (e.g. if it's the smsTAN mode), and the user needs to pick the device *in addition to* and after
+     *     picking this TanMode.
+     */
+    public function needsTanDevice();
+}

--- a/lib/Fhp/Response/GetVariables.php
+++ b/lib/Fhp/Response/GetVariables.php
@@ -45,8 +45,8 @@ class GetVariables extends Response
                 throw new \InvalidArgumentException("All HITANS segments must implement the HITANS interface");
             }
             foreach ($hitans->getParameterZweiSchrittTanEinreichung()->getVerfahrensparameterZweiSchrittVerfahren() as $verfahren) {
-                if ($allowedModes === null || in_array($verfahren->getSicherheitsfunktion(), $allowedModes)) {
-                    $result[$verfahren->getSicherheitsfunktion()] = $verfahren->getNameDesZweiSchrittVerfahrens();
+                if ($allowedModes === null || in_array($verfahren->getId(), $allowedModes)) {
+                    $result[$verfahren->getId()] = $verfahren->getName();
                 }
             }
         }

--- a/lib/Fhp/Segment/HITANS/VerfahrensparameterZweiSchrittVerfahren.php
+++ b/lib/Fhp/Segment/HITANS/VerfahrensparameterZweiSchrittVerfahren.php
@@ -2,11 +2,13 @@
 
 namespace Fhp\Segment\HITANS;
 
-interface VerfahrensparameterZweiSchrittVerfahren
+use Fhp\Model\TanMode;
+
+interface VerfahrensparameterZweiSchrittVerfahren extends TanMode
 {
     /** @return integer */
-    public function getSicherheitsfunktion();
+    public function getId();
 
     /** @return string */
-    public function getNameDesZweiSchrittVerfahrens();
+    public function getName();
 }

--- a/lib/Fhp/Segment/HITANS/VerfahrensparameterZweiSchrittVerfahren.php
+++ b/lib/Fhp/Segment/HITANS/VerfahrensparameterZweiSchrittVerfahren.php
@@ -11,4 +11,16 @@ interface VerfahrensparameterZweiSchrittVerfahren extends TanMode
 
     /** @return string */
     public function getName();
+
+    /** @return boolean */
+    public function getSmsAbbuchungskontoErforderlich();
+
+    /** @return boolean */
+    public function getAuftraggeberkontoErforderlich();
+
+    /** @return boolean */
+    public function getChallengeKlasseErforderlich();
+
+    /** @return boolean */
+    public function getAntwortHhdUcErforderlich();
 }

--- a/lib/Fhp/Segment/HITANS/VerfahrensparameterZweiSchrittVerfahrenV1.php
+++ b/lib/Fhp/Segment/HITANS/VerfahrensparameterZweiSchrittVerfahrenV1.php
@@ -29,13 +29,45 @@ class VerfahrensparameterZweiSchrittVerfahrenV1 extends BaseDeg implements Verfa
     /** @var boolean */
     public $tanZeitversetztDialoguebergreifendErlaubt;
 
-    public function getSicherheitsfunktion()
+    /** @inheritDoc */
+    public function getId()
     {
         return $this->sicherheitsfunktion;
     }
 
-    public function getNameDesZweiSchrittVerfahrens()
+    /** @inheritDoc */
+    public function getName()
     {
         return $this->nameDesZweiSchrittVerfahrens;
+    }
+
+    /** @inheritDoc */
+    public function getChallengeLabel()
+    {
+        return $this->textZurBelegungDesRueckgabewertes;
+    }
+
+    /** @inheritDoc */
+    public function getMaxChallengeLength()
+    {
+        return $this->maximaleLaengeDesRueckgabewertes;
+    }
+
+    /** @inheritDoc */
+    public function getMaxTanLength()
+    {
+        return $this->maximaleLaengeDesTanEingabewertes;
+    }
+
+    /** @inheritDoc */
+    public function getTanFormat()
+    {
+        return $this->erlaubtesFormat;
+    }
+
+    /** @inheritDoc */
+    public function needsTanDevice()
+    {
+        return false;
     }
 }

--- a/lib/Fhp/Segment/HITANS/VerfahrensparameterZweiSchrittVerfahrenV1.php
+++ b/lib/Fhp/Segment/HITANS/VerfahrensparameterZweiSchrittVerfahrenV1.php
@@ -42,6 +42,30 @@ class VerfahrensparameterZweiSchrittVerfahrenV1 extends BaseDeg implements Verfa
     }
 
     /** @inheritDoc */
+    public function getSmsAbbuchungskontoErforderlich()
+    {
+        return false;
+    }
+
+    /** @inheritDoc */
+    public function getAuftraggeberkontoErforderlich()
+    {
+        return false;
+    }
+
+    /** @inheritDoc */
+    public function getChallengeKlasseErforderlich()
+    {
+        return false;
+    }
+
+    /** @inheritDoc */
+    public function getAntwortHhdUcErforderlich()
+    {
+        return false;
+    }
+
+    /** @inheritDoc */
     public function getChallengeLabel()
     {
         return $this->textZurBelegungDesRueckgabewertes;

--- a/lib/Fhp/Segment/HITANS/VerfahrensparameterZweiSchrittVerfahrenV2.php
+++ b/lib/Fhp/Segment/HITANS/VerfahrensparameterZweiSchrittVerfahrenV2.php
@@ -56,6 +56,30 @@ class VerfahrensparameterZweiSchrittVerfahrenV2 extends BaseDeg implements Verfa
     }
 
     /** @inheritDoc */
+    public function getSmsAbbuchungskontoErforderlich()
+    {
+        return false;
+    }
+
+    /** @inheritDoc */
+    public function getAuftraggeberkontoErforderlich()
+    {
+        return false;
+    }
+
+    /** @inheritDoc */
+    public function getChallengeKlasseErforderlich()
+    {
+        return $this->challengeKlasseErforderlich;
+    }
+
+    /** @inheritDoc */
+    public function getAntwortHhdUcErforderlich()
+    {
+        return false;
+    }
+
+    /** @inheritDoc */
     public function getChallengeLabel()
     {
         return $this->textZurBelegungDesRueckgabewertes;

--- a/lib/Fhp/Segment/HITANS/VerfahrensparameterZweiSchrittVerfahrenV2.php
+++ b/lib/Fhp/Segment/HITANS/VerfahrensparameterZweiSchrittVerfahrenV2.php
@@ -43,13 +43,45 @@ class VerfahrensparameterZweiSchrittVerfahrenV2 extends BaseDeg implements Verfa
     /** @var boolean */
     public $challengeBetragErforderlich;
 
-    public function getSicherheitsfunktion()
+    /** @inheritDoc */
+    public function getId()
     {
         return $this->sicherheitsfunktion;
     }
 
-    public function getNameDesZweiSchrittVerfahrens()
+    /** @inheritDoc */
+    public function getName()
     {
         return $this->nameDesZweiSchrittVerfahrens;
+    }
+
+    /** @inheritDoc */
+    public function getChallengeLabel()
+    {
+        return $this->textZurBelegungDesRueckgabewertes;
+    }
+
+    /** @inheritDoc */
+    public function getMaxChallengeLength()
+    {
+        return $this->maximaleLaengeDesRueckgabewertes;
+    }
+
+    /** @inheritDoc */
+    public function getMaxTanLength()
+    {
+        return $this->maximaleLaengeDesTanEingabewertes;
+    }
+
+    /** @inheritDoc */
+    public function getTanFormat()
+    {
+        return $this->erlaubtesFormat;
+    }
+
+    /** @inheritDoc */
+    public function needsTanDevice()
+    {
+        return false;
     }
 }

--- a/lib/Fhp/Segment/HITANS/VerfahrensparameterZweiSchrittVerfahrenV3.php
+++ b/lib/Fhp/Segment/HITANS/VerfahrensparameterZweiSchrittVerfahrenV3.php
@@ -62,6 +62,30 @@ class VerfahrensparameterZweiSchrittVerfahrenV3 extends BaseDeg implements Verfa
     }
 
     /** @inheritDoc */
+    public function getSmsAbbuchungskontoErforderlich()
+    {
+        return false;
+    }
+
+    /** @inheritDoc */
+    public function getAuftraggeberkontoErforderlich()
+    {
+        return false;
+    }
+
+    /** @inheritDoc */
+    public function getChallengeKlasseErforderlich()
+    {
+        return $this->challengeKlasseErforderlich;
+    }
+
+    /** @inheritDoc */
+    public function getAntwortHhdUcErforderlich()
+    {
+        return false;
+    }
+
+    /** @inheritDoc */
     public function getChallengeLabel()
     {
         return $this->textZurBelegungDesRueckgabewertes;

--- a/lib/Fhp/Segment/HITANS/VerfahrensparameterZweiSchrittVerfahrenV3.php
+++ b/lib/Fhp/Segment/HITANS/VerfahrensparameterZweiSchrittVerfahrenV3.php
@@ -49,13 +49,45 @@ class VerfahrensparameterZweiSchrittVerfahrenV3 extends BaseDeg implements Verfa
     /** @var integer|null */
     public $anzahlUnterstuetzterAktiverTanMedien;
 
-    public function getSicherheitsfunktion()
+    /** @inheritDoc */
+    public function getId()
     {
         return $this->sicherheitsfunktion;
     }
 
-    public function getNameDesZweiSchrittVerfahrens()
+    /** @inheritDoc */
+    public function getName()
     {
         return $this->nameDesZweiSchrittVerfahrens;
+    }
+
+    /** @inheritDoc */
+    public function getChallengeLabel()
+    {
+        return $this->textZurBelegungDesRueckgabewertes;
+    }
+
+    /** @inheritDoc */
+    public function getMaxChallengeLength()
+    {
+        return $this->maximaleLaengeDesRueckgabewertes;
+    }
+
+    /** @inheritDoc */
+    public function getMaxTanLength()
+    {
+        return $this->maximaleLaengeDesTanEingabewertes;
+    }
+
+    /** @inheritDoc */
+    public function getTanFormat()
+    {
+        return $this->erlaubtesFormat;
+    }
+
+    /** @inheritDoc */
+    public function needsTanDevice()
+    {
+        return $this->bezeichnungDesTanMediumsErforderlich === 2 && $this->anzahlUnterstuetzterAktiverTanMedien > 0;
     }
 }

--- a/lib/Fhp/Segment/HITANS/VerfahrensparameterZweiSchrittVerfahrenV4.php
+++ b/lib/Fhp/Segment/HITANS/VerfahrensparameterZweiSchrittVerfahrenV4.php
@@ -57,13 +57,45 @@ class VerfahrensparameterZweiSchrittVerfahrenV4 extends BaseDeg implements Verfa
     /** @var integer|null */
     public $anzahlUnterstuetzterAktiverTanMedien;
 
-    public function getSicherheitsfunktion()
+    /** @inheritDoc */
+    public function getId()
     {
         return $this->sicherheitsfunktion;
     }
 
-    public function getNameDesZweiSchrittVerfahrens()
+    /** @inheritDoc */
+    public function getName()
     {
         return $this->nameDesZweiSchrittVerfahrens;
+    }
+
+    /** @inheritDoc */
+    public function getChallengeLabel()
+    {
+        return $this->textZurBelegungDesRueckgabewertes;
+    }
+
+    /** @inheritDoc */
+    public function getMaxChallengeLength()
+    {
+        return $this->maximaleLaengeDesRueckgabewertes;
+    }
+
+    /** @inheritDoc */
+    public function getMaxTanLength()
+    {
+        return $this->maximaleLaengeDesTanEingabewertes;
+    }
+
+    /** @inheritDoc */
+    public function getTanFormat()
+    {
+        return $this->erlaubtesFormat;
+    }
+
+    /** @inheritDoc */
+    public function needsTanDevice()
+    {
+        return $this->bezeichnungDesTanMediumsErforderlich === 2 && $this->anzahlUnterstuetzterAktiverTanMedien > 0;
     }
 }

--- a/lib/Fhp/Segment/HITANS/VerfahrensparameterZweiSchrittVerfahrenV4.php
+++ b/lib/Fhp/Segment/HITANS/VerfahrensparameterZweiSchrittVerfahrenV4.php
@@ -70,6 +70,30 @@ class VerfahrensparameterZweiSchrittVerfahrenV4 extends BaseDeg implements Verfa
     }
 
     /** @inheritDoc */
+    public function getSmsAbbuchungskontoErforderlich()
+    {
+        return $this->smsAbbuchungskontoErforderlich;
+    }
+
+    /** @inheritDoc */
+    public function getAuftraggeberkontoErforderlich()
+    {
+        return false;
+    }
+
+    /** @inheritDoc */
+    public function getChallengeKlasseErforderlich()
+    {
+        return $this->challengeKlasseErforderlich;
+    }
+
+    /** @inheritDoc */
+    public function getAntwortHhdUcErforderlich()
+    {
+        return false;
+    }
+
+    /** @inheritDoc */
     public function getChallengeLabel()
     {
         return $this->textZurBelegungDesRueckgabewertes;

--- a/lib/Fhp/Segment/HITANS/VerfahrensparameterZweiSchrittVerfahrenV5.php
+++ b/lib/Fhp/Segment/HITANS/VerfahrensparameterZweiSchrittVerfahrenV5.php
@@ -70,6 +70,30 @@ class VerfahrensparameterZweiSchrittVerfahrenV5 extends BaseDeg implements Verfa
     }
 
     /** @inheritDoc */
+    public function getSmsAbbuchungskontoErforderlich()
+    {
+        return $this->smsAbbuchungskontoErforderlich === 2;
+    }
+
+    /** @inheritDoc */
+    public function getAuftraggeberkontoErforderlich()
+    {
+        return $this->auftraggeberkontoErforderlich === 2;
+    }
+
+    /** @inheritDoc */
+    public function getChallengeKlasseErforderlich()
+    {
+        return $this->challengeKlasseErforderlich;
+    }
+
+    /** @inheritDoc */
+    public function getAntwortHhdUcErforderlich()
+    {
+        return false;
+    }
+
+    /** @inheritDoc */
     public function getChallengeLabel()
     {
         return $this->textZurBelegungDesRueckgabewertes;

--- a/lib/Fhp/Segment/HITANS/VerfahrensparameterZweiSchrittVerfahrenV5.php
+++ b/lib/Fhp/Segment/HITANS/VerfahrensparameterZweiSchrittVerfahrenV5.php
@@ -57,13 +57,45 @@ class VerfahrensparameterZweiSchrittVerfahrenV5 extends BaseDeg implements Verfa
     /** @var integer|null */
     public $anzahlUnterstuetzterAktiverTanMedien;
 
-    public function getSicherheitsfunktion()
+    /** @inheritDoc */
+    public function getId()
     {
         return $this->sicherheitsfunktion;
     }
 
-    public function getNameDesZweiSchrittVerfahrens()
+    /** @inheritDoc */
+    public function getName()
     {
         return $this->nameDesZweiSchrittVerfahrens;
+    }
+
+    /** @inheritDoc */
+    public function getChallengeLabel()
+    {
+        return $this->textZurBelegungDesRueckgabewertes;
+    }
+
+    /** @inheritDoc */
+    public function getMaxChallengeLength()
+    {
+        return $this->maximaleLaengeDesRueckgabewertes;
+    }
+
+    /** @inheritDoc */
+    public function getMaxTanLength()
+    {
+        return $this->maximaleLaengeDesTanEingabewertes;
+    }
+
+    /** @inheritDoc */
+    public function getTanFormat()
+    {
+        return $this->erlaubtesFormat;
+    }
+
+    /** @inheritDoc */
+    public function needsTanDevice()
+    {
+        return $this->bezeichnungDesTanMediumsErforderlich === 2 && $this->anzahlUnterstuetzterAktiverTanMedien > 0;
     }
 }

--- a/lib/Fhp/Segment/HITANS/VerfahrensparameterZweiSchrittVerfahrenV6.php
+++ b/lib/Fhp/Segment/HITANS/VerfahrensparameterZweiSchrittVerfahrenV6.php
@@ -55,13 +55,45 @@ class VerfahrensparameterZweiSchrittVerfahrenV6 extends BaseDeg implements Verfa
     /** @var integer|null */
     public $anzahlUnterstuetzterAktiverTanMedien;
 
-    public function getSicherheitsfunktion()
+    /** @inheritDoc */
+    public function getId()
     {
         return $this->sicherheitsfunktion;
     }
 
-    public function getNameDesZweiSchrittVerfahrens()
+    /** @inheritDoc */
+    public function getName()
     {
         return $this->nameDesZweiSchrittVerfahrens;
+    }
+
+    /** @inheritDoc */
+    public function getChallengeLabel()
+    {
+        return $this->textZurBelegungDesRueckgabewertes;
+    }
+
+    /** @inheritDoc */
+    public function getMaxChallengeLength()
+    {
+        return $this->maximaleLaengeDesRueckgabewertes;
+    }
+
+    /** @inheritDoc */
+    public function getMaxTanLength()
+    {
+        return $this->maximaleLaengeDesTanEingabewertes;
+    }
+
+    /** @inheritDoc */
+    public function getTanFormat()
+    {
+        return $this->erlaubtesFormat;
+    }
+
+    /** @inheritDoc */
+    public function needsTanDevice()
+    {
+        return $this->bezeichnungDesTanMediumsErforderlich === 2 && $this->anzahlUnterstuetzterAktiverTanMedien > 0;
     }
 }

--- a/lib/Fhp/Segment/HITANS/VerfahrensparameterZweiSchrittVerfahrenV6.php
+++ b/lib/Fhp/Segment/HITANS/VerfahrensparameterZweiSchrittVerfahrenV6.php
@@ -68,6 +68,30 @@ class VerfahrensparameterZweiSchrittVerfahrenV6 extends BaseDeg implements Verfa
     }
 
     /** @inheritDoc */
+    public function getSmsAbbuchungskontoErforderlich()
+    {
+        return $this->smsAbbuchungskontoErforderlich === 2;
+    }
+
+    /** @inheritDoc */
+    public function getAuftraggeberkontoErforderlich()
+    {
+        return $this->auftraggeberkontoErforderlich === 2;
+    }
+
+    /** @inheritDoc */
+    public function getChallengeKlasseErforderlich()
+    {
+        return $this->challengeKlasseErforderlich;
+    }
+
+    /** @inheritDoc */
+    public function getAntwortHhdUcErforderlich()
+    {
+        return $this->antwortHhdUcErforderlich;
+    }
+
+    /** @inheritDoc */
     public function getChallengeLabel()
     {
         return $this->textZurBelegungDesRueckgabewertes;


### PR DESCRIPTION
The new interface gives the application more information about a TAN mode, and defines a clearer interface than just an int=>string mapping. Also, let VerfahrensparameterZweiSchrittVerfahren implement the interface, so that the implementation can simply return those instances as TanModes directly.