### PR TITLE
Treat absent nested DEGs correctly in Parser/Serializer

### DIFF
--- a/lib/Fhp/Segment/BaseDeg.php
+++ b/lib/Fhp/Segment/BaseDeg.php
@@ -52,7 +52,7 @@ abstract class BaseDeg
      */
     public function serialize()
     {
-        return Serializer::serializeDeg($this);
+        return Serializer::serializeDeg($this, $this->getDescriptor());
     }
 
     /**

--- a/lib/Fhp/Segment/BaseDescriptor.php
+++ b/lib/Fhp/Segment/BaseDescriptor.php
@@ -27,6 +27,14 @@ abstract class BaseDescriptor
     public $elements = [];
 
     /**
+     * The last index that can be present in an exploded serialized segment/DEG. If one were to append a new field to
+     * segment/DEG described by this descriptor, it would get index $maxIndex+1.
+     * Usually $maxIndex==array_key_last($elements), but when the last element is repeated, then $maxIndex is larger.
+     * @var integer
+     */
+    public $maxIndex;
+
+    /**
      * @param \ReflectionClass $clazz
      */
     protected function __construct($clazz)
@@ -85,6 +93,7 @@ abstract class BaseDescriptor
         }
         if (empty($this->elements)) throw new \InvalidArgumentException("No fields found in $clazz->name");
         ksort($this->elements); // Make sure elements are parsed in wire-format order.
+        $this->maxIndex = $nextIndex - 1;
     }
 
     /**

--- a/lib/Fhp/Syntax/Parser.php
+++ b/lib/Fhp/Syntax/Parser.php
@@ -362,11 +362,23 @@ abstract class Parser
         }
         /** @var Segmentkopf $segmentkopf */
         $segmentkopf = Segmentkopf::parse(substr($rawSegment, 0, $firstElementDelimiter));
+
+        // Try the default class name Fhp\Segment\HABCD\HABCDvN.
         $segmentType = static::SEGMENT_NAMESPACE . '\\' . $segmentkopf->segmentkennung . '\\'
             . $segmentkopf->segmentkennung . 'v' . $segmentkopf->segmentversion;
         if (class_exists($segmentType)) {
             return static::parseSegment($rawSegment, $segmentType);
         }
+
+        // Alternatively, allow Geschäftsvorfall segments (HKXYZ, HIXYZ and HIXYZS) to live in an abbreviated namespace,
+        // i.e. like Fhp\Segment\XYZ\HKXYZSvN
+        $segmentType = static::SEGMENT_NAMESPACE . '\\' . substr($segmentkopf->segmentkennung, 2, 3) . '\\'
+            . $segmentkopf->segmentkennung . 'v' . $segmentkopf->segmentversion;
+        if (class_exists($segmentType)) {
+            return static::parseSegment($rawSegment, $segmentType);
+        }
+
+        // If the segment type is not implemented, fall back to an anonymous segment.
         return static::parseAnonymousSegment($rawSegment);
     }
 }

--- a/lib/Tests/Fhp/Segment/HITABTest.php
+++ b/lib/Tests/Fhp/Segment/HITABTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Tests\Fhp\Segment;
+
+use Fhp\Segment\TAB\HITABv4;
+
+class HITABTest extends \PHPUnit\Framework\TestCase
+{
+    const REAL_DKB_RESPONSE = "HITAB:1:4:3+0+A:1:::::::::::pushtan::::::::+A:1:::::::::::SomePhone1::::::::'";
+
+    public function test_parse_DKB()
+    {
+        // NOTE: Among the many colons, the response contains a KtvV3 and a Kti nested inside TanMediumListeV4. Each is
+        // a DEG nested inside another DEG. In that case, if the nested DEG is absent (null), we still need all the
+        // empty fields of the inside of the absent DEG in order not to mess up the field offsets for subsequent fields.
+        // This is different from DEGs nested in segments because the segment delimiters are different and we would just
+        // see two delimiters "++" with nothing in between for an absent DEG.
+        $parsed = HITABv4::parse(static::REAL_DKB_RESPONSE);
+        $liste = $parsed->getTanMediumListe();
+        $this->assertCount(2, $liste);
+        $this->assertEquals("pushtan", $liste[0]->getName());
+        $this->assertEquals("SomePhone1", $liste[1]->getName());
+    }
+
+    public function test_serialize()
+    {
+        // NOTE: Our serializer produces fewer redundant colons, but after parsing it again, it should be the same.
+        $parsed = HITABv4::parse(static::REAL_DKB_RESPONSE);
+        $serialized = $parsed->serialize();
+        $this->assertEquals("HITAB:1:4:3+0+A:1:::::::::::pushtan+A:1:::::::::::SomePhone1'", $serialized);
+        $reparsed = HITABv4::parse($serialized);
+        $this->assertEquals($reparsed, $parsed);
+    }
+}

--- a/lib/Tests/Fhp/Segment/SegmentComparator.php
+++ b/lib/Tests/Fhp/Segment/SegmentComparator.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Tests\Fhp\Segment;
+
+use Fhp\Segment\BaseDeg;
+use Fhp\Segment\BaseSegment;
+use SebastianBergmann\Comparator\ObjectComparator;
+
+/**
+ * Class SegmentComparator
+ *
+ * Comparator for sub-classes of {@link BaseSegment} and {@link BaseDeg} that ignores the descriptor private field.
+ *
+ * @package Tests\Fhp\Segment
+ */
+class SegmentComparator extends ObjectComparator
+{
+    public function accepts($expected, $actual)
+    {
+        if ($expected instanceof BaseSegment && $actual instanceof BaseSegment) return true;
+        if ($expected instanceof BaseDeg && $actual instanceof BaseDeg) return true;
+        return false;
+    }
+
+    protected function toArray($object)
+    {
+        $array = parent::toArray($object);
+        unset($array['descriptor']);
+        return $array;
+    }
+}

--- a/lib/Tests/Fhp/Syntax/ParserTest.php
+++ b/lib/Tests/Fhp/Syntax/ParserTest.php
@@ -68,6 +68,9 @@ class ParserTest extends \PHPUnit\Framework\TestCase
         $this->assertSame(false, Parser::parseDataElement('N', 'boolean'));
         $this->assertSame('1000', Parser::parseDataElement('1000', 'string'));
         $this->assertSame('ä', Parser::parseDataElement(utf8_decode('ä'), 'string'));
+
+        $this->assertSame(null, Parser::parseDataElement('', 'int'));
+        $this->assertSame(null, Parser::parseDataElement('', 'string'));
     }
 
     public function test_parseDataElement_invalid_int()

--- a/lib/Tests/Fhp/Syntax/SerializerTest.php
+++ b/lib/Tests/Fhp/Syntax/SerializerTest.php
@@ -46,6 +46,8 @@ class SerializerTest extends \PHPUnit\Framework\TestCase
             ['1000', '1000', 'string'],
             [utf8_decode('ä'), 'ä', 'string'],
             ['5?:5', "5:5", 'string'],
+            ['', null, 'int'],
+            ['', null, 'string'],
         ];
     }
 
@@ -53,12 +55,5 @@ class SerializerTest extends \PHPUnit\Framework\TestCase
     public function test_serializeDataElement($expected, $value, $type)
     {
         $this->assertSame($expected, Serializer::serializeDataElement($value, $type));
-    }
-
-    public function test_fillMissingKeys()
-    {
-        $arr = array(0 => 'a', 2 => 'b', 4 => 'c');
-        Serializer::fillMissingKeys($arr, 'X');
-        $this->assertEquals(array(0 => 'a', 1 => 'X', 2 => 'b', 3 => 'X', 4 => 'c'), $arr);
     }
 }

--- a/lib/Tests/phpunit_bootstrap.php
+++ b/lib/Tests/phpunit_bootstrap.php
@@ -1,0 +1,6 @@
+<?php
+
+use SebastianBergmann\Comparator\Factory;
+use Tests\Fhp\Segment\SegmentComparator;
+
+Factory::getInstance()->register(new SegmentComparator());

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,6 +8,7 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
+         bootstrap="./lib/Tests/phpunit_bootstrap.php"
 >
     <testsuites>
         <testsuite name="FHP Test Suite">


### PR DESCRIPTION
Unit test coverage through HITABTest, need to add support for the abbreviated `TAB` namespace (the segment definition were already part of a previous PR) and need to fix assertEquals() in unit tests for segments.