### PR TITLE
Add validation to Kik/Kti

### DIFF
--- a/lib/Fhp/Segment/Common/Kik.php
+++ b/lib/Fhp/Segment/Common/Kik.php
@@ -19,6 +19,15 @@ class Kik extends BaseDeg
     /** @var string|null Max length: 30 (Mandatory/absent depending on the country) */
     public $kreditinstitutscode;
 
+    /** {@inheritdoc} */
+    public function validate()
+    {
+        parent::validate();
+        if ($this->laenderkennzeichen === self::DEFAULT_COUNTRY_CODE && $this->kreditinstitutscode === null) {
+            throw new \InvalidArgumentException('Kik.kreditinstitutscode is mandatory for German banks (BLZ)');
+        }
+    }
+
     /**
      * @param string $kreditinstitutscode
      * @return Kik

--- a/lib/Fhp/Segment/Common/Kti.php
+++ b/lib/Fhp/Segment/Common/Kti.php
@@ -27,6 +27,21 @@ class Kti extends BaseDeg
     /** @var Kik|null */
     public $kreditinstitutskennung;
 
+    /** {@inheritdoc} */
+    public function validate()
+    {
+        parent::validate();
+        if ($this->iban !== null) {
+            if ($this->bic == null) {
+                throw new \InvalidArgumentException('Kti cannot have IBAN without BIC');
+            }
+        } else {
+            if ($this->kontonummer === null || $this->kreditinstitutskennung === null) {
+                throw new \InvalidArgumentException('Kti must have IBAN+BIC or Kontonummer+Kik or both');
+            }
+        }
+    }
+
     /**
      * @param string $iban
      * @param string $bic

--- a/lib/Tests/Fhp/Segment/HKCCSTest.php
+++ b/lib/Tests/Fhp/Segment/HKCCSTest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Tests\Fhp\Segment;
+
+use Fhp\Segment\CCS\HKCCSv1;
+use PHPUnit\Framework\TestCase;
+
+class HKCCSTest extends TestCase
+{
+    // This lacks a bank code (BLZ) after the 280, so the Kik is incomplete.
+    const INVALID_HKCCS = "HKCCS:3:1+<PRIVAT______________>:GENODEM1GLS:::280+urn?:iso?:std?:iso?:20022?:tech?:xsd?:pain.001.001.03+@1@0'";
+
+    public function test_validate_HBCI22_example1()
+    {
+        $parsed = HKCCSv1::parse(utf8_decode(static::INVALID_HKCCS));
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('kreditinstitutscode');
+        $parsed->validate();
+    }
+}


### PR DESCRIPTION
Matches the specification. Not all banks require a BIC, but the specification does, and banks that don't only respond with cryptic error messages, so it's easier for users if validation fails early with a clear message.