### PR TITLE
Don't call bank for selectTanMode()

### DIFF
--- a/lib/Tests/Fhp/Integration/Consors/ConsorsIntegrationTestBase.php
+++ b/lib/Tests/Fhp/Integration/Consors/ConsorsIntegrationTestBase.php
@@ -42,11 +42,9 @@ class ConsorsIntegrationTestBase extends FinTsTestCase
      */
     protected function initDialog()
     {
-        // We already know the TAN mode, so it will only fetch the BPD (anonymously) to verify it.
+        // We already know the TAN mode (900 below), so it will only fetch the BPD (anonymously) to verify it.
         $this->expectMessage(static::ANONYMOUS_INIT_REQUEST, static::ANONYMOUS_INIT_RESPONSE);
         $this->expectMessage(static::ANONYMOUS_END_REQUEST, static::ANONYMOUS_END_RESPONSE);
-        $this->fints->selectTanMode(900);
-        $this->assertAllMessagesSeen();
 
         // Then when we initialize a dialog, it's going to request a Kundensystem-ID and UPD.
         $this->expectMessage(static::SYNC_REQUEST, static::SYNC_RESPONSE);
@@ -54,6 +52,8 @@ class ConsorsIntegrationTestBase extends FinTsTestCase
 
         // And finally it can initialize the main dialog, but the bank wants a TAN.
         $this->expectMessage(static::LOGIN_REQUEST, static::LOGIN_RESPONSE);
+
+        $this->fints->selectTanMode(900);
         $login = $this->fints->login();
         $login->maybeThrowError();
         $this->assertAllMessagesSeen();

--- a/lib/Tests/Fhp/Integration/DKB/DKBIntegrationTestBase.php
+++ b/lib/Tests/Fhp/Integration/DKB/DKBIntegrationTestBase.php
@@ -37,16 +37,17 @@ class DKBIntegrationTestBase extends FinTsTestCase
      */
     protected function initDialog()
     {
-        // We already know the TAN mode, so it will only fetch the BPD (anonymously) to verify it.
+        // We already know the TAN mode (921 below), so it will only fetch the BPD (anonymously) to verify it.
         $this->expectMessage(static::ANONYMOUS_INIT_REQUEST, static::ANONYMOUS_INIT_RESPONSE);
         $this->expectMessage(static::ANONYMOUS_END_REQUEST, static::ANONYMOUS_END_RESPONSE);
-        $this->fints->selectTanMode(921, 'SomePhone1');
 
         // Then when we initialize a dialog, it's going to request a Kundensystem-ID and UPD.
         $this->expectMessage(static::SYNC_REQUEST, static::SYNC_RESPONSE);
         $this->expectMessage(static::SYNC_END_REQUEST, static::SYNC_END_RESPONSE);
         // And finally it can initialize the main dialog.
         $this->expectMessage(static::INIT_REQUEST, static::INIT_RESPONSE);
+
+        $this->fints->selectTanMode(921, 'SomePhone1');
         $login = $this->fints->login();
         $login->ensureSuccess();
         $this->assertAllMessagesSeen();

--- a/lib/Tests/Fhp/Integration/InitializationErrorTest.php
+++ b/lib/Tests/Fhp/Integration/InitializationErrorTest.php
@@ -22,7 +22,7 @@ class InitializationErrorTest extends FinTsTestCase
         $this->expectException(ServerException::class);
         $this->expectExceptionMessageMatches('/Pflichtfeld nicht gefunden/');
         $this->fints->selectTanMode(921, 'SomePhone1');
-        $this->fints->initDialog();
+        $this->fints->login();
     }
 
     /**
@@ -40,6 +40,6 @@ class InitializationErrorTest extends FinTsTestCase
         $this->expectException(ServerException::class);
         $this->expectExceptionMessageMatches('/Falsche Segmentzusammenstellung/');
         $this->fints->selectTanMode(921, 'SomePhone1');
-        $this->fints->initDialog();
+        $this->fints->login();
     }
 }


### PR DESCRIPTION
Closes #179

Instead allow storing a plain int (the Tan mode's ID) in the $selectedTanMode field and resolve it later (during login(), execute() or submitTan()), when the application expects server requests to happen anyway. This also means that selectTanMode() won't throw exceptions anymore.