### PR TITLE
Include UPD, Dialog-ID and message number in FinTs persisted state

### DIFF
--- a/lib/Fhp/BaseAction.php
+++ b/lib/Fhp/BaseAction.php
@@ -45,6 +45,8 @@ abstract class BaseAction implements \Serializable
     private $error;
 
     /**
+     * NOTE: A common mistake is to call this function directly. Instead, you probably want `serialize($instance)`.
+     *
      * An action can only be serialized *after* it has been executed in case it needs a TAN, i.e. when the result is not
      * present yet.
      * If a sub-class overrides this, it should call the parent function and include it in its result.

--- a/lib/Tests/Fhp/FinTsTestCase.php
+++ b/lib/Tests/Fhp/FinTsTestCase.php
@@ -39,9 +39,6 @@ abstract class FinTsTestCase extends TestCase
     /** @var string[][] Series of tuples of expected request and mock response */
     protected $expectedMessages;
 
-    /** @noinspection PhpLanguageLevelInspection */
-
-    /** @noinspection PhpUndefinedClassInspection */
     protected function setUp(): void
     {
         // We mock rand() for the $randomReference generation in Fhp\Protocol\Message.
@@ -107,9 +104,6 @@ abstract class FinTsTestCase extends TestCase
         return $this->connection;
     }
 
-    /** @noinspection PhpLanguageLevelInspection */
-
-    /** @noinspection PhpUndefinedClassInspection */
     protected function tearDown(): void
     {
         $this->assertAllMessagesSeen();

--- a/lib/Tests/Fhp/Integration/Consors/ConsorsIntegrationTestBase.php
+++ b/lib/Tests/Fhp/Integration/Consors/ConsorsIntegrationTestBase.php
@@ -68,7 +68,6 @@ class ConsorsIntegrationTestBase extends FinTsTestCase
         $persistedInstance = $this->fints->persist();
         $persistedLogin = serialize($login);
         $this->connection->expects($this->once())->method('disconnect');
-        $this->fints->close();
         $this->fints = new FinTsPeer($this->options, $this->credentials, $persistedInstance);
         $this->fints->mockConnection = $this->setUpConnection();
 

--- a/lib/Tests/Fhp/Integration/DKB/DKBIntegrationTestBase.php
+++ b/lib/Tests/Fhp/Integration/DKB/DKBIntegrationTestBase.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Fhp\Integration\DKB;
 
+use Fhp\Model\SEPAAccount;
 use Tests\Fhp\FinTsTestCase;
 
 class DKBIntegrationTestBase extends FinTsTestCase
@@ -49,5 +50,18 @@ class DKBIntegrationTestBase extends FinTsTestCase
         $login = $this->fints->login();
         $login->ensureSuccess();
         $this->assertAllMessagesSeen();
+    }
+
+    /**
+     * @return SEPAAccount
+     */
+    protected function getTestAccount()
+    {
+        $sepaAccount = new SEPAAccount();
+        $sepaAccount->setIban('DExxABCDEFGH1234567890');
+        $sepaAccount->setBic('BYLADEM1001');
+        $sepaAccount->setAccountNumber('1234567890');
+        $sepaAccount->setBlz('12030000');
+        return $sepaAccount;
     }
 }

--- a/lib/Tests/Fhp/Integration/DKB/GetStatementOfAccountTest.php
+++ b/lib/Tests/Fhp/Integration/DKB/GetStatementOfAccountTest.php
@@ -2,14 +2,35 @@
 
 namespace Tests\Fhp\Integration\DKB;
 
-use Fhp\Model\SEPAAccount;
+use Fhp\Action\GetStatementOfAccount;
 use Fhp\Model\StatementOfAccount\Statement;
+use Fhp\Model\StatementOfAccount\StatementOfAccount;
+use Tests\Fhp\FinTsPeer;
 
 class GetStatementOfAccountTest extends DKBIntegrationTestBase
 {
     // Statement request (HKKAZ). Note that DKB's BPD (see InitEndDialogTest) declares only HIKAZSv4 and HIKAZSv5.
     const GET_STATEMENT_REQUEST = "HKKAZ:3:5+1234567890::280:12030000+N+20190901+20190922'";
-    const GET_STATEMENT_RESPONSE = "HIRMG:3:2+3060::Bitte beachten Sie die enthaltenen Warnungen/Hinweise.'HIRMS:4:2:3+0020::Der Auftrag wurde ausgefuhrt.+0020::Die gebuchten Umsatze wurden ubermittelt.'HIRMS:5:2:4+3076::Starke Kundenauthentifizierung nicht notwendig.'HITAN:6:6:4+4++noref+nochallenge+++SomePhone1'HIKAZ:7:5:3+@611@\r\n:20:STARTUMSE\r\n:25:12030000/1234567890\r\n:28C:00000/001\r\n:60F:C190821EUR1234,56\r\n:61:1909030904DR12,00N033NONREF\r\n:86:177?00ONLINE-UEBERWEISUNG?109310?20KREF+HKCCS12345?21SVWZ+323\r\n01000-P111111-33333?22333?23DATUM 02.09.2019, 22.19 UHR?241.TAN 0\r\n12345?30DEUTDEBBXXX?31DExx123412341234123431?32EMPFAENGER ABCDE?3\r\n4997\r\n:62F:C190903EUR1222,56\r\n-\r\n:20:STARTUMSE\r\n:25:12030000/1234567890\r\n:28C:00000/001\r\n:60F:C190903EUR1222,56\r\n:61:1909130914CR123,45N060NONREF\r\n:86:152?00GUTSCHR. UEBERW. DAUERAUFTR?109253?20SVWZ+Irgendein Te\r\nxttt?30DAAEDEDD?31DExx123412341234123417?32Sender Name1\r\n:62F:C190913EUR1345,01\r\n-'";
+    const HIKAZ_CONTENT = "@611@\r\n:20:STARTUMSE\r\n:25:12030000/1234567890\r\n:28C:00000/001\r\n:60F:C190821EUR1234,56\r\n:61:1909030904DR12,00N033NONREF\r\n:86:177?00ONLINE-UEBERWEISUNG?109310?20KREF+HKCCS12345?21SVWZ+323\r\n01000-P111111-33333?22333?23DATUM 02.09.2019, 22.19 UHR?241.TAN 0\r\n12345?30DEUTDEBBXXX?31DExx123412341234123431?32EMPFAENGER ABCDE?3\r\n4997\r\n:62F:C190903EUR1222,56\r\n-\r\n:20:STARTUMSE\r\n:25:12030000/1234567890\r\n:28C:00000/001\r\n:60F:C190903EUR1222,56\r\n:61:1909130914CR123,45N060NONREF\r\n:86:152?00GUTSCHR. UEBERW. DAUERAUFTR?109253?20SVWZ+Irgendein Te\r\nxttt?30DAAEDEDD?31DExx123412341234123417?32Sender Name1\r\n:62F:C190913EUR1345,01\r\n-'";
+    const GET_STATEMENT_RESPONSE = "HIRMG:3:2+3060::Bitte beachten Sie die enthaltenen Warnungen/Hinweise.'HIRMS:4:2:3+0020::Der Auftrag wurde ausgefuhrt.+0020::Die gebuchten Umsatze wurden ubermittelt.'HIRMS:5:2:4+3076::Starke Kundenauthentifizierung nicht notwendig.'HITAN:6:6:4+4++noref+nochallenge+++SomePhone1'HIKAZ:7:5:3+" . self::HIKAZ_CONTENT;
+
+    // Sometimes, DKB wants a TAN.
+    const GET_STATEMENT_RESPONSE_BEFORE_TAN = "HIRMG:3:2+0010::Nachricht entgegengenommen.'HIRMS:4:2:4+0030::Auftrag empfangen - Bitte die empfangene TAN eingeben.(MBT65432100002)'HITAN:5:6:4+4++4567-11-30-17.17.09.654321+Bitte geben Sie die pushTAN ein.+++SomePhone1'";
+    const SEND_TAN_REQUEST = "HNHBK:1:3+000000000425+300+FAKEDIALOGIDabcdefghijklmnopqr+3'HNVSK:998:3+PIN:2+998+1+1::FAKEKUNDENSYSTEMIDabcdefghij+1:20190102:030405+2:2:13:@8@00000000:5:1+280:12030000:test?@user:V:0:0+0'HNVSD:999:1+@206@HNSHK:2:4+PIN:2+921+9999999+1+1+1::FAKEKUNDENSYSTEMIDabcdefghij+1+1:20190102:030405+1:999:1+6:10:19+280:12030000:test?@user:S:0:0'HKTAN:3:6+2++++4567-11-30-17.17.09.654321+N'HNSHA:4:2+9999999++12345:777666''HNHBS:5:1+3'";
+    const SEND_TAN_RESPONSE = "HIRMG:3:2+0010::Nachricht entgegengenommen.'HIRMS:4:2:3+0020::Der Auftrag wurde ausgefuhrt.+0020::Die gebuchten Umsatze wurden ubermittelt.'HITAN:5:6:3+2++4567-11-30-17.17.09.654321'HIKAZ:6:5:3+" . self::HIKAZ_CONTENT;
+
+    /**
+     * @return GetStatementOfAccount
+     * @throws \Throwable
+     */
+    private function runInitialRequest(): GetStatementOfAccount
+    {
+        $getStatement = GetStatementOfAccount::create($this->getTestAccount(),
+            new \DateTime('2019-09-01'), new \DateTime('2019-09-22'), false);
+        $this->fints->execute($getStatement);
+        $getStatement->maybeThrowError();
+        return $getStatement;
+    }
 
     /**
      * @throws \Throwable
@@ -17,18 +38,66 @@ class GetStatementOfAccountTest extends DKBIntegrationTestBase
     public function test_getStatementOfAccount()
     {
         $this->initDialog();
-
-        $sepaAccount = new SEPAAccount();
-        $sepaAccount->setIban('DExxABCDEFGH1234567890');
-        $sepaAccount->setBic('BYLADEM1001');
-        $sepaAccount->setAccountNumber('1234567890');
-        $sepaAccount->setBlz('12030000');
-
         $this->expectMessage(static::GET_STATEMENT_REQUEST, static::GET_STATEMENT_RESPONSE);
-        $getStatement = \Fhp\Action\GetStatementOfAccount::create($sepaAccount, new \DateTime('2019-09-01'), new \DateTime('2019-09-22'), false);
-        $this->fints->execute($getStatement);
-        $statement = $getStatement->getStatement();
+        $getStatement = $this->runInitialRequest();
+        $this->assertFalse($getStatement->needsTan());
+        $this->checkResult($getStatement->getStatement());
+    }
 
+    /**
+     * @param GetStatementOfAccount $getStatement
+     * @throws \Throwable
+     */
+    private function completeWithTan(GetStatementOfAccount $getStatement)
+    {
+        $this->expectMessage(static::SEND_TAN_REQUEST, static::SEND_TAN_RESPONSE);
+        $this->fints->submitTan($getStatement, '777666');
+        $this->assertFalse($getStatement->needsTan());
+        $this->checkResult($getStatement->getStatement());
+    }
+
+    /**
+     * @throws \Throwable
+     */
+    public function test_getStatementOfAccount_withTan()
+    {
+        $this->initDialog();
+
+        $this->expectMessage(static::GET_STATEMENT_REQUEST, static::GET_STATEMENT_RESPONSE_BEFORE_TAN);
+        $getStatement = $this->runInitialRequest();
+        $this->assertTrue($getStatement->needsTan());
+        $this->completeWithTan($getStatement);
+    }
+
+    /**
+     * @throws \Throwable
+     */
+    public function test_getStatementOfAccount_withTan_persist()
+    {
+        $this->initDialog();
+
+        $this->expectMessage(static::GET_STATEMENT_REQUEST, static::GET_STATEMENT_RESPONSE_BEFORE_TAN);
+        $getStatement = $this->runInitialRequest();
+        $this->assertTrue($getStatement->needsTan());
+
+        // Pretend that we close everything and open everything from scratch, as if it were a new PHP session.
+        $persistedInstance = $this->fints->persist();
+        $persistedGetStatement = serialize($getStatement);
+        $this->connection->expects($this->once())->method('disconnect');
+        $this->fints = new FinTsPeer($this->options, $this->credentials, $persistedInstance);
+        $this->fints->mockConnection = $this->setUpConnection();
+        /** @var GetStatementOfAccount $getStatement */
+        $getStatement = unserialize($persistedGetStatement);
+
+        $this->completeWithTan($getStatement);
+    }
+
+    /**
+     * @param StatementOfAccount $statement
+     * @throws \Exception
+     */
+    private function checkResult($statement)
+    {
         $this->assertCount(2, $statement->getStatements());
 
         $statement1 = $statement->getStatements()[0];


### PR DESCRIPTION
This is required with most banks to submit a TAN within the same dialog in which it was requested. In particular, those banks to not require any dialog initialization after re-opening the physical connection when the TAN is available.

This makes GetStatementOfAccount with a TAN work for DKB, add integration test.

See #157 for discussion.
@ampaze fyi