### PR TITLE
$tanMechanism is already an array

### DIFF
--- a/lib/Fhp/Dialog/Dialog.php
+++ b/lib/Fhp/Dialog/Dialog.php
@@ -237,7 +237,7 @@ class Dialog
 				new HKTAN(HKTAN::VERSION, 3, $response->get()->getProcessID())
 			),
 			array(
-				AbstractMessage::OPT_PINTAN_MECH => $tanMechanism
+                              AbstractMessage::OPT_PINTAN_MECH => $tanMechanism
 			),
 			$tan
 		);

--- a/lib/Fhp/Dialog/Dialog.php
+++ b/lib/Fhp/Dialog/Dialog.php
@@ -237,7 +237,7 @@ class Dialog
 				new HKTAN(HKTAN::VERSION, 3, $response->get()->getProcessID())
 			),
 			array(
-				AbstractMessage::OPT_PINTAN_MECH => array($tanMechanism)
+				AbstractMessage::OPT_PINTAN_MECH => $tanMechanism
 			),
 			$tan
 		);


### PR DESCRIPTION
$tanMechanism ist bereits ein Array, wenn gesetzt. Das nochmal in ein Array zu packen führt zu:
Fatal Error: Method Fhp\Segment\HNSHK::__toString() must not throw an exception
wegen
Array to string conversion