### PR TITLE
Handle response codes 9050/9800 correctly

### DIFF
--- a/lib/Fhp/FinTsNew.php
+++ b/lib/Fhp/FinTsNew.php
@@ -263,6 +263,10 @@ class FinTsNew
             $actionError = $e->extractErrorsForReference($action->getRequestSegmentNumbers());
             if ($actionError !== null) {
                 $action->processError($actionError, $this->bpd, $this->upd);
+                $e->extractError(Rueckmeldungscode::TEILWEISE_FEHLERHAFT); // Drop global error.
+                if ($e->extractError(Rueckmeldungscode::ABGEBROCHEN) !== null) {
+                    $this->forgetDialog();
+                }
             }
             if (!empty($e->getErrors())) {
                 throw $e;

--- a/lib/Fhp/Protocol/ServerException.php
+++ b/lib/Fhp/Protocol/ServerException.php
@@ -114,6 +114,21 @@ class ServerException extends \Exception
     }
 
     /**
+     * @param int $code A Rueckmeldungscode to look for.
+     * @return Rueckmeldung|null The first matching Rueckmeldung, which will have been removed from this instance, or
+     *     null if no match was found.
+     */
+    public function extractError($code)
+    {
+        foreach ($this->errors as $index => $error) {
+            if ($error->rueckmeldungscode === $code) {
+                return array_splice($this->errors, $index, 1)[0];
+            }
+        }
+        return null;
+    }
+
+    /**
      * @return bool True if the {@link Credentials} used to make this request are wrong. If this returns true, the
      *     application should ask the user to re-enter the credentials before making any further requests to the bank.
      */

--- a/lib/Fhp/Segment/HIRMS/Rueckmeldungscode.php
+++ b/lib/Fhp/Segment/HIRMS/Rueckmeldungscode.php
@@ -75,6 +75,16 @@ abstract class Rueckmeldungscode
     const ZUGELASSENE_VERFAHREN = 3920;
 
     /**
+     * In einer Nachricht ist mindestens ein fehlerhafter Auftrag enthalten.
+     */
+    const TEILWEISE_FEHLERHAFT = 9050;
+
+    /**
+     * Kreditinstitutsseitige Beendigung des Dialoges
+     */
+    const ABGEBROCHEN = 9800;
+
+    /**
      * Ihre PIN ist gesperrt.
      */
     const PIN_GESPERRT = 9930;
@@ -116,9 +126,4 @@ abstract class Rueckmeldungscode
      * TAN/Signatur ungültig
      */
     const ZEITUEBERSCHREITUNG_IM_ZWEI_SCHRITT_VERFAHREN = 9951;
-
-    /**
-     * Kreditinstitutsseitige Beendigung des Dialoges.
-     */
-    const ABGEBROCHEN = 9800;
 }


### PR DESCRIPTION
Closes #181

They are global errors that regularly accompany per-action errors without providing more relevant information. Extracting them prevents throwing a ServerException from execute() or submitTan() that only contains these two error codes and no further information. In case of 9800, the bank closed the dialog, so we consider it closed too.