### PR TITLE
Fix for bad class reference caused by PR #100

### DIFF
--- a/lib/Fhp/FinTs.php
+++ b/lib/Fhp/FinTs.php
@@ -10,6 +10,8 @@ use Fhp\Message\AbstractMessage;
 use Fhp\Message\Message;
 use Fhp\Model\SEPAAccount;
 use Fhp\Model\SEPAStandingOrder;
+use Fhp\MT940\Dialect\PostbankMT940;
+use Fhp\MT940\Dialect\SpardaMT940;
 use Fhp\MT940\MT940;
 use Fhp\Response\GetAccounts;
 use Fhp\Response\GetSaldo;
@@ -24,14 +26,12 @@ use Fhp\Segment\HKKAZ;
 use Fhp\Segment\HKSAL;
 use Fhp\Segment\HKSPA;
 use Fhp\Segment\HKCDB;
-use Fhp\Segment\HKTAN;
 use Fhp\Segment\HKDSE;
 use Fhp\Segment\HKDSC;
 use Fhp\Segment\HKCAZ;
 use Fhp\Segment\HKVVB;
 use Fhp\Segment\HKIDN;
 use Fhp\Segment\HKTAB;
-use Fhp\Model\Account;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Fhp\Dialog\Exception\TANException;
@@ -402,11 +402,11 @@ class FinTs extends FinTsInternal
 		]);
 
         switch ($dialectId) {
-            case MT940\Dialect\SpardaMT940::DIALECT_ID:
-                $parser = new MT940\Dialect\SpardaMT940();
+            case SpardaMT940::DIALECT_ID:
+                $parser = new SpardaMT940();
                 break;
-            case MT940\Dialect\PostbankMT940::DIALECT_ID:
-                $parser = new MT940\Dialect\PostbankMT940();
+            case PostbankMT940::DIALECT_ID:
+                $parser = new PostbankMT940();
                 break;
             default:
                 $parser = new MT940();

--- a/lib/Fhp/MT940/MT940.php
+++ b/lib/Fhp/MT940/MT940.php
@@ -2,8 +2,6 @@
 
 namespace Fhp\MT940;
 
-use Fhp\MT940\MT940Exception;
-
 /**
  * Class MT940
  * Data format: MT 940 (Version SRG 2001)


### PR DESCRIPTION
`MT940` is now both a class name and a namespace name. Just using `use` declarations for every used class instead of relying on namespace-relative class references to work is the more future-proof and reliable solution, and it also makes the out-of-namespace dependencies clearly visible at the top of the file.