### PR TITLE
Explizite Methode zum Dialog initialisieren

### DIFF
--- a/Samples/accounts.php
+++ b/Samples/accounts.php
@@ -34,6 +34,7 @@ $fints = new FinTs(
     FHP_SOFTWARE_VERSION
 );
 $fints->setLogger(new testLogger());
+$fints->initializeDialog();
 $accounts = $fints->getSEPAAccounts();
 
 $fints->end();

--- a/Samples/directDebit.php
+++ b/Samples/directDebit.php
@@ -70,7 +70,7 @@ $fints = new FinTs(
     FHP_SOFTWARE_VERSION
 );
 $fints->setLogger(new testLogger());
-$fints->setTANMechanism(901); //901 for mobileTAN
+$fints->initializeDialog();
 file_put_contents(__DIR__."/tan.txt", "");
 
 $accounts = $fints->getSEPAAccounts();

--- a/Samples/saldo.php
+++ b/Samples/saldo.php
@@ -36,7 +36,7 @@ $fints = new FinTs(
     FHP_SOFTWARE_VERSION
 );
 $fints->setLogger(new testLogger());
-
+$fints->initializeDialog();
 $accounts = $fints->getSEPAAccounts();
 
 $oneAccount = $accounts[0];

--- a/Samples/standingOrderDelete.php
+++ b/Samples/standingOrderDelete.php
@@ -33,6 +33,7 @@ $fints = new FinTs(
     FHP_SOFTWARE_VERSION
 );
 $fints->setLogger(new testLogger());
+$fints->initializeDialog();
 $accounts = $fints->getSEPAAccounts();
 file_put_contents(__DIR__."/tan.txt", "");
 

--- a/Samples/standingOrders.php
+++ b/Samples/standingOrders.php
@@ -33,6 +33,7 @@ $fints = new FinTs(
     FHP_SOFTWARE_VERSION
 );
 $fints->setLogger(new testLogger());
+$fints->initializeDialog();
 $accounts = $fints->getSEPAAccounts();
 
 $orders = $fints->getSEPAStandingOrders($accounts[0]);

--- a/Samples/statement_of_account.php
+++ b/Samples/statement_of_account.php
@@ -41,7 +41,7 @@ $fints->setLogger(new testLogger());
 try {
 
     $fints->initializeDialog();
-	$accounts = $fints->getSEPAAccounts();
+    $accounts = $fints->getSEPAAccounts();
 
     $oneAccount = $accounts[0];
     $from = new \DateTime('2016-01-01');

--- a/Samples/statement_of_account.php
+++ b/Samples/statement_of_account.php
@@ -39,10 +39,9 @@ $fints = new FinTs(
 $fints->setLogger(new testLogger());
 
 try {
-	
-	$fints->setTANMechanism(901); //request available TAN modes with $fints->getVariables();!
-	
-    $accounts = $fints->getSEPAAccounts();
+
+    $fints->initializeDialog();
+	$accounts = $fints->getSEPAAccounts();
 
     $oneAccount = $accounts[0];
     $from = new \DateTime('2016-01-01');

--- a/Samples/transfer.php
+++ b/Samples/transfer.php
@@ -66,7 +66,7 @@ $fints = new FinTs(
 $fints->setLogger(new testLogger());
 $accounts = $fints->getSEPAAccounts();
 
-$fints->setTANMechanism(901); //901 for mobileTAN
+$fints->initializeDialog();
 file_put_contents(__DIR__."/tan.txt", "");
 
 $oneAccount = $accounts[0];

--- a/lib/Fhp/Dialog/Dialog.php
+++ b/lib/Fhp/Dialog/Dialog.php
@@ -398,11 +398,9 @@ class Dialog
 		);
 
 		$options = array();
-		if (null === $tanMechanism) {
-			$options[AbstractMessage::OPT_PINTAN_MECH] = array_keys($this->supportedTanMechanisms);
-		} else {
-			$options[AbstractMessage::OPT_PINTAN_MECH] = array($tanMechanism);
-		}
+		if (!is_null($tanMechanism)) {
+            $options[AbstractMessage::OPT_PINTAN_MECH] = $tanMechanism;
+        }
 
 		$message = new Message(
 			$this->bankCode,
@@ -453,7 +451,7 @@ class Dialog
 	 * @throws FailedRequestException
 	 * @throws \Exception
 	 */
-	public function syncDialog($tanMechanism = null, $tanMediaName = null, \Closure $tanCallback = null)
+	public function syncDialog()
 	{
 		$this->logger->info('');
 		$this->logger->info('SYNC initialize');
@@ -477,13 +475,7 @@ class Dialog
 			$prepare
 		);
 
-		if (null !== $tanMechanism) {
-			$options[AbstractMessage::OPT_PINTAN_MECH] = array($tanMechanism);
-			$encryptedSegments[] = new HKTAN(HKTAN::VERSION, 5, null, $tanMediaName);
-			$encryptedSegments[] = new HKSYN(6);
-		} else {
-			$encryptedSegments[] = new HKSYN(5);
-		}
+        $encryptedSegments[] = new HKSYN(5);
 
 		$syncMsg = new Message(
 			$this->bankCode,
@@ -498,7 +490,7 @@ class Dialog
 
 		#$this->logger->debug('Sending SYNC message:');
 		#$this->logger->debug((string) $syncMsg);
-		$response = $this->sendMessage($syncMsg, $tanMechanism, $tanCallback);
+		$response = $this->sendMessage($syncMsg);
 
 		#$this->checkResponse($response);
 

--- a/lib/Fhp/Dialog/Dialog.php
+++ b/lib/Fhp/Dialog/Dialog.php
@@ -8,6 +8,7 @@ use Fhp\Message\AbstractMessage;
 use Fhp\Message\Message;
 use Fhp\Protocol\BPD;
 use Fhp\Protocol\UPD;
+use Fhp\Response\GetAccounts;
 use Fhp\Response\Initialization;
 use Fhp\Response\Response;
 use Fhp\Response\GetTANRequest;
@@ -381,7 +382,7 @@ class Dialog
 	 * @throws FailedRequestException
 	 * @throws \Exception
 	 */
-	public function initDialog($tanMechanism = null, $tanMediaName = null)
+	public function initDialog($tanMechanism = null, $tanMediaName = null, \Closure $tanCallback = null)
 	{
 		$this->logger->info('');
 		$this->logger->info('DIALOG initialize');
@@ -420,7 +421,7 @@ class Dialog
 		#$this->logger->debug('Sending INIT message:');
 		#$this->logger->debug((string) $message);
 
-		$response = $this->sendMessage($message)->rawResponse;
+		$response = $this->sendMessage($message, $tanMechanism, $tanCallback)->rawResponse;
 
         $parsedMessage = \Fhp\Protocol\Message::parse($response);
         // Update the BPD, as it could differ from the values received via syncDialog
@@ -439,7 +440,7 @@ class Dialog
 
 		$this->logger->info('DIALOG end');
 
-		return $this->dialogId;
+		return $response;
 	}
 
 	/**

--- a/lib/Fhp/Dialog/Dialog.php
+++ b/lib/Fhp/Dialog/Dialog.php
@@ -382,7 +382,7 @@ class Dialog
 	 * @throws FailedRequestException
 	 * @throws \Exception
 	 */
-	public function initDialog($tanMechanism = null, $tanMediaName = null, \Closure $tanCallback = null)
+    public function initDialog($tanMechanism = null, $tanMediaName = null, \Closure $tanCallback = null)
 	{
 		$this->logger->info('');
 		$this->logger->info('DIALOG initialize');
@@ -399,7 +399,7 @@ class Dialog
 		);
 
 		$options = array();
-		if (!is_null($tanMechanism)) {
+        if (!is_null($tanMechanism)) {
             $options[AbstractMessage::OPT_PINTAN_MECH] = $tanMechanism;
         }
 
@@ -421,7 +421,7 @@ class Dialog
 		#$this->logger->debug('Sending INIT message:');
 		#$this->logger->debug((string) $message);
 
-		$response = $this->sendMessage($message, $tanMechanism, $tanCallback)->rawResponse;
+        $response = $this->sendMessage($message, $tanMechanism, $tanCallback)->rawResponse;
 
         $parsedMessage = \Fhp\Protocol\Message::parse($response);
         // Update the BPD, as it could differ from the values received via syncDialog
@@ -440,7 +440,7 @@ class Dialog
 
 		$this->logger->info('DIALOG end');
 
-		return $response;
+        return $response;
 	}
 
 	/**
@@ -452,7 +452,7 @@ class Dialog
 	 * @throws FailedRequestException
 	 * @throws \Exception
 	 */
-	public function syncDialog()
+    public function syncDialog()
 	{
 		$this->logger->info('');
 		$this->logger->info('SYNC initialize');
@@ -491,7 +491,7 @@ class Dialog
 
 		#$this->logger->debug('Sending SYNC message:');
 		#$this->logger->debug((string) $syncMsg);
-		$response = $this->sendMessage($syncMsg);
+        $response = $this->sendMessage($syncMsg);
 
 		#$this->checkResponse($response);
 

--- a/lib/Fhp/FinTs.php
+++ b/lib/Fhp/FinTs.php
@@ -54,8 +54,8 @@ class FinTs extends FinTsInternal
 	protected $systemId = 0;
 	/** @var string */
 	protected $bankName;
-	/** @var Account[] */
-	protected $accounts;
+    /** @var Account[] */
+    protected $accounts;
 	/** @var int */
 	protected $tanMechanism;
 	/** @var Dialog */
@@ -141,11 +141,11 @@ class FinTs extends FinTsInternal
 	{
 	    $this->logger->debug(__CLASS__ . ':' . __FUNCTION__ . ' called');
 
-		$dialog = $this->getDialog();
+        $dialog = $this->getDialog();
 
 		$message = $this->getNewMessage(
 			$dialog,
-			array(new HKSPA(3))
+            array(new HKSPA(3))
 		);
 
 		$this->logger->info('');
@@ -207,7 +207,7 @@ class FinTs extends FinTsInternal
 	{
         $this->logger->debug(__CLASS__ . ':' . __FUNCTION__ . ' called');
 
-		$dialog = $this->getDialog();
+        $dialog = $this->getDialog();
 		$response = $dialog->syncDialog();
 		if ($response->isTANRequest()) {
 			return $response;

--- a/lib/Fhp/FinTsInternal.php
+++ b/lib/Fhp/FinTsInternal.php
@@ -32,8 +32,6 @@ abstract class FinTsInternal
     protected function startDeleteSEPAStandingOrder(SEPAAccount $account, SEPAStandingOrder $order)
     {
         $dialog = $this->getDialog();
-        #$dialog->syncDialog();
-        #$dialog->initDialog();
 
         $hkcdbAccount = new Kti(
             $account->getIban(),
@@ -68,8 +66,6 @@ abstract class FinTsInternal
         $painMessage = $this->clearXML($painMessage);
 
         $dialog = $this->getDialog();
-        #$dialog->syncDialog();
-        #$dialog->initDialog();
 
         $hkcdbAccount = new Kti(
             $account->getIban(),
@@ -217,8 +213,7 @@ abstract class FinTsInternal
                     $to,
                     $touchdown
                 )
-            ),
-            array(AbstractMessage::OPT_PINTAN_MECH => $this->getUsedPinTanMechanism($dialog))
+            )
         );
 
         return $message;

--- a/lib/Fhp/FinTsInternal.php
+++ b/lib/Fhp/FinTsInternal.php
@@ -46,9 +46,6 @@ abstract class FinTsInternal
         $message = $this->getNewMessage($dialog,
             array(
                 new HKCDL(HKCDL::VERSION, 3, $hkcdbAccount, 'urn?:iso?:std?:iso?:20022?:tech?:xsd?:pain.001.001.03', $order),
-            ),
-            array(
-                AbstractMessage::OPT_PINTAN_MECH => $this->getUsedPinTanMechanism($dialog)
             )
         );
 
@@ -85,9 +82,6 @@ abstract class FinTsInternal
         $message = $this->getNewMessage($dialog,
             array(
                 new HKCCS(HKCCS::VERSION, 3, $hkcdbAccount, 'urn?:iso?:std?:iso?:20022?:tech?:xsd?:pain.001.003.03', $painMessage),
-            ),
-            array(
-                AbstractMessage::OPT_PINTAN_MECH => $this->getUsedPinTanMechanism($dialog)
             )
         );
 
@@ -108,11 +102,14 @@ abstract class FinTsInternal
      * @param array $options
      * @return Message
      */
-    protected function getNewMessage(Dialog $dialog, array $segments, array $options)
+    protected function getNewMessage(Dialog $dialog, array $segments, array $options = [])
     {
         // Add an HKTAN Segment if the Bank requires it
         if ($dialog->bpd->tanRequiredForRequest($segments)) {
             $segments[] = $this->createHKTAN(count($segments) + 3);
+        }
+        if (!isset($options[AbstractMessage::OPT_PINTAN_MECH]) && $this->tanMechanism) {
+            $options[AbstractMessage::OPT_PINTAN_MECH] = $this->tanMechanism;
         }
         return new Message(
             $this->bankCode,
@@ -133,7 +130,7 @@ abstract class FinTsInternal
      * @return Dialog
      * @throws \Exception
      */
-    abstract protected function getDialog($sync = true);
+    abstract protected function getDialog();
 
     /**
      * Needed for escaping userdata.
@@ -321,8 +318,7 @@ abstract class FinTsInternal
                     $to,
                     $touchdown
                 )
-            ),
-            array(AbstractMessage::OPT_PINTAN_MECH => $this->getUsedPinTanMechanism($dialog))
+            )
         );
 
         return $message;

--- a/lib/Fhp/Message/Message.php
+++ b/lib/Fhp/Message/Message.php
@@ -102,11 +102,9 @@ class Message extends AbstractMessage
 
         $this->securityReference = !$useEncryption ? 1 : rand(1000000, 9999999);
 
-        if(isset($options[static::OPT_PINTAN_MECH])) {
-            if (!in_array('999', $this->options[static::OPT_PINTAN_MECH])) {
-                $this->profileVersion = SecurityProfile::PROFILE_VERSION_2;
-                $this->securityFunction = $this->options[static::OPT_PINTAN_MECH][0];
-            }
+        if (isset($options[static::OPT_PINTAN_MECH]) && $this->options[static::OPT_PINTAN_MECH] != HNSHK::SECURITY_FUNC_999) {
+            $this->profileVersion = SecurityProfile::PROFILE_VERSION_2;
+            $this->securityFunction = $this->options[static::OPT_PINTAN_MECH];
         }
 
         $this->encryptionEnvelop = new HNVSD(999, '');

--- a/lib/Tests/Fhp/Message/MessageTest.php
+++ b/lib/Tests/Fhp/Message/MessageTest.php
@@ -51,7 +51,7 @@ class MessageTest extends \PHPUnit\Framework\TestCase
         $ktv = new Ktv('123123123', 'sub', $kik);
         $hksal = new HKSAL(HKSAL::VERSION, 3, $ktv, true);
         $options = array(
-            Message::OPT_PINTAN_MECH => array('998')
+            Message::OPT_PINTAN_MECH => 998
         );
 
         $message = new Message(


### PR DESCRIPTION
* Explizite Methode zum Dialog initialisieren
* beim Dialog::sync keine Sicherheitsfunktion verwenden, somit sollte dort auch keine TAN verlang werden,
* pro Dialog eine eindeutige Sicherheitsfunktion verwenden
* getAccounts ohne separaten Dialog::init