### PR TITLE
Add some development tools to log and inspect segments and messages

### DIFF
--- a/lib/Tests/Fhp/SanitizingCLILogger.php
+++ b/lib/Tests/Fhp/SanitizingCLILogger.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Tests\Fhp;
+
+use Fhp\Credentials;
+use Fhp\FinTsOptions;
+use Fhp\Model\Account;
+use Fhp\Model\SEPAAccount;
+use Fhp\Syntax\Serializer;
+
+/**
+ * A logger that prints log messages to the console (just PHP `echo`) but attempts to remove confidential information
+ * like usernames, passwords/PINs and so on. This class is designed to be used only for testing purposes, specifically
+ * to record real traffic for integration tests, which ends up hard-coded in the Git repository.
+ *
+ * Example usage:
+ * $credentials = \Fhp\Credentials::create('username', 'sensitivePIN');
+ * $options = new \Fhp\FinTsOptions();
+ * $options->productName = 'YourProductRegistrationID';
+ * $options->productVersion = '1.0';
+ * $options->logger = new \Fhp\SanitizingCLILogger([$options, $credentials]);
+ * ...
+ * $sepaAccount = new SEPAAccount();
+ * $sepaAccount->setIban('DE45SENSITIVEIBAN');
+ * $options->logger->addSensitiveMaterial([$sepaAccount])
+ */
+class SanitizingCLILogger extends \Psr\Log\AbstractLogger
+{
+    /** @var string[] */
+    private $needles;
+
+    /**
+     * @param array $sensitiveMaterial An array of various objects typically used with the phpFinTS library that contain
+     *     some sensitive information. This array may also contain plain strings, which are themselves interpreted as
+     *     sensitive.
+     */
+    public function __construct($sensitiveMaterial)
+    {
+        $this->needles = static::computeNeedles($sensitiveMaterial);
+    }
+
+    /**
+     * @param array $sensitiveMaterial See the constructor.
+     */
+    public function addSensitiveMaterial($sensitiveMaterial)
+    {
+        $this->needles = array_merge($this->needles, static::computeNeedles($sensitiveMaterial));
+    }
+
+    /** @noinspection PhpLanguageLevelInspection */
+    /** @noinspection PhpUndefinedClassInspection */
+    public function log($level, $message, array $context = array()): void
+    {
+        $message .= empty($context) ? '' : ' ' . implode(', ', $context);
+        $sanitizedMessage = static::sanitizeForLogging($message, $this->needles);
+        echo "$level: $sanitizedMessage\n";
+    }
+
+    /**
+     * @param array $sensitiveMaterial An array of various objects typically used with the phpFinTS library that contain
+     *     some sensitive information. This array may also contain plain strings, which are themselves interpreted as
+     *     sensitive.
+     * @return string[] An array of search-replacement "needles" that should be replaced in log messages.
+     */
+    public static function computeNeedles($sensitiveMaterial)
+    {
+        $needles = [];
+        foreach ($sensitiveMaterial as $item) {
+            if (is_string($item)) {
+                $needles[] = $item;
+            } elseif ($item instanceof Credentials) {
+                $needles[] = $item->benutzerkennung;
+                $needles[] = $item->pin;
+            } elseif ($item instanceof FinTsOptions) {
+                $needles[] = $item->bankCode;
+                $needles[] = $item->productName;
+            } elseif ($item instanceof Account) {
+                $needles[] = $item->getIban();
+                $needles[] = $item->getAccountNumber();
+                $needles[] = $item->getAccountOwnerName();
+                $needles[] = $item->getCustomerId();
+            } elseif ($item instanceof SEPAAccount) {
+                $needles[] = $item->getIban();
+                $needles[] = $item->getAccountNumber();
+            } else {
+                throw new \InvalidArgumentException("Unsupported type of sensitive material " . gettype($item));
+            }
+        }
+        $needles = array_filter($needles); // Filter out empty entries.
+        $escapedNeedles = array_map(function ($needle) {
+            return Serializer::escape($needle);
+        }, $needles);
+        return array_merge($needles, $escapedNeedles);
+    }
+
+    /**
+     * Removes sensitive values from the given string, while preserving its overall length, so that wrappers like FinTS
+     * messages or Bin containers, which declare the length of their contents, remain parsable.
+     * @param string $str Some string.
+     * @param string[] The sensitive values to be replaced, usually from {@link #computeNeedles()}.
+     * @return string The same string, but with sensitive values removed.
+     */
+    public static function sanitizeForLogging($str, $needles)
+    {
+        $replacements = array_map(function ($needle) {
+            $len = strlen($needle) - 1;
+            $prefix = '<PRIVATE';
+            return substr($prefix, 0, $len) . str_repeat('_', max(0, $len - strlen($prefix))) . '>';
+        }, $needles);
+        return str_replace($needles, $replacements, $str);
+    }
+}

--- a/lib/Tests/Fhp/SanitizingCLILoggerTest.php
+++ b/lib/Tests/Fhp/SanitizingCLILoggerTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Tests\Fhp;
+
+use Fhp\Credentials;
+use Fhp\FinTsOptions;
+
+class SanitizingCLILoggerTest extends \PHPUnit\Framework\TestCase
+{
+    public function test_sanitize()
+    {
+        $credentials = Credentials::create('USER123', 'pw+?123');
+        $options = new FinTsOptions();
+        $options->productName = 'ABCDEFGHIJKLMNOPQRS';
+        $needles = SanitizingCLILogger::computeNeedles([$credentials, $options, 'RAWNEEDLE']);
+        $sanitize = function ($str) use ($needles) {
+            $result = SanitizingCLILogger::sanitizeForLogging($str, $needles);
+            $this->assertEquals(strlen($str), strlen($result));
+            return $result;
+        };
+        $this->assertEquals(
+            "HKVVB:4:3+3+0+0+<PRIVATE__________>+1.0'HKTAN:5:",
+            $sanitize("HKVVB:4:3+3+0+0+ABCDEFGHIJKLMNOPQRS+1.0'HKTAN:5:"));
+        $this->assertEquals(
+            "Look here is the password: <PRIVA>",
+            $sanitize("Look here is the password: pw+?123"));
+        $this->assertEquals(
+            "HNSHA:4:2+9999999++<PRIVATE>'",
+            $sanitize("HNSHA:4:2+9999999++pw?+??123'")); // Note: The password is escaped to wire format here.
+        $this->assertEquals(
+            "20190102:030405+1:999:1+6:10:19+280:11223344:<PRIVA>:S:0:0'HIRMG:3:2",
+            $sanitize("20190102:030405+1:999:1+6:10:19+280:11223344:USER123:S:0:0'HIRMG:3:2"));
+    }
+}

--- a/prettify_message.php
+++ b/prettify_message.php
@@ -1,0 +1,13 @@
+<?php
+
+$classLoader = require(__DIR__ . '/vendor/autoload.php');
+
+// Read a message from stdin.
+echo "Please enter a serialized FinTS message:\n";
+$line = trim(fgets(STDIN));
+
+// Parse it.
+$message = \Fhp\Protocol\Message::parse($line);
+
+// Print it. Tip: Put a breakpoint here to inspect it in your IDE.
+print_r($message);

--- a/prettify_segment.php
+++ b/prettify_segment.php
@@ -1,0 +1,13 @@
+<?php
+
+$classLoader = require(__DIR__ . '/vendor/autoload.php');
+
+// Read a message from stdin.
+echo "Please enter a serialized FinTS segment:\n";
+$line = trim(fgets(STDIN));
+
+// Parse it.
+$segment = \Fhp\Syntax\Parser::detectAndParseSegment($line);
+
+// Print it. Tip: Put a breakpoint here to inspect it in your IDE.
+print_r($segment);


### PR DESCRIPTION
The logger removes sensitive information like PINs from the log output without breaking the wire format. The inspect tools read a serialized message or segment from the command line and print it as a parsed tree structure, or allow viewing it in an interactive debugger.

@ampaze fyi