### PR TITLE
Replace some isset() and empty() calls with safer alternatives

### DIFF
--- a/lib/Fhp/Action/GetStatementOfAccount.php
+++ b/lib/Fhp/Action/GetStatementOfAccount.php
@@ -63,7 +63,7 @@ class GetStatementOfAccount extends BaseAction
      */
     public static function create(SEPAAccount $account, $from = null, $to = null, $allAccounts = false)
     {
-        if (isset($from) && isset($to) && $from > $to) {
+        if ($from !== null && $to !== null && $from > $to) {
             throw new \InvalidArgumentException('From-date must be before to-date');
         }
 

--- a/lib/Fhp/Action/GetStatementOfAccountXML.php
+++ b/lib/Fhp/Action/GetStatementOfAccountXML.php
@@ -51,7 +51,7 @@ class GetStatementOfAccountXML extends BaseAction
      */
     public static function create(SEPAAccount $account, $from = null, $to = null, ?string $camtURN = null, $allAccounts = false): GetStatementOfAccountXML
     {
-        if (isset($from) && isset($to) && $from > $to) {
+        if ($from !== null && $to !== null && $from > $to) {
             throw new \InvalidArgumentException('From-date must be before to-date');
         }
 

--- a/lib/Fhp/FinTsNew.php
+++ b/lib/Fhp/FinTsNew.php
@@ -142,7 +142,7 @@ class FinTsNew
     public function loadPersistedInstance(string $persistedInstance)
     {
         $unserialized = unserialize($persistedInstance);
-        if (!is_array($unserialized) || empty($unserialized)) {
+        if (!is_array($unserialized) || count($unserialized) === 0) {
             throw new \InvalidArgumentException("Invalid persistedInstance: '$persistedInstance'");
         }
         $version = $unserialized[0];
@@ -216,7 +216,7 @@ class FinTsNew
             $action->processError($e, $this->bpd, $this->upd);
             return;
         }
-        if (empty($requestSegments)) {
+        if (count($requestSegments) === 0) {
             return; // No request needed.
         }
         $this->checkPaginationToken($action, $requestSegments);
@@ -284,7 +284,7 @@ class FinTsNew
                     $this->forgetDialog();
                 }
             }
-            if (!empty($e->getErrors())) {
+            if (count($e->getErrors()) > 0) {
                 throw $e;
             }
             return null;

--- a/lib/Fhp/FinTsOptions.php
+++ b/lib/Fhp/FinTsOptions.php
@@ -58,16 +58,16 @@ class FinTsOptions
         $this->productVersion = trim($this->productVersion);
         $this->bankCode = trim($this->bankCode);
         $this->url = trim($this->url);
-        if (empty($this->productName)) {
+        if (strlen($this->productName) === 0) {
             throw new \InvalidArgumentException('Product name required!');
         }
-        if (empty($this->productVersion)) {
+        if (strlen($this->productVersion) === 0) {
             throw new \InvalidArgumentException('Product version required!');
         }
-        if (empty($this->bankCode)) {
+        if (strlen($this->bankCode) === 0) {
             throw new \InvalidArgumentException('Bank code required!');
         }
-        if (empty($this->url)) {
+        if (strlen($this->url) === 0) {
             throw new \InvalidArgumentException('Server URL required!');
         }
         if ($this->logger === null) {

--- a/lib/Fhp/Protocol/Message.php
+++ b/lib/Fhp/Protocol/Message.php
@@ -124,7 +124,7 @@ class Message
         if (count($matchedSegments) > 1) {
             throw new UnexpectedResponseException("Multiple segments matched $segmentType");
         }
-        return empty($matchedSegments) ? null : $matchedSegments[0];
+        return count($matchedSegments) === 0 ? null : $matchedSegments[0];
     }
 
     /**
@@ -172,7 +172,7 @@ class Message
     public function filterByReferenceSegments($referenceNumbers)
     {
         $result = new Message();
-        if (empty($referenceNumbers)) {
+        if (count($referenceNumbers) === 0) {
             return $result;
         }
         $result->plainSegments = array_filter($this->plainSegments, function ($segment) use ($referenceNumbers) {

--- a/lib/Fhp/Protocol/ServerException.php
+++ b/lib/Fhp/Protocol/ServerException.php
@@ -41,9 +41,9 @@ class ServerException extends \Exception
         $this->requestSegments = $requestSegments;
         $this->request = $request;
         $this->response = $response;
-        $errorsStr = empty($errors) ? '' : "FinTS errors:\n" . implode("\n", $errors);
-        $warningsStr = empty($warnings) ? '' : "FinTS warnings:\n" . implode("\n", $warnings);
-        $segmentsStr = empty($requestSegments) ? '' : "Request segments:\n" . implode("\n", $requestSegments);
+        $errorsStr = count($errors) === 0 ? '' : "FinTS errors:\n" . implode("\n", $errors);
+        $warningsStr = count($warnings) === 0 ? '' : "FinTS warnings:\n" . implode("\n", $warnings);
+        $segmentsStr = count($requestSegments) === 0 ? '' : "Request segments:\n" . implode("\n", $requestSegments);
         parent::__construct(implode("\n", array_filter([$errorsStr, $warningsStr, $segmentsStr])));
     }
 
@@ -56,14 +56,14 @@ class ServerException extends \Exception
      */
     public function extractErrorsForReference($referenceNumbers)
     {
-        if (empty($referenceNumbers)) {
+        if (count($referenceNumbers) === 0) {
             return null;
         }
         $errors = array_filter($this->errors, function ($error) use ($referenceNumbers) {
             /* @var Rueckmeldung $error */
             return in_array($error->referenceSegment, $referenceNumbers);
         });
-        if (empty($errors)) {
+        if (count($errors) === 0) {
             return null;
         }
         $warnings = array_filter($this->warnings, function ($error) use ($referenceNumbers) {
@@ -194,7 +194,7 @@ class ServerException extends \Exception
                 }
             }
         }
-        if (!empty($errors)) {
+        if (count($errors) > 0) {
             throw new ServerException($errors, $warnings, $requestSegments, $request, $response);
         }
     }

--- a/lib/Fhp/Protocol/ServerException.php
+++ b/lib/Fhp/Protocol/ServerException.php
@@ -183,9 +183,9 @@ class ServerException extends \Exception
                 $rueckmeldung->referenceSegment = $referenceSegment;
                 if (Rueckmeldungscode::isError($rueckmeldung->rueckmeldungscode)) {
                     $errors[] = $rueckmeldung;
-                    if (isset($referenceSegment)) {
+                    if ($referenceSegment !== null) {
                         $requestSegment = $request->findSegmentByNumber($referenceSegment);
-                        if (isset($requestSegment)) {
+                        if ($requestSegment !== null) {
                             $requestSegments[] = $requestSegment;
                         }
                     }

--- a/lib/Fhp/Segment/BaseDeg.php
+++ b/lib/Fhp/Segment/BaseDeg.php
@@ -15,14 +15,14 @@ abstract class BaseDeg implements \Serializable
      * Reference to the descriptor for this type of segment.
      * @var DegDescriptor|null
      */
-    private $descriptor;
+    private $descriptor = null;
 
     /**
      * @return DegDescriptor The descriptor for this Deg type.
      */
     public function getDescriptor()
     {
-        if (!isset($this->descriptor)) {
+        if ($this->descriptor === null) {
             $this->descriptor = DegDescriptor::get(static::class);
         }
         return $this->descriptor;

--- a/lib/Fhp/Segment/BaseDescriptor.php
+++ b/lib/Fhp/Segment/BaseDescriptor.php
@@ -62,7 +62,7 @@ abstract class BaseDescriptor
             $descriptor = new ElementDescriptor();
             $descriptor->field = $property->getName();
             $type = static::getVarAnnotation($docComment);
-            if (empty($type)) {
+            if ($type === null) {
                 throw new \InvalidArgumentException("Need type on property $property");
             }
             $maxCount = static::getIntAnnotation('Max', $docComment);
@@ -87,7 +87,7 @@ abstract class BaseDescriptor
             $descriptor->type = static::resolveType($type, $property->getDeclaringClass());
             $this->elements[$index] = $descriptor;
         }
-        if (empty($this->elements)) {
+        if (count($this->elements) === 0) {
             throw new \InvalidArgumentException("No fields found in $clazz->name");
         }
         ksort($this->elements); // Make sure elements are parsed in wire-format order.

--- a/lib/Fhp/Segment/BaseSegment.php
+++ b/lib/Fhp/Segment/BaseSegment.php
@@ -17,7 +17,7 @@ abstract class BaseSegment implements SegmentInterface, \Serializable
      * Reference to the descriptor for this type of segment.
      * @var SegmentDescriptor|null
      */
-    private $descriptor;
+    private $descriptor = null;
 
     /**
      * @var Segmentkopf
@@ -29,7 +29,7 @@ abstract class BaseSegment implements SegmentInterface, \Serializable
      */
     public function getDescriptor()
     {
-        if (!isset($this->descriptor)) {
+        if ($this->descriptor === null) {
             $this->descriptor = SegmentDescriptor::get(static::class);
         }
         return $this->descriptor;

--- a/lib/Fhp/Segment/CAZ/HKCAZv1.php
+++ b/lib/Fhp/Segment/CAZ/HKCAZv1.php
@@ -36,8 +36,8 @@ class HKCAZv1 extends BaseSegment
         $result->kontoverbindungInternational = $kti;
         $result->unterstuetzteCamtMessages = $unterstuetzteCamtMessages;
         $result->alleKonten = $alleKonten;
-        $result->vonDatum = isset($vonDatum) ? $vonDatum->format('Ymd') : null;
-        $result->bisDatum = isset($bisDatum) ? $bisDatum->format('Ymd') : null;
+        $result->vonDatum = $vonDatum === null ? null : $vonDatum->format('Ymd');
+        $result->bisDatum = $bisDatum === null ? null : $bisDatum->format('Ymd');
         $result->aufsetzpunkt = $aufsetzpunkt;
 
         return $result;

--- a/lib/Fhp/Segment/DegDescriptor.php
+++ b/lib/Fhp/Segment/DegDescriptor.php
@@ -9,7 +9,7 @@ namespace Fhp\Segment;
 class DegDescriptor extends BaseDescriptor
 {
     /** @var DegDescriptor[] */
-    private static $descriptors;
+    private static $descriptors = [];
 
     /**
      * @param string $class The name of a sub-class of {@link BaseDeg}.
@@ -17,7 +17,7 @@ class DegDescriptor extends BaseDescriptor
      */
     public static function get($class)
     {
-        if (!isset(static::$descriptors[$class])) {
+        if (!array_key_exists($class, static::$descriptors)) {
             static::$descriptors[$class] = new DegDescriptor($class);
         }
         return static::$descriptors[$class];

--- a/lib/Fhp/Segment/HIRMS/FindRueckmeldungTrait.php
+++ b/lib/Fhp/Segment/HIRMS/FindRueckmeldungTrait.php
@@ -20,6 +20,6 @@ trait FindRueckmeldungTrait
         if (count($matches) > 1) {
             throw new \InvalidArgumentException("Unexpectedly multiple matches for Rueckmeldungscode $code");
         }
-        return empty($matches) ? null : $matches[0];
+        return count($matches) === 0 ? null : $matches[0];
     }
 }

--- a/lib/Fhp/Segment/HIRMS/Rueckmeldung.php
+++ b/lib/Fhp/Segment/HIRMS/Rueckmeldung.php
@@ -39,7 +39,7 @@ class Rueckmeldung extends BaseDeg
         if ($this->bezugsdatenelement !== null) {
             $result .= " (wrt DE $this->bezugsdatenelement)";
         }
-        if (!empty($this->rueckmeldungsparameter)) {
+        if ($this->rueckmeldungsparameter !== null && count($this->rueckmeldungsparameter) > 0) {
             $result .= ' [' . implode(', ', $this->rueckmeldungsparameter) . ']';
         }
         return $result;

--- a/lib/Fhp/Segment/HIRMS/Rueckmeldung.php
+++ b/lib/Fhp/Segment/HIRMS/Rueckmeldung.php
@@ -34,9 +34,9 @@ class Rueckmeldung extends BaseDeg
 
     public function __toString()
     {
-        $referenceSegment = isset($this->referenceSegment) ? "wrt seg $this->referenceSegment" : 'global';
+        $referenceSegment = $this->referenceSegment === null ? 'global' : "wrt seg $this->referenceSegment";
         $result = "$this->rueckmeldungscode ($referenceSegment): $this->rueckmeldungstext";
-        if (isset($this->bezugsdatenelement)) {
+        if ($this->bezugsdatenelement !== null) {
             $result .= " (wrt DE $this->bezugsdatenelement)";
         }
         if (!empty($this->rueckmeldungsparameter)) {

--- a/lib/Fhp/Segment/KAZ/HKKAZv4.php
+++ b/lib/Fhp/Segment/KAZ/HKKAZv4.php
@@ -37,8 +37,8 @@ class HKKAZv4 extends BaseSegment
     {
         $result = HKKAZv4::createEmpty();
         $result->kontoverbindungAuftraggeber = $kto;
-        $result->vonDatum = isset($vonDatum) ? $vonDatum->format('Ymd') : null;
-        $result->bisDatum = isset($bisDatum) ? $bisDatum->format('Ymd') : null;
+        $result->vonDatum = $vonDatum === null ? null : $vonDatum->format('Ymd');
+        $result->bisDatum = $bisDatum === null ? null : $bisDatum->format('Ymd');
         $result->aufsetzpunkt = $aufsetzpunkt;
         return $result;
     }

--- a/lib/Fhp/Segment/KAZ/HKKAZv5.php
+++ b/lib/Fhp/Segment/KAZ/HKKAZv5.php
@@ -39,8 +39,8 @@ class HKKAZv5 extends BaseSegment
         $result = HKKAZv5::createEmpty();
         $result->kontoverbindungAuftraggeber = $ktv;
         $result->alleKonten = $alleKonten;
-        $result->vonDatum = isset($vonDatum) ? $vonDatum->format('Ymd') : null;
-        $result->bisDatum = isset($bisDatum) ? $bisDatum->format('Ymd') : null;
+        $result->vonDatum = $vonDatum === null ? null : $vonDatum->format('Ymd');
+        $result->bisDatum = $bisDatum === null ? null : $bisDatum->format('Ymd');
         $result->aufsetzpunkt = $aufsetzpunkt;
         return $result;
     }

--- a/lib/Fhp/Segment/KAZ/HKKAZv6.php
+++ b/lib/Fhp/Segment/KAZ/HKKAZv6.php
@@ -38,8 +38,8 @@ class HKKAZv6 extends BaseSegment
         $result = HKKAZv6::createEmpty();
         $result->kontoverbindungAuftraggeber = $ktv;
         $result->alleKonten = $alleKonten;
-        $result->vonDatum = isset($vonDatum) ? $vonDatum->format('Ymd') : null;
-        $result->bisDatum = isset($bisDatum) ? $bisDatum->format('Ymd') : null;
+        $result->vonDatum = $vonDatum === null ? null : $vonDatum->format('Ymd');
+        $result->bisDatum = $bisDatum === null ? null : $bisDatum->format('Ymd');
         $result->aufsetzpunkt = $aufsetzpunkt;
         return $result;
     }

--- a/lib/Fhp/Segment/KAZ/HKKAZv7.php
+++ b/lib/Fhp/Segment/KAZ/HKKAZv7.php
@@ -38,8 +38,8 @@ class HKKAZv7 extends BaseSegment
         $result = HKKAZv7::createEmpty();
         $result->kontoverbindungInternational = $kti;
         $result->alleKonten = $alleKonten;
-        $result->vonDatum = isset($vonDatum) ? $vonDatum->format('Ymd') : null;
-        $result->bisDatum = isset($bisDatum) ? $bisDatum->format('Ymd') : null;
+        $result->vonDatum = $vonDatum === null  ? null : $vonDatum->format('Ymd');
+        $result->bisDatum = $bisDatum === null  ? null : $bisDatum->format('Ymd');
         $result->aufsetzpunkt = $aufsetzpunkt;
         return $result;
     }

--- a/lib/Fhp/Segment/SegmentDescriptor.php
+++ b/lib/Fhp/Segment/SegmentDescriptor.php
@@ -9,7 +9,7 @@ namespace Fhp\Segment;
 class SegmentDescriptor extends BaseDescriptor
 {
     /** @var SegmentDescriptor[] */
-    private static $descriptors;
+    private static $descriptors = [];
 
     /**
      * @param string $class The name of a sub-class of {@link BaseSegment}.
@@ -17,7 +17,7 @@ class SegmentDescriptor extends BaseDescriptor
      */
     public static function get($class)
     {
-        if (!isset(static::$descriptors[$class])) {
+        if (!array_key_exists($class, static::$descriptors)) {
             static::$descriptors[$class] = new SegmentDescriptor($class);
         }
         return static::$descriptors[$class];

--- a/lib/Fhp/Syntax/Parser.php
+++ b/lib/Fhp/Syntax/Parser.php
@@ -47,7 +47,7 @@ abstract class Parser
      */
     public static function splitEscapedString($delimiter, $str, $trailingDelimiter = false)
     {
-        if (empty($str)) {
+        if (strlen($str) === 0) {
             return [];
         }
         // Since most of the $delimiters used in FinTs are also special characters in regexes, we need to escape.
@@ -171,7 +171,6 @@ abstract class Parser
 
         $delimiterPos = strpos($rawValue, Delimiter::BINARY, 1);
         if (
-            empty($rawValue) ||
             substr($rawValue, 0, 1) !== Delimiter::BINARY ||
             $delimiterPos === false
         ) {
@@ -362,7 +361,7 @@ abstract class Parser
         return new AnonymousSegment(
             Segmentkopf::parse(array_shift($rawElements)),
             array_map(function ($rawElement) {
-                if (empty($rawElement)) {
+                if (strlen($rawElement) === 0) {
                     return null;
                 }
                 $subElements = static::splitEscapedString(Delimiter::GROUP, $rawElement);
@@ -384,7 +383,7 @@ abstract class Parser
         }
         $rawSegment = substr($rawSegment, 0, -1); // Strip segment delimiter at the end.
         $rawElements = static::splitEscapedString(Delimiter::ELEMENT, $rawSegment);
-        if (empty($rawElements)) {
+        if (count($rawElements) === 0) {
             throw new \InvalidArgumentException("Invalid segment: $rawSegment");
         }
         return $rawElements;
@@ -450,7 +449,7 @@ abstract class Parser
      */
     public static function parseSegments($rawSegments)
     {
-        if (empty($rawSegments)) {
+        if (strlen($rawSegments) === 0) {
             return [];
         }
         $rawSegments = static::splitEscapedString(Delimiter::SEGMENT, $rawSegments, true);
@@ -464,7 +463,7 @@ abstract class Parser
      */
     public static function parseRawSegments($rawSegments)
     {
-        if (empty($rawSegments)) {
+        if (strlen($rawSegments) === 0) {
             return [];
         }
         $rawSegments = static::splitEscapedString(Delimiter::SEGMENT, $rawSegments, true);

--- a/lib/Fhp/Syntax/Parser.php
+++ b/lib/Fhp/Syntax/Parser.php
@@ -242,7 +242,7 @@ abstract class Parser
 
             // Skip optional single elements that are not present. Note that for elements with multiple fields we cannot
             // just skip because here we would only detect whether the first field is empty or not.
-            if ($isSingleField && (!isset($rawElements[$offset]) || $rawElements[$offset] === '')) {
+            if ($isSingleField && (!array_key_exists($offset, $rawElements) || $rawElements[$offset] === '')) {
                 if ($elementDescriptor->optional) {
                     ++$offset;
                     continue;
@@ -317,7 +317,7 @@ abstract class Parser
         }
         // The iteration order guarantees that $index is strictly monotonically increasing, but there can be gaps.
         foreach ($descriptor->elements as $index => $elementDescriptor) {
-            if (!isset($rawElements[$index]) || $rawElements[$index] === '') {
+            if (!array_key_exists($index, $rawElements) || $rawElements[$index] === '') {
                 if ($elementDescriptor->optional) {
                     continue;
                 }

--- a/lib/Fhp/Syntax/Serializer.php
+++ b/lib/Fhp/Syntax/Serializer.php
@@ -103,7 +103,7 @@ abstract class Serializer
             }
             $elementDescriptor = $descriptor->elements[$index];
             $value = $obj === null ? null : $obj->{$elementDescriptor->field};
-            if (isset($serializedElements[$index])) {
+            if (array_key_exists($index, $serializedElements)) {
                 throw new \AssertionError("Duplicate index $index");
             }
             if ($elementDescriptor->repeated === 0) {

--- a/lib/Tests/Fhp/FinTsTestCase.php
+++ b/lib/Tests/Fhp/FinTsTestCase.php
@@ -74,7 +74,7 @@ abstract class FinTsTestCase extends TestCase
             list($expectedRequest, $mockResponse) = array_shift($this->expectedMessages);
 
             // Check that the request matches the expectation.
-            if (!empty($expectedRequest) && strpos($expectedRequest, 'HNHBK') !== 0) {
+            if (strlen($expectedRequest) > 0 && strpos($expectedRequest, 'HNHBK') !== 0) {
                 // The expected request is just the inner part, so we need to unwrap the actual request. This is done in
                 // in a quick and hacky way, which slices everything from HNSHK's terminating delimiter to the start of
                 // HNSHA.

--- a/lib/Tests/Fhp/SanitizingCLILogger.php
+++ b/lib/Tests/Fhp/SanitizingCLILogger.php
@@ -47,12 +47,9 @@ class SanitizingCLILogger extends \Psr\Log\AbstractLogger
         $this->needles = array_merge($this->needles, static::computeNeedles($sensitiveMaterial));
     }
 
-    /** @noinspection PhpLanguageLevelInspection */
-
-    /** @noinspection PhpUndefinedClassInspection */
     public function log($level, $message, array $context = []): void
     {
-        $message .= empty($context) ? '' : ' ' . implode(', ', $context);
+        $message .= count($context) === 0 ? '' : ' ' . implode(', ', $context);
         $sanitizedMessage = static::sanitizeForLogging($message, $this->needles);
         echo "$level: $sanitizedMessage\n";
     }


### PR DESCRIPTION
See also https://dev.to/aleksikauppila/using-isset-and-empty-hurts-your-code-aaa and the two commit messages. I'm replacing mostly in the newer code that I authored, where I can be sure that the replacement is equivalent.

@ampaze @fbett @nemiah Any opinions from PHP experts? It just seems to me that silently swallowing typos and removed/renamed variables isn't a good idea. Maybe we want to replace occurrences in the remainder of the codebase as well.