### PR TITLE
Fix: wrong segment number set on HKTAN; segment numbers are now autom…

### DIFF
--- a/lib/Fhp/FinTsInternal.php
+++ b/lib/Fhp/FinTsInternal.php
@@ -112,7 +112,7 @@ abstract class FinTsInternal
     {
         // Add an HKTAN Segment if the Bank requires it
         if ($dialog->bpd->tanRequiredForRequest($segments)) {
-            $segments[] = $this->createHKTAN(count($segments) + 4);
+            $segments[] = $this->createHKTAN(null);
         }
         return new Message(
             $this->bankCode,

--- a/lib/Fhp/Message/Message.php
+++ b/lib/Fhp/Message/Message.php
@@ -3,6 +3,7 @@
 namespace Fhp\Message;
 
 use Fhp\DataElementGroups\SecurityProfile;
+use Fhp\Segment\AbstractSegment;
 use Fhp\Segment\HNHBS;
 use Fhp\Segment\HNSHA;
 use Fhp\Segment\HNSHK;
@@ -73,7 +74,7 @@ class Message extends AbstractMessage
      * @param $systemId
      * @param int $dialogId
      * @param int $messageNumber
-     * @param array $segments
+     * @param AbstractSegment[] $segments
      * @param array $options
      */
     public function __construct(
@@ -117,6 +118,7 @@ class Message extends AbstractMessage
             $segmentNumberOffset -= 2; // HNVSK + HNVSD have different numbers
         }
 
+        /** @var AbstractSegment[] $subSegments */
         $subSegments = [];
         $subSegments[] = $this->buildSignatureHead(); // HNSHK
 
@@ -124,12 +126,12 @@ class Message extends AbstractMessage
             $subSegments[] = $segment;
         }
 
-        $subSegments[] = new HNSHA(
-            count($this->segments) + count($this->encryptedSegments) + count($subSegments) + $segmentNumberOffset,
-            $this->securityReference, $this->pin, $tan
-        );
+        $subSegments[] = new HNSHA(null, $this->securityReference, $this->pin, $tan);
 
         foreach($subSegments as $subSegment) {
+
+            $subSegment->setSegmentNumber(count($this->segments) + count($this->encryptedSegments) + $segmentNumberOffset);
+
             if($useEncryption) {
                 $this->addEncryptedSegment($subSegment);
             } else {

--- a/lib/Fhp/Segment/AbstractSegment.php
+++ b/lib/Fhp/Segment/AbstractSegment.php
@@ -20,7 +20,7 @@ abstract class AbstractSegment implements SegmentInterface
      * AbstractSegment constructor.
      *
      * @param $type
-     * @param $segmentNumber
+     * @param int|null $segmentNumber
      * @param $version
      * @param array $dataElements
      */
@@ -95,6 +95,13 @@ abstract class AbstractSegment implements SegmentInterface
     public function getSegmentNumber()
     {
         return $this->segmentNumber;
+    }
+
+    /**
+     * @param int $number
+     */
+    public function setSegmentNumber($number) {
+        $this->segmentNumber = $number;
     }
 
     /**


### PR DESCRIPTION
…atically set, when the message is build.

Before, "Deutsche Bank" has reported:
[HIRMG] 9050: Teilweise fehlerhaft.
[HIRMG] 9120: Nachricht nicht erwartet.