### PR TITLE
Move @param and @return information to PHP type hints

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -22,6 +22,8 @@ return PhpCsFixer\Config::create()
         'phpdoc_align' => null, // Don't add spaces within phpDoc just to make parameter names / descriptions align.
         'phpdoc_annotation_without_dot' => null, // Allow terminating dot on @param and such.
         'phpdoc_no_alias_tag' => null, // Allow @link in addition to @see.
+        'phpdoc_to_param_type' => true,
+        'phpdoc_to_return_type' => true,
         'phpdoc_separation' => null, // Don't put blank line between @params, @throws and @return.
         'phpdoc_summary' => null, // Don't force terminating dot on the first line.
         'no_superfluous_phpdoc_tags' => null, // Don't remove @param tags just because their type is clear from the signature.

--- a/.php_cs
+++ b/.php_cs
@@ -22,8 +22,6 @@ return PhpCsFixer\Config::create()
         'phpdoc_align' => null, // Don't add spaces within phpDoc just to make parameter names / descriptions align.
         'phpdoc_annotation_without_dot' => null, // Allow terminating dot on @param and such.
         'phpdoc_no_alias_tag' => null, // Allow @link in addition to @see.
-        'phpdoc_to_param_type' => true,
-        'phpdoc_to_return_type' => true,
         'phpdoc_separation' => null, // Don't put blank line between @params, @throws and @return.
         'phpdoc_summary' => null, // Don't force terminating dot on the first line.
         'no_superfluous_phpdoc_tags' => null, // Don't remove @param tags just because their type is clear from the signature.

--- a/.php_cs
+++ b/.php_cs
@@ -24,6 +24,5 @@ return PhpCsFixer\Config::create()
         'phpdoc_no_alias_tag' => null, // Allow @link in addition to @see.
         'phpdoc_separation' => null, // Don't put blank line between @params, @throws and @return.
         'phpdoc_summary' => null, // Don't force terminating dot on the first line.
-        'no_superfluous_phpdoc_tags' => null, // Don't remove @param tags just because their type is clear from the signature.
     ])
     ->setFinder($finder);

--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,6 @@
       "@cs"
     ],
     "cs": "php-cs-fixer fix -v --diff --dry-run",
-    "cs-fix": "php-cs-fixer fix -v --diff --allow-risky=yes"
+    "cs-fix": "php-cs-fixer fix -v --diff"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,6 @@
       "@cs"
     ],
     "cs": "php-cs-fixer fix -v --diff --dry-run",
-    "cs-fix": "php-cs-fixer fix -v --diff"
+    "cs-fix": "php-cs-fixer fix -v --diff --allow-risky=yes"
   }
 }

--- a/lib/Fhp/Action/GetSEPAAccounts.php
+++ b/lib/Fhp/Action/GetSEPAAccounts.php
@@ -4,6 +4,9 @@ namespace Fhp\Action;
 
 use Fhp\BaseAction;
 use Fhp\Model\SEPAAccount;
+use Fhp\Protocol\BPD;
+use Fhp\Protocol\Message;
+use Fhp\Protocol\UPD;
 use Fhp\Segment\BaseSegment;
 use Fhp\Segment\Common\Ktz;
 use Fhp\Segment\SPA\HISPA;
@@ -44,7 +47,7 @@ class GetSEPAAccounts extends BaseAction
     }
 
     /** {@inheritdoc} */
-    public function createRequest($bpd, $upd)
+    public function createRequest(BPD $bpd, UPD $upd)
     {
         /** @var BaseSegment $hispas */
         $hispas = $bpd->requireLatestSupportedParameters('HISPAS');
@@ -59,7 +62,7 @@ class GetSEPAAccounts extends BaseAction
     }
 
     /** {@inheritdoc} */
-    public function processResponse($response)
+    public function processResponse(Message $response)
     {
         parent::processResponse($response);
         /** @var HISPA $hispa */

--- a/lib/Fhp/Action/GetSEPAAccounts.php
+++ b/lib/Fhp/Action/GetSEPAAccounts.php
@@ -28,7 +28,7 @@ class GetSEPAAccounts extends BaseAction
     /**
      * @return GetSEPAAccounts A new action instance.
      */
-    public static function create()
+    public static function create(): GetSEPAAccounts
     {
         return new GetSEPAAccounts();
     }

--- a/lib/Fhp/Action/GetSEPAAccounts.php
+++ b/lib/Fhp/Action/GetSEPAAccounts.php
@@ -47,7 +47,7 @@ class GetSEPAAccounts extends BaseAction
     }
 
     /** {@inheritdoc} */
-    public function createRequest(BPD $bpd, UPD $upd)
+    public function createRequest(BPD $bpd, ?UPD $upd)
     {
         /** @var BaseSegment $hispas */
         $hispas = $bpd->requireLatestSupportedParameters('HISPAS');

--- a/lib/Fhp/Action/GetSEPADirectDebitParameters.php
+++ b/lib/Fhp/Action/GetSEPADirectDebitParameters.php
@@ -3,6 +3,8 @@
 namespace Fhp\Action;
 
 use Fhp\BaseAction;
+use Fhp\Protocol\BPD;
+use Fhp\Protocol\UPD;
 use Fhp\Segment\DME\HIDXES;
 use Fhp\Segment\DME\MinimaleVorlaufzeitSEPALastschrift;
 
@@ -43,7 +45,7 @@ class GetSEPADirectDebitParameters extends BaseAction
     }
 
     /** {@inheritdoc} */
-    public function createRequest($bpd, $upd)
+    public function createRequest(BPD $bpd, ?UPD $upd)
     {
         $type = $this->singleDirectDebit ? 'HIDSES' : 'HIDMES';
 

--- a/lib/Fhp/Action/GetStatementOfAccount.php
+++ b/lib/Fhp/Action/GetStatementOfAccount.php
@@ -122,7 +122,7 @@ class GetStatementOfAccount extends BaseAction
     }
 
     /** {@inheritdoc} */
-    public function createRequest(BPD $bpd, UPD $upd)
+    public function createRequest(BPD $bpd, ?UPD $upd)
     {
         $this->bankName = $bpd->getBankName();
 

--- a/lib/Fhp/Action/GetStatementOfAccount.php
+++ b/lib/Fhp/Action/GetStatementOfAccount.php
@@ -9,7 +9,10 @@ use Fhp\MT940\Dialect\PostbankMT940;
 use Fhp\MT940\Dialect\SpardaMT940;
 use Fhp\MT940\MT940;
 use Fhp\MT940\MT940Exception;
+use Fhp\Protocol\BPD;
+use Fhp\Protocol\Message;
 use Fhp\Protocol\UnexpectedResponseException;
+use Fhp\Protocol\UPD;
 use Fhp\Segment\Common\Kti;
 use Fhp\Segment\Common\Kto;
 use Fhp\Segment\Common\KtvV3;
@@ -75,7 +78,7 @@ class GetStatementOfAccount extends BaseAction
         return $result;
     }
 
-    public function serialize()
+    public function serialize(): string
     {
         return serialize([parent::serialize(), $this->bankName]);
     }
@@ -119,7 +122,7 @@ class GetStatementOfAccount extends BaseAction
     }
 
     /** {@inheritdoc} */
-    public function createRequest($bpd, $upd)
+    public function createRequest(BPD $bpd, UPD $upd)
     {
         $this->bankName = $bpd->getBankName();
 
@@ -143,7 +146,7 @@ class GetStatementOfAccount extends BaseAction
     }
 
     /** {@inheritdoc} */
-    public function processResponse($response)
+    public function processResponse(Message $response)
     {
         parent::processResponse($response);
 

--- a/lib/Fhp/Action/GetStatementOfAccount.php
+++ b/lib/Fhp/Action/GetStatementOfAccount.php
@@ -61,7 +61,7 @@ class GetStatementOfAccount extends BaseAction
      *     pass one of the accounts into $account, though.
      * @return GetStatementOfAccount A new action instance.
      */
-    public static function create(SEPAAccount $account, $from = null, $to = null, $allAccounts = false)
+    public static function create(SEPAAccount $account, ?\DateTime $from = null, ?\DateTime $to = null, bool $allAccounts = false): GetStatementOfAccount
     {
         if ($from !== null && $to !== null && $from > $to) {
             throw new \InvalidArgumentException('From-date must be before to-date');

--- a/lib/Fhp/Action/GetStatementOfAccountXML.php
+++ b/lib/Fhp/Action/GetStatementOfAccountXML.php
@@ -78,7 +78,7 @@ class GetStatementOfAccountXML extends BaseAction
     }
 
     /** {@inheritdoc} */
-    public function createRequest(BPD $bpd, UPD $upd)
+    public function createRequest(BPD $bpd, ?UPD $upd)
     {
         if (!$upd->isRequestSupportedForAccount($this->account, 'HKCAZ')) {
             throw new UnsupportedException('The bank (or the given account/user combination) does not allow this type of request.');

--- a/lib/Fhp/Action/GetStatementOfAccountXML.php
+++ b/lib/Fhp/Action/GetStatementOfAccountXML.php
@@ -6,7 +6,10 @@ namespace Fhp\Action;
 
 use Fhp\BaseAction;
 use Fhp\Model\SEPAAccount;
+use Fhp\Protocol\BPD;
+use Fhp\Protocol\Message;
 use Fhp\Protocol\UnexpectedResponseException;
+use Fhp\Protocol\UPD;
 use Fhp\Segment\CAZ\HICAZSv1;
 use Fhp\Segment\CAZ\HICAZv1;
 use Fhp\Segment\CAZ\HKCAZv1;
@@ -75,7 +78,7 @@ class GetStatementOfAccountXML extends BaseAction
     }
 
     /** {@inheritdoc} */
-    public function createRequest($bpd, $upd)
+    public function createRequest(BPD $bpd, UPD $upd)
     {
         if (!$upd->isRequestSupportedForAccount($this->account, 'HKCAZ')) {
             throw new UnsupportedException('The bank (or the given account/user combination) does not allow this type of request.');
@@ -84,7 +87,6 @@ class GetStatementOfAccountXML extends BaseAction
         /** @var HICAZSv1 $hicazs */
         $hicazs = $bpd->requireLatestSupportedParameters('HICAZS');
         $supportedCamtURNs = $hicazs->getParameter()->getUnterstuetzteCamtMessages()->camtDescriptor;
-        $camtURNs = [];
         if (is_null($this->camtURN)) {
             $camtURNs = $supportedCamtURNs;
         } elseif (!in_array($this->camtURN, $supportedCamtURNs)) {
@@ -106,7 +108,7 @@ class GetStatementOfAccountXML extends BaseAction
     }
 
     /** {@inheritdoc} */
-    public function processResponse($response)
+    public function processResponse(Message $response)
     {
         parent::processResponse($response);
 

--- a/lib/Fhp/Action/GetStatementOfAccountXML.php
+++ b/lib/Fhp/Action/GetStatementOfAccountXML.php
@@ -49,7 +49,7 @@ class GetStatementOfAccountXML extends BaseAction
      *     pass one of the accounts into $account, though.
      * @return GetStatementOfAccountXML A new action instance.
      */
-    public static function create(SEPAAccount $account, $from = null, $to = null, ?string $camtURN = null, $allAccounts = false): GetStatementOfAccountXML
+    public static function create(SEPAAccount $account, ?\DateTime $from = null, ?\DateTime $to = null, ?string $camtURN = null, bool $allAccounts = false): GetStatementOfAccountXML
     {
         if ($from !== null && $to !== null && $from > $to) {
             throw new \InvalidArgumentException('From-date must be before to-date');

--- a/lib/Fhp/Action/SendSEPADirectDebit.php
+++ b/lib/Fhp/Action/SendSEPADirectDebit.php
@@ -5,6 +5,8 @@ namespace Fhp\Action;
 use Fhp\BaseAction;
 use Fhp\DataTypes\Bin;
 use Fhp\Model\SEPAAccount;
+use Fhp\Protocol\BPD;
+use Fhp\Protocol\UPD;
 use Fhp\Segment\BaseSegment;
 use Fhp\Segment\Common\Btg;
 use Fhp\Segment\Common\Kti;
@@ -55,7 +57,7 @@ class SendSEPADirectDebit extends BaseAction
         return $result;
     }
 
-    public function createRequest($bpd, $upd)
+    public function createRequest(BPD $bpd, ?UPD $upd)
     {
         $type = $this->singleDirectDebit ? 'S' : 'M';
 

--- a/lib/Fhp/Action/SendSEPATransfer.php
+++ b/lib/Fhp/Action/SendSEPATransfer.php
@@ -5,7 +5,10 @@ namespace Fhp\Action;
 use Fhp\BaseAction;
 use Fhp\DataTypes\Bin;
 use Fhp\Model\SEPAAccount;
+use Fhp\Protocol\BPD;
+use Fhp\Protocol\Message;
 use Fhp\Protocol\UnexpectedResponseException;
+use Fhp\Protocol\UPD;
 use Fhp\Segment\CCS\HKCCSv1;
 use Fhp\Segment\Common\Kti;
 use Fhp\Segment\HIRMS\Rueckmeldungscode;
@@ -43,7 +46,7 @@ class SendSEPATransfer extends BaseAction
     }
 
     /** {@inheritdoc} */
-    public function createRequest($bpd, $upd)
+    public function createRequest(BPD $bpd, UPD $upd)
     {
         if (!$bpd->supportsParameters('HICCSS', 1)) {
             throw new UnsupportedException('The bank does not support HKCCSv1');
@@ -65,7 +68,7 @@ class SendSEPATransfer extends BaseAction
     }
 
     /** {@inheritdoc} */
-    public function processResponse($response)
+    public function processResponse(Message $response)
     {
         parent::processResponse($response);
         if ($response->findRueckmeldung(Rueckmeldungscode::ENTGEGENGENOMMEN) === null) {

--- a/lib/Fhp/Action/SendSEPATransfer.php
+++ b/lib/Fhp/Action/SendSEPATransfer.php
@@ -46,7 +46,7 @@ class SendSEPATransfer extends BaseAction
     }
 
     /** {@inheritdoc} */
-    public function createRequest(BPD $bpd, UPD $upd)
+    public function createRequest(BPD $bpd, ?UPD $upd)
     {
         if (!$bpd->supportsParameters('HICCSS', 1)) {
             throw new UnsupportedException('The bank does not support HKCCSv1');

--- a/lib/Fhp/BaseAction.php
+++ b/lib/Fhp/BaseAction.php
@@ -176,7 +176,8 @@ abstract class BaseAction implements \Serializable
      * multiple times in case the response is paginated. On all but the first call, {@link #getPaginationToken()} will
      * return a non-null token that should be included in the returned request.
      * @param BPD $bpd See {@link BPD}.
-     * @param UPD $upd See {@link UPD}.
+     * @param UPD|null $upd See {@link UPD}. This is usually present (non-null), except for a few special login and TAN
+     *     management actions.
      * @return BaseSegment|BaseSegment[] A segment or a series of segments that should be sent to the bank server.
      *     Note that an action can return an empty array to indicate that it does not need to make a request to the
      *     server, but can instead compute the result just from the BPD/UPD, in which case it should set
@@ -184,7 +185,7 @@ abstract class BaseAction implements \Serializable
      *     be executed.
      * @throws \InvalidArgumentException When the request cannot be built because the input data or BPD/UPD is invalid.
      */
-    abstract public function createRequest(BPD $bpd, UPD $upd);
+    abstract public function createRequest(BPD $bpd, ?UPD $upd);
 
     /**
      * Called when this action was executed on the server (never if {@link #createRequest()} returned an empty request),

--- a/lib/Fhp/BaseAction.php
+++ b/lib/Fhp/BaseAction.php
@@ -65,7 +65,7 @@ abstract class BaseAction implements \Serializable
      * If a sub-class overrides this, it should call the parent function and include it in its result.
      * @return string The serialized action, e.g. for storage in a database. This will not contain sensitive user data.
      */
-    public function serialize()
+    public function serialize(): string
     {
         if (!$this->needsTan()) {
             throw new \RuntimeException('Cannot serialize this action, because it is not waiting for a TAN.');
@@ -83,7 +83,7 @@ abstract class BaseAction implements \Serializable
      * @return bool Whether the underlying operation has completed (whether successfully or not) and the result or error
      *     message in this future is available. Note: If this returns false, check {@link #needsTan()}.
      */
-    public function isAvailable()
+    public function isAvailable(): bool
     {
         return $this->isAvailable;
     }
@@ -92,7 +92,7 @@ abstract class BaseAction implements \Serializable
      * @return bool Whether the underlying operation has completed successfully and the result in this future is
      *     available.
      */
-    public function isSuccess()
+    public function isSuccess(): bool
     {
         return $this->isAvailable && $this->error === null;
     }
@@ -101,7 +101,7 @@ abstract class BaseAction implements \Serializable
      * @return bool Whether the underlying operation has completed unsuccessfully and the {@link #getError()} is
      *     available.
      */
-    public function isError()
+    public function isError(): bool
     {
         return $this->isAvailable && $this->error !== null;
     }
@@ -110,7 +110,7 @@ abstract class BaseAction implements \Serializable
      * @return bool If this returns true, the underlying operation has not completed because it is awaiting a TAN. You
      *     should ask the user for this TAN and pass it to {@link #submitTan()}.
      */
-    public function needsTan()
+    public function needsTan(): bool
     {
         return !$this->isAvailable && $this->tanRequest !== null;
     }
@@ -187,7 +187,7 @@ abstract class BaseAction implements \Serializable
      *     be executed.
      * @throws \InvalidArgumentException When the request cannot be built because the input data or BPD/UPD is invalid.
      */
-    abstract public function createRequest($bpd, $upd);
+    abstract public function createRequest(BPD $bpd, UPD $upd);
 
     /**
      * Called when this action was executed on the server (never if {@link #createRequest()} returned an empty request),
@@ -198,7 +198,7 @@ abstract class BaseAction implements \Serializable
      *     were in response to the request segments that were created by {@link #createRequest()}.
      * @throws UnexpectedResponseException When the response indicates failure.
      */
-    public function processResponse($response)
+    public function processResponse(Message $response)
     {
         $pagination = $response->findRueckmeldung(Rueckmeldungscode::PAGINATION);
         if ($pagination === null) {
@@ -217,7 +217,7 @@ abstract class BaseAction implements \Serializable
      * @param BPD $bpd See {@link BPD}.
      * @param UPD $upd See {@link UPD}.
      */
-    public function processError($error, $bpd, $upd)
+    public function processError(\Exception $error, BPD $bpd, UPD $upd)
     {
         unset($bpd, $upd); // These parameters are used in sub-classes.
         $this->isAvailable = true;
@@ -225,7 +225,7 @@ abstract class BaseAction implements \Serializable
     }
 
     /** @return int[] */
-    public function getRequestSegmentNumbers()
+    public function getRequestSegmentNumbers(): array
     {
         return $this->requestSegmentNumbers;
     }
@@ -234,7 +234,7 @@ abstract class BaseAction implements \Serializable
      * To be called only by the FinTs instance that executes this action.
      * @param int[] $requestSegmentNumbers
      */
-    final public function setRequestSegmentNumbers($requestSegmentNumbers)
+    final public function setRequestSegmentNumbers(array $requestSegmentNumbers)
     {
         foreach ($requestSegmentNumbers as $segmentNumber) {
             if (!is_int($segmentNumber)) {
@@ -248,7 +248,7 @@ abstract class BaseAction implements \Serializable
      * To be called only by the FinTs instance that executes this action.
      * @param TanRequest|null $tanRequest
      */
-    final public function setTanRequest($tanRequest)
+    final public function setTanRequest(?TanRequest $tanRequest)
     {
         $this->tanRequest = $tanRequest;
     }

--- a/lib/Fhp/BaseAction.php
+++ b/lib/Fhp/BaseAction.php
@@ -115,9 +115,6 @@ abstract class BaseAction implements \Serializable
         return !$this->isAvailable && $this->tanRequest !== null;
     }
 
-    /**
-     * @return TanRequest|null
-     */
     public function getTanRequest(): ?TanRequest
     {
         return $this->tanRequest;
@@ -246,7 +243,6 @@ abstract class BaseAction implements \Serializable
 
     /**
      * To be called only by the FinTs instance that executes this action.
-     * @param TanRequest|null $tanRequest
      */
     final public function setTanRequest(?TanRequest $tanRequest)
     {

--- a/lib/Fhp/Connection.php
+++ b/lib/Fhp/Connection.php
@@ -27,9 +27,6 @@ class Connection
      */
     protected $timeoutResponse = 30;
 
-    /**
-     * Connection constructor.
-     */
     public function __construct(string $url, int $timeoutConnect = 15, int $timeoutResponse = 30)
     {
         $this->url = $url;

--- a/lib/Fhp/Connection.php
+++ b/lib/Fhp/Connection.php
@@ -29,10 +29,6 @@ class Connection
 
     /**
      * Connection constructor.
-     *
-     * @param string $url
-     * @param int $timeoutConnect
-     * @param int $timeoutResponse
      */
     public function __construct(string $url, int $timeoutConnect = 15, int $timeoutResponse = 30)
     {

--- a/lib/Fhp/Connection.php
+++ b/lib/Fhp/Connection.php
@@ -34,7 +34,7 @@ class Connection
      * @param int $timeoutConnect
      * @param int $timeoutResponse
      */
-    public function __construct($url, $timeoutConnect = 15, $timeoutResponse = 30)
+    public function __construct(string $url, int $timeoutConnect = 15, int $timeoutResponse = 30)
     {
         $this->url = $url;
         $this->timeoutConnect = $timeoutConnect;
@@ -72,7 +72,7 @@ class Connection
      * @return string The response from the server, in HBCI/FinTS wire format, ISO-8859-1 encoded.
      * @throws CurlException When the request fails.
      */
-    public function send($message)
+    public function send(string $message): string
     {
         if (!$this->curlHandle) {
             $this->connect();

--- a/lib/Fhp/Credentials.php
+++ b/lib/Fhp/Credentials.php
@@ -26,7 +26,7 @@ class Credentials
      *     could contain alphabetical or even arbitrary characters.
      * @return Credentials A new Credentials instance.
      */
-    public static function create($benutzerkennung, $pin)
+    public static function create(string $benutzerkennung, string $pin): Credentials
     {
         $result = new Credentials();
         $result->benutzerkennung = $benutzerkennung;

--- a/lib/Fhp/CurlException.php
+++ b/lib/Fhp/CurlException.php
@@ -22,7 +22,7 @@ class CurlException extends \Exception
      * @param int $code
      * @param mixed $curlInfo
      */
-    public function __construct($message, $response, $code = 0, $curlInfo = [])
+    public function __construct(string $message, ?string $response, int $code = 0, $curlInfo = [])
     {
         parent::__construct($message, $code, null);
         $this->response = $response;
@@ -32,7 +32,7 @@ class CurlException extends \Exception
     /**
      * @return string|null
      */
-    public function getResponse()
+    public function getResponse(): ?string
     {
         return $this->response;
     }
@@ -42,7 +42,7 @@ class CurlException extends \Exception
      *
      * @return array
      */
-    public function getCurlInfo()
+    public function getCurlInfo(): array
     {
         return $this->curlInfo;
     }

--- a/lib/Fhp/CurlException.php
+++ b/lib/Fhp/CurlException.php
@@ -14,12 +14,7 @@ class CurlException extends \Exception
      */
     protected $response;
 
-    /**
-     * CurlException constructor.
-     *
-     * @param mixed $curlInfo
-     */
-    public function __construct(string $message, ?string $response, int $code = 0, $curlInfo = [])
+    public function __construct(string $message, ?string $response, int $code = 0, array $curlInfo = [])
     {
         parent::__construct($message, $code, null);
         $this->response = $response;

--- a/lib/Fhp/CurlException.php
+++ b/lib/Fhp/CurlException.php
@@ -17,9 +17,6 @@ class CurlException extends \Exception
     /**
      * CurlException constructor.
      *
-     * @param string $message
-     * @param string|null $response
-     * @param int $code
      * @param mixed $curlInfo
      */
     public function __construct(string $message, ?string $response, int $code = 0, $curlInfo = [])
@@ -29,9 +26,6 @@ class CurlException extends \Exception
         $this->curlInfo = $curlInfo;
     }
 
-    /**
-     * @return string|null
-     */
     public function getResponse(): ?string
     {
         return $this->response;
@@ -39,8 +33,6 @@ class CurlException extends \Exception
 
     /**
      * Gets the curl info from request / response.
-     *
-     * @return array
      */
     public function getCurlInfo(): array
     {

--- a/lib/Fhp/DataElementGroups/SecurityDateTime.php
+++ b/lib/Fhp/DataElementGroups/SecurityDateTime.php
@@ -20,7 +20,6 @@ class SecurityDateTime extends Deg
      * SecurityDateTime constructor.
      *
      * @param int $type
-     * @param \DateTime|null $dateTime
      */
     public function __construct($type = self::DATETIME_TYPE_STS, \DateTime $dateTime = null)
     {

--- a/lib/Fhp/DataTypes/Bin.php
+++ b/lib/Fhp/DataTypes/Bin.php
@@ -11,8 +11,6 @@ class Bin
 
     /**
      * Bin constructor.
-     *
-     * @param string $string
      */
     public function __construct(string $string)
     {
@@ -22,7 +20,6 @@ class Bin
     /**
      * Sets the binary data.
      *
-     * @param string $data
      * @return $this
      */
     public function setData(string $data)
@@ -34,8 +31,6 @@ class Bin
 
     /**
      * Gets the binary data.
-     *
-     * @return string
      */
     public function getData(): string
     {
@@ -44,17 +39,12 @@ class Bin
 
     /**
      * Convert to string.
-     *
-     * @return string
      */
     public function toString(): string
     {
         return '@' . strlen($this->string) . '@' . $this->string;
     }
 
-    /**
-     * @return string
-     */
     public function __toString(): string
     {
         return $this->toString();

--- a/lib/Fhp/DataTypes/Bin.php
+++ b/lib/Fhp/DataTypes/Bin.php
@@ -9,9 +9,6 @@ class Bin
      */
     protected $string;
 
-    /**
-     * Bin constructor.
-     */
     public function __construct(string $string)
     {
         $this->string = $string;

--- a/lib/Fhp/DataTypes/Bin.php
+++ b/lib/Fhp/DataTypes/Bin.php
@@ -14,7 +14,7 @@ class Bin
      *
      * @param string $string
      */
-    public function __construct($string)
+    public function __construct(string $string)
     {
         $this->string = $string;
     }
@@ -25,7 +25,7 @@ class Bin
      * @param string $data
      * @return $this
      */
-    public function setData($data)
+    public function setData(string $data)
     {
         $this->string = $data;
 
@@ -37,7 +37,7 @@ class Bin
      *
      * @return string
      */
-    public function getData()
+    public function getData(): string
     {
         return $this->string;
     }
@@ -47,7 +47,7 @@ class Bin
      *
      * @return string
      */
-    public function toString()
+    public function toString(): string
     {
         return '@' . strlen($this->string) . '@' . $this->string;
     }
@@ -55,7 +55,7 @@ class Bin
     /**
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return $this->toString();
     }

--- a/lib/Fhp/DataTypes/Dat.php
+++ b/lib/Fhp/DataTypes/Dat.php
@@ -29,7 +29,7 @@ class Dat
     /**
      * @return \DateTime
      */
-    public function getDate()
+    public function getDate(): \DateTime
     {
         return $this->value;
     }
@@ -37,7 +37,7 @@ class Dat
     /**
      * @return string
      */
-    public function toString()
+    public function toString(): string
     {
         return $this->value->format('Ymd');
     }
@@ -45,7 +45,7 @@ class Dat
     /**
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return $this->toString();
     }

--- a/lib/Fhp/DataTypes/Dat.php
+++ b/lib/Fhp/DataTypes/Dat.php
@@ -11,40 +11,27 @@ class Dat
 
     /**
      * Dat constructor.
-     * @param \DateTime $dateTime
      */
     public function __construct(\DateTime $dateTime)
     {
         $this->value = $dateTime;
     }
 
-    /**
-     * @param \DateTime $date
-     */
     public function setDate(\DateTime $date)
     {
         $this->value = $date;
     }
 
-    /**
-     * @return \DateTime
-     */
     public function getDate(): \DateTime
     {
         return $this->value;
     }
 
-    /**
-     * @return string
-     */
     public function toString(): string
     {
         return $this->value->format('Ymd');
     }
 
-    /**
-     * @return string
-     */
     public function __toString(): string
     {
         return $this->toString();

--- a/lib/Fhp/DataTypes/Dat.php
+++ b/lib/Fhp/DataTypes/Dat.php
@@ -9,9 +9,6 @@ class Dat
      */
     protected $value;
 
-    /**
-     * Dat constructor.
-     */
     public function __construct(\DateTime $dateTime)
     {
         $this->value = $dateTime;

--- a/lib/Fhp/DataTypes/Kik.php
+++ b/lib/Fhp/DataTypes/Kik.php
@@ -16,9 +16,6 @@ class Kik
 
     /**
      * Kik constructor.
-     *
-     * @param string $countryCode
-     * @param string $bankCode
      */
     public function __construct(string $countryCode, string $bankCode)
     {
@@ -26,17 +23,11 @@ class Kik
         $this->bankCode = (string) $bankCode;
     }
 
-    /**
-     * @return string
-     */
     public function toString(): string
     {
         return $this->countryCode . ':' . $this->bankCode;
     }
 
-    /**
-     * @return string
-     */
     public function __toString(): string
     {
         return $this->toString();

--- a/lib/Fhp/DataTypes/Kik.php
+++ b/lib/Fhp/DataTypes/Kik.php
@@ -14,9 +14,6 @@ class Kik
      */
     protected $bankCode;
 
-    /**
-     * Kik constructor.
-     */
     public function __construct(string $countryCode, string $bankCode)
     {
         $this->countryCode = (string) $countryCode;

--- a/lib/Fhp/DataTypes/Kik.php
+++ b/lib/Fhp/DataTypes/Kik.php
@@ -20,7 +20,7 @@ class Kik
      * @param string $countryCode
      * @param string $bankCode
      */
-    public function __construct($countryCode, $bankCode)
+    public function __construct(string $countryCode, string $bankCode)
     {
         $this->countryCode = (string) $countryCode;
         $this->bankCode = (string) $bankCode;
@@ -29,7 +29,7 @@ class Kik
     /**
      * @return string
      */
-    public function toString()
+    public function toString(): string
     {
         return $this->countryCode . ':' . $this->bankCode;
     }
@@ -37,7 +37,7 @@ class Kik
     /**
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return $this->toString();
     }

--- a/lib/Fhp/DataTypes/Kti.php
+++ b/lib/Fhp/DataTypes/Kti.php
@@ -38,7 +38,7 @@ class Kti
      * @param string $subAccountFeature
      * @param Kik $kik
      */
-    public function __construct($iban, $bic, $accountNumber, $subAccountFeature, Kik $kik)
+    public function __construct(string $iban, string $bic, string $accountNumber, string $subAccountFeature, Kik $kik)
     {
         $this->iban = $iban;
         $this->bic = $bic;
@@ -50,7 +50,7 @@ class Kti
     /**
      * @return string
      */
-    public function toString()
+    public function toString(): string
     {
         return $this->iban . ':'
             . $this->bic . ':'
@@ -62,7 +62,7 @@ class Kti
     /**
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return $this->toString();
     }

--- a/lib/Fhp/DataTypes/Kti.php
+++ b/lib/Fhp/DataTypes/Kti.php
@@ -31,12 +31,6 @@ class Kti
 
     /**
      * Kti constructor.
-     *
-     * @param string $iban
-     * @param string $bic
-     * @param string $accountNumber
-     * @param string $subAccountFeature
-     * @param Kik $kik
      */
     public function __construct(string $iban, string $bic, string $accountNumber, string $subAccountFeature, Kik $kik)
     {
@@ -47,9 +41,6 @@ class Kti
         $this->kik = $kik;
     }
 
-    /**
-     * @return string
-     */
     public function toString(): string
     {
         return $this->iban . ':'
@@ -59,9 +50,6 @@ class Kti
             . (string) $this->kik;
     }
 
-    /**
-     * @return string
-     */
     public function __toString(): string
     {
         return $this->toString();

--- a/lib/Fhp/DataTypes/Kti.php
+++ b/lib/Fhp/DataTypes/Kti.php
@@ -29,9 +29,6 @@ class Kti
      */
     protected $kik;
 
-    /**
-     * Kti constructor.
-     */
     public function __construct(string $iban, string $bic, string $accountNumber, string $subAccountFeature, Kik $kik)
     {
         $this->iban = $iban;

--- a/lib/Fhp/DataTypes/Ktv.php
+++ b/lib/Fhp/DataTypes/Ktv.php
@@ -30,7 +30,7 @@ class Ktv
      * @param string $subAccountFeature
      * @param Kik $kik
      */
-    public function __construct($accountNumber, $subAccountFeature, Kik $kik)
+    public function __construct(string $accountNumber, string $subAccountFeature, Kik $kik)
     {
         $this->accountNumber = $accountNumber;
         $this->subAccountFeature = $subAccountFeature;
@@ -40,7 +40,7 @@ class Ktv
     /**
      * @return string
      */
-    public function toString()
+    public function toString(): string
     {
         return $this->accountNumber . ':' . $this->subAccountFeature . ':' . (string) $this->kik;
     }
@@ -48,7 +48,7 @@ class Ktv
     /**
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return $this->toString();
     }

--- a/lib/Fhp/DataTypes/Ktv.php
+++ b/lib/Fhp/DataTypes/Ktv.php
@@ -23,9 +23,6 @@ class Ktv
      */
     protected $kik;
 
-    /**
-     * Ktv constructor.
-     */
     public function __construct(string $accountNumber, string $subAccountFeature, Kik $kik)
     {
         $this->accountNumber = $accountNumber;

--- a/lib/Fhp/DataTypes/Ktv.php
+++ b/lib/Fhp/DataTypes/Ktv.php
@@ -25,10 +25,6 @@ class Ktv
 
     /**
      * Ktv constructor.
-     *
-     * @param string $accountNumber
-     * @param string $subAccountFeature
-     * @param Kik $kik
      */
     public function __construct(string $accountNumber, string $subAccountFeature, Kik $kik)
     {
@@ -37,17 +33,11 @@ class Ktv
         $this->kik = $kik;
     }
 
-    /**
-     * @return string
-     */
     public function toString(): string
     {
         return $this->accountNumber . ':' . $this->subAccountFeature . ':' . (string) $this->kik;
     }
 
-    /**
-     * @return string
-     */
     public function __toString(): string
     {
         return $this->toString();

--- a/lib/Fhp/Dialog/Dialog.php
+++ b/lib/Fhp/Dialog/Dialog.php
@@ -105,12 +105,10 @@ class Dialog
     /**
      * Dialog constructor.
      *
-     * @param Connection $connection
      * @param string $bankCode
      * @param string $username
      * @param string $pin
      * @param string $systemId
-     * @param LoggerInterface $logger
      * @param string $productName
      * @param string $productVersion
      */
@@ -273,7 +271,6 @@ class Dialog
     }
 
     /**
-     * @param Response $response
      * @throws \Exception
      */
     protected function handleResponse(Response $response)
@@ -317,8 +314,6 @@ class Dialog
 
     /**
      * Gets the dialog ID.
-     *
-     * @return string
      */
     public function getDialogId(): string
     {
@@ -337,8 +332,6 @@ class Dialog
 
     /**
      * Gets the system ID.
-     *
-     * @return string
      */
     public function getSystemId(): string
     {

--- a/lib/Fhp/Dialog/Exception/FailedRequestException.php
+++ b/lib/Fhp/Dialog/Exception/FailedRequestException.php
@@ -24,8 +24,6 @@ class FailedRequestException extends \Exception
 
     /**
      * FailedRequestException constructor.
-     *
-     * @param array $summary
      */
     public function __construct(array $summary)
     {

--- a/lib/Fhp/Dialog/Exception/TANRequiredException.php
+++ b/lib/Fhp/Dialog/Exception/TANRequiredException.php
@@ -44,57 +44,36 @@ class TANRequiredException extends \Exception
         parent::__construct('Sicherheitsfreigabe erforderlich; Challenge: ' . $response->getTanChallenge());
     }
 
-    /**
-     * @return GetTANRequest
-     */
     public function getResponse(): GetTANRequest
     {
         return $this->response;
     }
 
-    /**
-     * @return string
-     */
     public function getTanMechanism(): string
     {
         return $this->tanMechanism;
     }
 
-    /**
-     * @return string|null
-     */
     public function getTanMediaName(): ?string
     {
         return $this->tanMediaName;
     }
 
-    /**
-     * @return string
-     */
     public function getSystemId(): string
     {
         return $this->systemId;
     }
 
-    /**
-     * @return string
-     */
     public function getDialogId(): string
     {
         return $this->dialogId;
     }
 
-    /**
-     * @return int
-     */
     public function getMessageNumber(): int
     {
         return $this->messageNumber;
     }
 
-    /**
-     * @return string
-     */
     public function getProcessId(): string
     {
         return $this->processId;
@@ -104,8 +83,6 @@ class TANRequiredException extends \Exception
      * Konkateniert die benötigten Wert mit Tilde (~),
      * da Tilde nicht im FinTS-Basiszeichensatz enthalten ist und somit nicht in einem
      * dieser Wert vorkommen kann und ~ außerdem URL-Safe ist.
-     *
-     * @return string
      */
     public function getTANToken(): string
     {

--- a/lib/Fhp/FinTs.php
+++ b/lib/Fhp/FinTs.php
@@ -250,9 +250,6 @@ class FinTs extends FinTsInternal
     /**
      * Gets statement of account.
      *
-     * @param SEPAAccount $account
-     * @param \DateTime $from
-     * @param \DateTime $to
      * @param \Closure $tanCallback
      * @param $interval
      * @return Model\StatementOfAccount\StatementOfAccount|null
@@ -343,9 +340,6 @@ class FinTs extends FinTsInternal
     /**
      * Gets Bank To Customer Account Report as camt XML
      *
-     * @param SEPAAccount $account
-     * @param \DateTime $from
-     * @param \DateTime $to
      * @return string[]
      * @throws \Exception
      */
@@ -394,7 +388,6 @@ class FinTs extends FinTsInternal
     /**
      * Gets the saldo of given SEPAAccount.
      *
-     * @param SEPAAccount $account
      * @return Model\Saldo|null
      * @throws \CurlException
      * @throws \Exception
@@ -476,7 +469,6 @@ class FinTs extends FinTsInternal
      * Executes SEPA transfer
      * You have to call finishSEPATAN(), if $tanCallback is not set
      *
-     * @param SEPAAccount $account
      * @param string $painMessage
      * @param \Closure $tanCallback
      */
@@ -570,8 +562,6 @@ class FinTs extends FinTsInternal
      *
      * You have to call finishSEPATAN(), if $tanCallback is not set
      *
-     * @param SEPAAccount $account
-     * @param SEPAStandingOrder $order
      * @param \Closure $tanCallback
      */
     public function deleteSEPAStandingOrder(SEPAAccount $account, SEPAStandingOrder $order, \Closure $tanCallback = null)

--- a/lib/Fhp/FinTsInternal.php
+++ b/lib/Fhp/FinTsInternal.php
@@ -57,7 +57,6 @@ abstract class FinTsInternal
     }
 
     /**
-     * @param SEPAAccount $account
      * @param string $painMessage
      * @return GetTANRequest
      */
@@ -93,9 +92,6 @@ abstract class FinTsInternal
      * Helper method to retrieve a pre configured message object.
      * Factory for poor people :)
      *
-     * @param Dialog $dialog
-     * @param array $segments
-     * @param array $options
      * @return Message
      */
     protected function getNewMessage(Dialog $dialog, array $segments, array $options = [])
@@ -181,10 +177,6 @@ abstract class FinTsInternal
     /**
      * Helper method to create a "Statement of Account Message".
      *
-     * @param Dialog $dialog
-     * @param SEPAAccount $account
-     * @param \DateTime $from
-     * @param \DateTime $to
      * @param string|null $touchdown
      * @return Message
      * @throws \Exception
@@ -221,10 +213,6 @@ abstract class FinTsInternal
     /**
      * Helper method to create a "Statement of Account Message".
      *
-     * @param Dialog $dialog
-     * @param SEPAAccount $account
-     * @param \DateTime $from
-     * @param \DateTime $to
      * @param string|null $touchdown
      * @return Message
      * @throws \Exception

--- a/lib/Fhp/FinTsNew.php
+++ b/lib/Fhp/FinTsNew.php
@@ -64,7 +64,6 @@ class FinTsNew
     private $messageNumber = 1;
 
     /**
-     * FinTsNew constructor.
      * @param FinTsOptions $options Configuration options for the connection to the bank.
      * @param Credentials $credentials Authentication information for the user. Note: This library does not support
      *     anonymous connections, so the credentials are mandatory.

--- a/lib/Fhp/MT940/Dialect/PostbankMT940.php
+++ b/lib/Fhp/MT940/Dialect/PostbankMT940.php
@@ -8,7 +8,7 @@ class PostbankMT940 extends MT940
 {
     const DIALECT_ID = 'https://hbci.postbank.de/banking/hbci.do';
 
-    /** {@inheritDoc} */
+    /** {@inheritdoc} */
     public function extractStructuredDataFromRemittanceLines($descriptionLines, string &$gvc, string &$rawLines): array
     {
         // z.B bei Zinsen o.ä. ist alles leer

--- a/lib/Fhp/MT940/Dialect/PostbankMT940.php
+++ b/lib/Fhp/MT940/Dialect/PostbankMT940.php
@@ -9,7 +9,7 @@ class PostbankMT940 extends MT940
     const DIALECT_ID = 'https://hbci.postbank.de/banking/hbci.do';
 
     /** {@inheritdoc} */
-    public function extractStructuredDataFromRemittanceLines($descriptionLines, string &$gvc, string &$rawLines): array
+    public function extractStructuredDataFromRemittanceLines($descriptionLines, string &$gvc, array &$rawLines): array
     {
         // z.B bei Zinsen o.ä. ist alles leer
         if (!isset($descriptionLines[0])) {

--- a/lib/Fhp/MT940/Dialect/PostbankMT940.php
+++ b/lib/Fhp/MT940/Dialect/PostbankMT940.php
@@ -8,7 +8,8 @@ class PostbankMT940 extends MT940
 {
     const DIALECT_ID = 'https://hbci.postbank.de/banking/hbci.do';
 
-    public function extractStructuredDataFromRemittanceLines($descriptionLines, &$gvc, &$rawLines)
+    /** {@inheritDoc} */
+    public function extractStructuredDataFromRemittanceLines($descriptionLines, string &$gvc, string &$rawLines): array
     {
         // z.B bei Zinsen o.ä. ist alles leer
         if (!isset($descriptionLines[0])) {

--- a/lib/Fhp/MT940/Dialect/SpardaMT940.php
+++ b/lib/Fhp/MT940/Dialect/SpardaMT940.php
@@ -8,7 +8,8 @@ class SpardaMT940 extends MT940
 {
     const DIALECT_ID = 'https://fints.bankingonline.de/fints/FinTs30PinTanHttpGate';
 
-    public function extractStructuredDataFromRemittanceLines($descriptionLines, &$gvc, &$rawLines)
+    /** {@inheritDoc} */
+    public function extractStructuredDataFromRemittanceLines($descriptionLines, string &$gvc, string &$rawLines): array
     {
         $otherInfo = [];
         $structuredStartFound = false;

--- a/lib/Fhp/MT940/Dialect/SpardaMT940.php
+++ b/lib/Fhp/MT940/Dialect/SpardaMT940.php
@@ -8,7 +8,7 @@ class SpardaMT940 extends MT940
 {
     const DIALECT_ID = 'https://fints.bankingonline.de/fints/FinTs30PinTanHttpGate';
 
-    /** {@inheritDoc} */
+    /** {@inheritdoc} */
     public function extractStructuredDataFromRemittanceLines($descriptionLines, string &$gvc, string &$rawLines): array
     {
         $otherInfo = [];

--- a/lib/Fhp/MT940/Dialect/SpardaMT940.php
+++ b/lib/Fhp/MT940/Dialect/SpardaMT940.php
@@ -9,7 +9,7 @@ class SpardaMT940 extends MT940
     const DIALECT_ID = 'https://fints.bankingonline.de/fints/FinTs30PinTanHttpGate';
 
     /** {@inheritdoc} */
-    public function extractStructuredDataFromRemittanceLines($descriptionLines, string &$gvc, string &$rawLines): array
+    public function extractStructuredDataFromRemittanceLines($descriptionLines, string &$gvc, array &$rawLines): array
     {
         $otherInfo = [];
         $structuredStartFound = false;

--- a/lib/Fhp/MT940/MT940.php
+++ b/lib/Fhp/MT940/MT940.php
@@ -18,7 +18,7 @@ class MT940
      * @return array
      * @throws MT940Exception
      */
-    public function parse($rawData)
+    public function parse(string $rawData): array
     {
         // The divider can be either \r\n or @@
         $divider = substr_count($rawData, "\r\n-") > substr_count($rawData, '@@-') ? "\r\n" : '@@';
@@ -181,7 +181,7 @@ class MT940
      * @param string $rawLines All the lines in the Multi-Purpose-Field 86; Out-Parameter, might be changed from information in remittance info
      * @return array
      */
-    protected function extractStructuredDataFromRemittanceLines($descriptionLines, &$gvc, &$rawLines)
+    protected function extractStructuredDataFromRemittanceLines($descriptionLines, string &$gvc, string &$rawLines): array
     {
         $description = [];
         if (empty($descriptionLines) || strlen($descriptionLines[0]) < 5 || $descriptionLines[0][4] !== '+') {
@@ -216,7 +216,7 @@ class MT940
      * @param string $val
      * @return string
      */
-    protected function getDate($val)
+    protected function getDate(string $val): string
     {
         $val = '20' . $val;
         preg_match('/(\d{4})(\d{2})(\d{2})/', $val, $m);

--- a/lib/Fhp/MT940/MT940.php
+++ b/lib/Fhp/MT940/MT940.php
@@ -174,11 +174,11 @@ class MT940
     }
 
     /**
-     * @param string[] $lines that contain the remittance information
+     * @param string[] $descriptionLines that contain the remittance information
      * @param string $gvc Geschätsvorfallcode; Out-Parameter, might be changed from information in remittance info
-     * @param string $rawLines All the lines in the Multi-Purpose-Field 86; Out-Parameter, might be changed from information in remittance info
+     * @param string[] $rawLines All the lines in the Multi-Purpose-Field 86; Out-Parameter, might be changed from information in remittance info
      */
-    protected function extractStructuredDataFromRemittanceLines($descriptionLines, string &$gvc, string &$rawLines): array
+    protected function extractStructuredDataFromRemittanceLines($descriptionLines, string &$gvc, array &$rawLines): array
     {
         $description = [];
         if (empty($descriptionLines) || strlen($descriptionLines[0]) < 5 || $descriptionLines[0][4] !== '+') {

--- a/lib/Fhp/MT940/MT940.php
+++ b/lib/Fhp/MT940/MT940.php
@@ -14,8 +14,6 @@ class MT940
     const CD_DEBIT = 'debit';
 
     /**
-     * @param string $rawData
-     * @return array
      * @throws MT940Exception
      */
     public function parse(string $rawData): array
@@ -179,7 +177,6 @@ class MT940
      * @param string[] $lines that contain the remittance information
      * @param string $gvc Geschätsvorfallcode; Out-Parameter, might be changed from information in remittance info
      * @param string $rawLines All the lines in the Multi-Purpose-Field 86; Out-Parameter, might be changed from information in remittance info
-     * @return array
      */
     protected function extractStructuredDataFromRemittanceLines($descriptionLines, string &$gvc, string &$rawLines): array
     {
@@ -212,10 +209,6 @@ class MT940
         return $description;
     }
 
-    /**
-     * @param string $val
-     * @return string
-     */
     protected function getDate(string $val): string
     {
         $val = '20' . $val;

--- a/lib/Fhp/Message/AbstractMessage.php
+++ b/lib/Fhp/Message/AbstractMessage.php
@@ -31,8 +31,6 @@ class AbstractMessage
 
     /**
      * Adds a segment to the message.
-     *
-     * @param SegmentInterface $segment
      */
     protected function addSegment(SegmentInterface $segment)
     {
@@ -49,9 +47,6 @@ class AbstractMessage
         return $this->segments;
     }
 
-    /**
-     * @return string
-     */
     public function getSystemId(): string
     {
         return $this->systemId;
@@ -69,8 +64,6 @@ class AbstractMessage
 
     /**
      * Gets the dialog ID.
-     *
-     * @return string
      */
     public function getDialogId(): string
     {

--- a/lib/Fhp/Message/Message.php
+++ b/lib/Fhp/Message/Message.php
@@ -69,8 +69,6 @@ class Message extends AbstractMessage
      * @param $systemId
      * @param int $dialogId
      * @param int $messageNumber
-     * @param array $segments
-     * @param array $options
      */
     public function __construct(
         $bankCode,
@@ -137,9 +135,6 @@ class Message extends AbstractMessage
         ));
     }
 
-    /**
-     * @return string
-     */
     public function getSecurityFunction(): string
     {
         return $this->securityFunction;
@@ -185,8 +180,6 @@ class Message extends AbstractMessage
 
     /**
      * Adds a encrypted segment to the message.
-     *
-     * @param SegmentInterface $segment
      */
     protected function addEncryptedSegment(SegmentInterface $segment)
     {

--- a/lib/Fhp/Model/Account.php
+++ b/lib/Fhp/Model/Account.php
@@ -37,8 +37,6 @@ class Account
     /**
      * Set id
      *
-     * @param string $id
-     *
      * @return $this
      */
     public function setId(string $id)
@@ -50,8 +48,6 @@ class Account
 
     /**
      * Get accountNumber
-     *
-     * @return string
      */
     public function getAccountNumber(): string
     {
@@ -60,8 +56,6 @@ class Account
 
     /**
      * Set accountNumber
-     *
-     * @param string $accountNumber
      *
      * @return $this
      */
@@ -74,8 +68,6 @@ class Account
 
     /**
      * Get bankCode
-     *
-     * @return string
      */
     public function getBankCode(): string
     {
@@ -84,8 +76,6 @@ class Account
 
     /**
      * Set bankCode
-     *
-     * @param string $bankCode
      *
      * @return $this
      */
@@ -98,8 +88,6 @@ class Account
 
     /**
      * Get iban
-     *
-     * @return string
      */
     public function getIban(): string
     {
@@ -108,8 +96,6 @@ class Account
 
     /**
      * Set iban
-     *
-     * @param string $iban
      *
      * @return $this
      */
@@ -122,8 +108,6 @@ class Account
 
     /**
      * Get customerId
-     *
-     * @return string
      */
     public function getCustomerId(): string
     {
@@ -132,8 +116,6 @@ class Account
 
     /**
      * Set customerId
-     *
-     * @param string $customerId
      *
      * @return $this
      */
@@ -146,8 +128,6 @@ class Account
 
     /**
      * Get currency
-     *
-     * @return string
      */
     public function getCurrency(): string
     {
@@ -156,8 +136,6 @@ class Account
 
     /**
      * Set currency
-     *
-     * @param string $currency
      *
      * @return $this
      */
@@ -170,8 +148,6 @@ class Account
 
     /**
      * Get accountOwnerName
-     *
-     * @return string
      */
     public function getAccountOwnerName(): string
     {
@@ -180,8 +156,6 @@ class Account
 
     /**
      * Set accountOwnerName
-     *
-     * @param string $accountOwnerName
      *
      * @return $this
      */
@@ -194,8 +168,6 @@ class Account
 
     /**
      * Get accountDescription
-     *
-     * @return string
      */
     public function getAccountDescription(): string
     {
@@ -204,8 +176,6 @@ class Account
 
     /**
      * Set accountDescription
-     *
-     * @param string $accountDescription
      *
      * @return $this
      */

--- a/lib/Fhp/Model/Account.php
+++ b/lib/Fhp/Model/Account.php
@@ -7,181 +7,139 @@ namespace Fhp\Model;
  */
 class Account
 {
-    /** @var string */
+    /** @var string|null */
     protected $id;
-    /** @var string */
+    /** @var string|null */
     protected $accountNumber;
-    /** @var string */
+    /** @var string|null */
     protected $bankCode;
-    /** @var string */
+    /** @var string|null */
     protected $iban;
-    /** @var string */
+    /** @var string|null */
     protected $customerId;
-    /** @var string */
+    /** @var string|null */
     protected $currency;
-    /** @var string */
+    /** @var string|null */
     protected $accountOwnerName;
-    /** @var string */
+    /** @var string|null */
     protected $accountDescription;
 
-    /**
-     * Get id
-     *
-     * @return mixed
-     */
-    public function getId()
+    public function getId(): ?string
     {
         return $this->id;
     }
 
     /**
-     * Set id
-     *
      * @return $this
      */
-    public function setId(string $id)
+    public function setId(?string $id)
     {
         $this->id = $id;
 
         return $this;
     }
 
-    /**
-     * Get accountNumber
-     */
-    public function getAccountNumber(): string
+    public function getAccountNumber(): ?string
     {
         return $this->accountNumber;
     }
 
     /**
-     * Set accountNumber
-     *
      * @return $this
      */
-    public function setAccountNumber(string $accountNumber)
+    public function setAccountNumber(?string $accountNumber)
     {
-        $this->accountNumber = (string) $accountNumber;
+        $this->accountNumber = $accountNumber;
 
         return $this;
     }
 
-    /**
-     * Get bankCode
-     */
-    public function getBankCode(): string
+    public function getBankCode(): ?string
     {
         return $this->bankCode;
     }
 
     /**
-     * Set bankCode
-     *
      * @return $this
      */
-    public function setBankCode(string $bankCode)
+    public function setBankCode(?string $bankCode)
     {
-        $this->bankCode = (string) $bankCode;
+        $this->bankCode = $bankCode;
 
         return $this;
     }
 
-    /**
-     * Get iban
-     */
-    public function getIban(): string
+    public function getIban(): ?string
     {
         return $this->iban;
     }
 
     /**
-     * Set iban
-     *
      * @return $this
      */
-    public function setIban(string $iban)
+    public function setIban(?string $iban)
     {
-        $this->iban = (string) $iban;
+        $this->iban = $iban;
 
         return $this;
     }
 
-    /**
-     * Get customerId
-     */
-    public function getCustomerId(): string
+    public function getCustomerId(): ?string
     {
         return $this->customerId;
     }
 
     /**
-     * Set customerId
-     *
      * @return $this
      */
-    public function setCustomerId(string $customerId)
+    public function setCustomerId(?string $customerId)
     {
-        $this->customerId = (string) $customerId;
+        $this->customerId = $customerId;
 
         return $this;
     }
 
-    /**
-     * Get currency
-     */
-    public function getCurrency(): string
+    public function getCurrency(): ?string
     {
         return $this->currency;
     }
 
     /**
-     * Set currency
-     *
      * @return $this
      */
-    public function setCurrency(string $currency)
+    public function setCurrency(?string $currency)
     {
-        $this->currency = (string) $currency;
+        $this->currency = $currency;
 
         return $this;
     }
 
-    /**
-     * Get accountOwnerName
-     */
-    public function getAccountOwnerName(): string
+    public function getAccountOwnerName(): ?string
     {
         return $this->accountOwnerName;
     }
 
     /**
-     * Set accountOwnerName
-     *
      * @return $this
      */
-    public function setAccountOwnerName(string $accountOwnerName)
+    public function setAccountOwnerName(?string $accountOwnerName)
     {
-        $this->accountOwnerName = (string) $accountOwnerName;
+        $this->accountOwnerName = $accountOwnerName;
 
         return $this;
     }
 
-    /**
-     * Get accountDescription
-     */
-    public function getAccountDescription(): string
+    public function getAccountDescription(): ?string
     {
         return $this->accountDescription;
     }
 
     /**
-     * Set accountDescription
-     *
      * @return $this
      */
-    public function setAccountDescription(string $accountDescription)
+    public function setAccountDescription(?string $accountDescription)
     {
-        $this->accountDescription = (string) $accountDescription;
+        $this->accountDescription = $accountDescription;
 
         return $this;
     }

--- a/lib/Fhp/Model/Account.php
+++ b/lib/Fhp/Model/Account.php
@@ -41,7 +41,7 @@ class Account
      *
      * @return $this
      */
-    public function setId($id)
+    public function setId(string $id)
     {
         $this->id = $id;
 
@@ -53,7 +53,7 @@ class Account
      *
      * @return string
      */
-    public function getAccountNumber()
+    public function getAccountNumber(): string
     {
         return $this->accountNumber;
     }
@@ -65,7 +65,7 @@ class Account
      *
      * @return $this
      */
-    public function setAccountNumber($accountNumber)
+    public function setAccountNumber(string $accountNumber)
     {
         $this->accountNumber = (string) $accountNumber;
 
@@ -77,7 +77,7 @@ class Account
      *
      * @return string
      */
-    public function getBankCode()
+    public function getBankCode(): string
     {
         return $this->bankCode;
     }
@@ -89,7 +89,7 @@ class Account
      *
      * @return $this
      */
-    public function setBankCode($bankCode)
+    public function setBankCode(string $bankCode)
     {
         $this->bankCode = (string) $bankCode;
 
@@ -101,7 +101,7 @@ class Account
      *
      * @return string
      */
-    public function getIban()
+    public function getIban(): string
     {
         return $this->iban;
     }
@@ -113,7 +113,7 @@ class Account
      *
      * @return $this
      */
-    public function setIban($iban)
+    public function setIban(string $iban)
     {
         $this->iban = (string) $iban;
 
@@ -125,7 +125,7 @@ class Account
      *
      * @return string
      */
-    public function getCustomerId()
+    public function getCustomerId(): string
     {
         return $this->customerId;
     }
@@ -137,7 +137,7 @@ class Account
      *
      * @return $this
      */
-    public function setCustomerId($customerId)
+    public function setCustomerId(string $customerId)
     {
         $this->customerId = (string) $customerId;
 
@@ -149,7 +149,7 @@ class Account
      *
      * @return string
      */
-    public function getCurrency()
+    public function getCurrency(): string
     {
         return $this->currency;
     }
@@ -161,7 +161,7 @@ class Account
      *
      * @return $this
      */
-    public function setCurrency($currency)
+    public function setCurrency(string $currency)
     {
         $this->currency = (string) $currency;
 
@@ -173,7 +173,7 @@ class Account
      *
      * @return string
      */
-    public function getAccountOwnerName()
+    public function getAccountOwnerName(): string
     {
         return $this->accountOwnerName;
     }
@@ -185,7 +185,7 @@ class Account
      *
      * @return $this
      */
-    public function setAccountOwnerName($accountOwnerName)
+    public function setAccountOwnerName(string $accountOwnerName)
     {
         $this->accountOwnerName = (string) $accountOwnerName;
 
@@ -197,7 +197,7 @@ class Account
      *
      * @return string
      */
-    public function getAccountDescription()
+    public function getAccountDescription(): string
     {
         return $this->accountDescription;
     }
@@ -209,7 +209,7 @@ class Account
      *
      * @return $this
      */
-    public function setAccountDescription($accountDescription)
+    public function setAccountDescription(string $accountDescription)
     {
         $this->accountDescription = (string) $accountDescription;
 

--- a/lib/Fhp/Model/SEPAAccount.php
+++ b/lib/Fhp/Model/SEPAAccount.php
@@ -23,7 +23,7 @@ class SEPAAccount
      *
      * @return string
      */
-    public function getIban()
+    public function getIban(): string
     {
         return $this->iban;
     }
@@ -35,7 +35,7 @@ class SEPAAccount
      *
      * @return $this
      */
-    public function setIban($iban)
+    public function setIban(string $iban)
     {
         $this->iban = (string) $iban;
 
@@ -47,7 +47,7 @@ class SEPAAccount
      *
      * @return string
      */
-    public function getBic()
+    public function getBic(): string
     {
         return $this->bic;
     }
@@ -59,7 +59,7 @@ class SEPAAccount
      *
      * @return $this
      */
-    public function setBic($bic)
+    public function setBic(string $bic)
     {
         $this->bic = (string) $bic;
 
@@ -71,7 +71,7 @@ class SEPAAccount
      *
      * @return string
      */
-    public function getAccountNumber()
+    public function getAccountNumber(): string
     {
         return $this->accountNumber;
     }
@@ -83,7 +83,7 @@ class SEPAAccount
      *
      * @return $this
      */
-    public function setAccountNumber($accountNumber)
+    public function setAccountNumber(string $accountNumber)
     {
         $this->accountNumber = (string) $accountNumber;
 
@@ -95,7 +95,7 @@ class SEPAAccount
      *
      * @return string
      */
-    public function getSubAccount()
+    public function getSubAccount(): string
     {
         return $this->subAccount;
     }
@@ -107,7 +107,7 @@ class SEPAAccount
      *
      * @return $this
      */
-    public function setSubAccount($subAccount)
+    public function setSubAccount(string $subAccount)
     {
         $this->subAccount = (string) $subAccount;
 
@@ -119,7 +119,7 @@ class SEPAAccount
      *
      * @return string
      */
-    public function getBlz()
+    public function getBlz(): string
     {
         return $this->blz;
     }
@@ -131,7 +131,7 @@ class SEPAAccount
      *
      * @return $this
      */
-    public function setBlz($blz)
+    public function setBlz(string $blz)
     {
         $this->blz = (string) $blz;
 

--- a/lib/Fhp/Model/SEPAAccount.php
+++ b/lib/Fhp/Model/SEPAAccount.php
@@ -7,113 +7,90 @@ namespace Fhp\Model;
  */
 class SEPAAccount
 {
-    /** @var string */
+    // All fields are nullable, but the overall SEPAAccount is only valid if at least {IBAN,BIC} or {accountNumber,blz} are present.
+
+    /** @var string|null */
     protected $iban;
-    /** @var string */
+    /** @var string|null */
     protected $bic;
-    /** @var string */
+    /** @var string|null */
     protected $accountNumber;
-    /** @var string */
+    /** @var string|null */
     protected $subAccount;
-    /** @var string */
+    /** @var string|null */
     protected $blz;
 
-    /**
-     * Get iban
-     */
-    public function getIban(): string
+    public function getIban(): ?string
     {
         return $this->iban;
     }
 
     /**
-     * Set iban
-     *
      * @return $this
      */
-    public function setIban(string $iban)
+    public function setIban(?string $iban)
     {
-        $this->iban = (string) $iban;
+        $this->iban = $iban;
 
         return $this;
     }
 
-    /**
-     * Get bic
-     */
-    public function getBic(): string
+    public function getBic(): ?string
     {
         return $this->bic;
     }
 
     /**
-     * Set bic
-     *
      * @return $this
      */
-    public function setBic(string $bic)
+    public function setBic(?string $bic)
     {
-        $this->bic = (string) $bic;
+        $this->bic = $bic;
 
         return $this;
     }
 
-    /**
-     * Get accountNumber
-     */
-    public function getAccountNumber(): string
+    public function getAccountNumber(): ?string
     {
         return $this->accountNumber;
     }
 
     /**
-     * Set accountNumber
-     *
      * @return $this
      */
-    public function setAccountNumber(string $accountNumber)
+    public function setAccountNumber(?string $accountNumber)
     {
-        $this->accountNumber = (string) $accountNumber;
+        $this->accountNumber = $accountNumber;
 
         return $this;
     }
 
-    /**
-     * Get subAccount
-     */
-    public function getSubAccount(): string
+    public function getSubAccount(): ?string
     {
         return $this->subAccount;
     }
 
     /**
-     * Set subAccount
-     *
      * @return $this
      */
-    public function setSubAccount(string $subAccount)
+    public function setSubAccount(?string $subAccount)
     {
-        $this->subAccount = (string) $subAccount;
+        $this->subAccount = $subAccount;
 
         return $this;
     }
 
-    /**
-     * Get blz
-     */
-    public function getBlz(): string
+    public function getBlz(): ?string
     {
         return $this->blz;
     }
 
     /**
-     * Set blz
-     *
      * @return $this
      */
-    public function setBlz(string $blz)
+    public function setBlz(?string $blz)
     {
-        $this->blz = (string) $blz;
+        $this->blz = $blz;
 
         return $this;
     }

--- a/lib/Fhp/Model/SEPAAccount.php
+++ b/lib/Fhp/Model/SEPAAccount.php
@@ -20,8 +20,6 @@ class SEPAAccount
 
     /**
      * Get iban
-     *
-     * @return string
      */
     public function getIban(): string
     {
@@ -30,8 +28,6 @@ class SEPAAccount
 
     /**
      * Set iban
-     *
-     * @param string $iban
      *
      * @return $this
      */
@@ -44,8 +40,6 @@ class SEPAAccount
 
     /**
      * Get bic
-     *
-     * @return string
      */
     public function getBic(): string
     {
@@ -54,8 +48,6 @@ class SEPAAccount
 
     /**
      * Set bic
-     *
-     * @param string $bic
      *
      * @return $this
      */
@@ -68,8 +60,6 @@ class SEPAAccount
 
     /**
      * Get accountNumber
-     *
-     * @return string
      */
     public function getAccountNumber(): string
     {
@@ -78,8 +68,6 @@ class SEPAAccount
 
     /**
      * Set accountNumber
-     *
-     * @param string $accountNumber
      *
      * @return $this
      */
@@ -92,8 +80,6 @@ class SEPAAccount
 
     /**
      * Get subAccount
-     *
-     * @return string
      */
     public function getSubAccount(): string
     {
@@ -102,8 +88,6 @@ class SEPAAccount
 
     /**
      * Set subAccount
-     *
-     * @param string $subAccount
      *
      * @return $this
      */
@@ -116,8 +100,6 @@ class SEPAAccount
 
     /**
      * Get blz
-     *
-     * @return string
      */
     public function getBlz(): string
     {
@@ -126,8 +108,6 @@ class SEPAAccount
 
     /**
      * Set blz
-     *
-     * @param string $blz
      *
      * @return $this
      */

--- a/lib/Fhp/Model/Saldo.php
+++ b/lib/Fhp/Model/Saldo.php
@@ -24,7 +24,7 @@ class Saldo
      *
      * @return string
      */
-    public function getCurrency()
+    public function getCurrency(): string
     {
         return $this->currency;
     }
@@ -36,7 +36,7 @@ class Saldo
      *
      * @return $this
      */
-    public function setCurrency($currency)
+    public function setCurrency(string $currency)
     {
         $this->currency = (string) $currency;
 
@@ -48,7 +48,7 @@ class Saldo
      *
      * @return float
      */
-    public function getAmount()
+    public function getAmount(): float
     {
         return $this->amount;
     }
@@ -60,7 +60,7 @@ class Saldo
      *
      * @return $this
      */
-    public function setAmount($amount)
+    public function setAmount(float $amount)
     {
         $this->amount = (float) $amount;
 
@@ -72,7 +72,7 @@ class Saldo
      *
      * @return \DateTime
      */
-    public function getValuta()
+    public function getValuta(): \DateTime
     {
         return $this->valuta;
     }

--- a/lib/Fhp/Model/Saldo.php
+++ b/lib/Fhp/Model/Saldo.php
@@ -21,8 +21,6 @@ class Saldo
 
     /**
      * Get currency
-     *
-     * @return string
      */
     public function getCurrency(): string
     {
@@ -31,8 +29,6 @@ class Saldo
 
     /**
      * Set currency
-     *
-     * @param string $currency
      *
      * @return $this
      */
@@ -45,8 +41,6 @@ class Saldo
 
     /**
      * Get amount
-     *
-     * @return float
      */
     public function getAmount(): float
     {
@@ -55,8 +49,6 @@ class Saldo
 
     /**
      * Set amount
-     *
-     * @param float $amount
      *
      * @return $this
      */
@@ -69,8 +61,6 @@ class Saldo
 
     /**
      * Get valuta
-     *
-     * @return \DateTime
      */
     public function getValuta(): \DateTime
     {
@@ -79,8 +69,6 @@ class Saldo
 
     /**
      * Set valuta
-     *
-     * @param \DateTime $valuta
      *
      * @return $this
      */

--- a/lib/Fhp/Model/StatementOfAccount/Statement.php
+++ b/lib/Fhp/Model/StatementOfAccount/Statement.php
@@ -58,8 +58,6 @@ class Statement
 
     /**
      * Get startBalance
-     *
-     * @return float
      */
     public function getStartBalance(): float
     {
@@ -68,8 +66,6 @@ class Statement
 
     /**
      * Set startBalance
-     *
-     * @param float $startBalance
      *
      * @return $this
      */
@@ -82,8 +78,6 @@ class Statement
 
     /**
      * Get creditDebit
-     *
-     * @return string
      */
     public function getCreditDebit(): string
     {
@@ -92,8 +86,6 @@ class Statement
 
     /**
      * Set creditDebit
-     *
-     * @param string|null $creditDebit
      *
      * @return $this
      */
@@ -106,8 +98,6 @@ class Statement
 
     /**
      * Get date
-     *
-     * @return \DateTime
      */
     public function getDate(): \DateTime
     {
@@ -116,8 +106,6 @@ class Statement
 
     /**
      * Set date
-     *
-     * @param \DateTime $date
      *
      * @return $this
      */

--- a/lib/Fhp/Model/StatementOfAccount/Statement.php
+++ b/lib/Fhp/Model/StatementOfAccount/Statement.php
@@ -32,7 +32,7 @@ class Statement
      *
      * @return Transaction[]
      */
-    public function getTransactions()
+    public function getTransactions(): array
     {
         return $this->transactions;
     }
@@ -61,7 +61,7 @@ class Statement
      *
      * @return float
      */
-    public function getStartBalance()
+    public function getStartBalance(): float
     {
         return $this->startBalance;
     }
@@ -73,7 +73,7 @@ class Statement
      *
      * @return $this
      */
-    public function setStartBalance($startBalance)
+    public function setStartBalance(float $startBalance)
     {
         $this->startBalance = (float) $startBalance;
 
@@ -85,7 +85,7 @@ class Statement
      *
      * @return string
      */
-    public function getCreditDebit()
+    public function getCreditDebit(): string
     {
         return $this->creditDebit;
     }
@@ -97,7 +97,7 @@ class Statement
      *
      * @return $this
      */
-    public function setCreditDebit($creditDebit)
+    public function setCreditDebit(?string $creditDebit)
     {
         $this->creditDebit = $creditDebit;
 
@@ -109,7 +109,7 @@ class Statement
      *
      * @return \DateTime
      */
-    public function getDate()
+    public function getDate(): \DateTime
     {
         return $this->date;
     }

--- a/lib/Fhp/Model/StatementOfAccount/StatementOfAccount.php
+++ b/lib/Fhp/Model/StatementOfAccount/StatementOfAccount.php
@@ -14,7 +14,7 @@ class StatementOfAccount
      *
      * @return Statement[]
      */
-    public function getStatements()
+    public function getStatements(): array
     {
         return $this->statements;
     }
@@ -52,7 +52,7 @@ class StatementOfAccount
      * @param string|\DateTime $date
      * @return Statement|null
      */
-    public function getStatementForDate($date)
+    public function getStatementForDate($date): ?Statement
     {
         if (is_string($date)) {
             $date = new \DateTime($date);
@@ -73,7 +73,7 @@ class StatementOfAccount
      * @param string|\DateTime $date
      * @return bool
      */
-    public function hasStatementForDate($date)
+    public function hasStatementForDate($date): bool
     {
         if (is_string($date)) {
             $date = new \DateTime($date);

--- a/lib/Fhp/Model/StatementOfAccount/StatementOfAccount.php
+++ b/lib/Fhp/Model/StatementOfAccount/StatementOfAccount.php
@@ -38,9 +38,6 @@ class StatementOfAccount
         return false;
     }
 
-    /**
-     * @param Statement $statement
-     */
     public function addStatement(Statement $statement)
     {
         $this->statements[] = $statement;
@@ -50,7 +47,6 @@ class StatementOfAccount
      * Gets statement for given date.
      *
      * @param string|\DateTime $date
-     * @return Statement|null
      */
     public function getStatementForDate($date): ?Statement
     {
@@ -71,7 +67,6 @@ class StatementOfAccount
      * Checks if a statement with given date exists.
      *
      * @param string|\DateTime $date
-     * @return bool
      */
     public function hasStatementForDate($date): bool
     {

--- a/lib/Fhp/Model/StatementOfAccount/Transaction.php
+++ b/lib/Fhp/Model/StatementOfAccount/Transaction.php
@@ -83,7 +83,6 @@ class Transaction
      *
      * @deprecated Use getBookingDate() instead
      * @codeCoverageIgnore
-     * @return \DateTime|null
      */
     public function getDate(): ?\DateTime
     {
@@ -92,8 +91,6 @@ class Transaction
 
     /**
      * Get booking date
-     *
-     * @return \DateTime|null
      */
     public function getBookingDate(): ?\DateTime
     {
@@ -102,8 +99,6 @@ class Transaction
 
     /**
      * Get date
-     *
-     * @return \DateTime|null
      */
     public function getValutaDate(): ?\DateTime
     {
@@ -112,8 +107,6 @@ class Transaction
 
     /**
      * Set booking date
-     *
-     * @param \DateTime|null $date
      *
      * @return $this
      */
@@ -127,8 +120,6 @@ class Transaction
     /**
      * Set valuta date
      *
-     * @param \DateTime|null $date
-     *
      * @return $this
      */
     public function setValutaDate(\DateTime $date = null)
@@ -140,8 +131,6 @@ class Transaction
 
     /**
      * Get amount
-     *
-     * @return float
      */
     public function getAmount(): float
     {
@@ -150,8 +139,6 @@ class Transaction
 
     /**
      * Set booked status
-     *
-     * @param bool $booked
      *
      * @return $this
      */
@@ -165,8 +152,6 @@ class Transaction
     /**
      * Set amount
      *
-     * @param float $amount
-     *
      * @return $this
      */
     public function setAmount(float $amount)
@@ -178,8 +163,6 @@ class Transaction
 
     /**
      * Get creditDebit
-     *
-     * @return string
      */
     public function getCreditDebit(): string
     {
@@ -188,8 +171,6 @@ class Transaction
 
     /**
      * Set creditDebit
-     *
-     * @param string $creditDebit
      *
      * @return $this
      */
@@ -202,8 +183,6 @@ class Transaction
 
     /**
      * Get bookingCode
-     *
-     * @return string
      */
     public function getBookingCode(): string
     {
@@ -212,8 +191,6 @@ class Transaction
 
     /**
      * Set bookingCode
-     *
-     * @param string $bookingCode
      *
      * @return $this
      */
@@ -226,8 +203,6 @@ class Transaction
 
     /**
      * Get bookingText
-     *
-     * @return string
      */
     public function getBookingText(): string
     {
@@ -236,8 +211,6 @@ class Transaction
 
     /**
      * Set bookingText
-     *
-     * @param string $bookingText
      *
      * @return $this
      */
@@ -250,8 +223,6 @@ class Transaction
 
     /**
      * Get description1
-     *
-     * @return string
      */
     public function getDescription1(): string
     {
@@ -260,8 +231,6 @@ class Transaction
 
     /**
      * Set description1
-     *
-     * @param string $description1
      *
      * @return $this
      */
@@ -274,8 +243,6 @@ class Transaction
 
     /**
      * Get description2
-     *
-     * @return string
      */
     public function getDescription2(): string
     {
@@ -284,8 +251,6 @@ class Transaction
 
     /**
      * Set description2
-     *
-     * @param string $description2
      *
      * @return $this
      */
@@ -322,8 +287,6 @@ class Transaction
 
     /**
      * Get the main description (SVWZ)
-     *
-     * @return string
      */
     public function getMainDescription(): string
     {
@@ -336,8 +299,6 @@ class Transaction
 
     /**
      * Get the end to end id (EREF)
-     *
-     * @return string
      */
     public function getEndToEndID(): string
     {
@@ -350,8 +311,6 @@ class Transaction
 
     /**
      * Get bankCode
-     *
-     * @return string
      */
     public function getBankCode(): string
     {
@@ -360,8 +319,6 @@ class Transaction
 
     /**
      * Set bankCode
-     *
-     * @param string $bankCode
      *
      * @return $this
      */
@@ -374,8 +331,6 @@ class Transaction
 
     /**
      * Get accountNumber
-     *
-     * @return string
      */
     public function getAccountNumber(): string
     {
@@ -384,8 +339,6 @@ class Transaction
 
     /**
      * Set accountNumber
-     *
-     * @param string $accountNumber
      *
      * @return $this
      */
@@ -398,8 +351,6 @@ class Transaction
 
     /**
      * Get name
-     *
-     * @return string
      */
     public function getName(): string
     {
@@ -408,8 +359,6 @@ class Transaction
 
     /**
      * Get booked status
-     *
-     * @return bool
      */
     public function getBooked(): bool
     {
@@ -418,8 +367,6 @@ class Transaction
 
     /**
      * Set name
-     *
-     * @param string $name
      *
      * @return $this
      */
@@ -432,8 +379,6 @@ class Transaction
 
     /**
      * Get primanota number
-     *
-     * @return int
      */
     public function getPN(): int
     {
@@ -442,8 +387,6 @@ class Transaction
 
     /**
      * Set primanota number
-     *
-     * @param int $nr
      *
      * @return $this
      */

--- a/lib/Fhp/Model/StatementOfAccount/Transaction.php
+++ b/lib/Fhp/Model/StatementOfAccount/Transaction.php
@@ -85,7 +85,7 @@ class Transaction
      * @codeCoverageIgnore
      * @return \DateTime|null
      */
-    public function getDate()
+    public function getDate(): ?\DateTime
     {
         return $this->getBookingDate();
     }
@@ -95,7 +95,7 @@ class Transaction
      *
      * @return \DateTime|null
      */
-    public function getBookingDate()
+    public function getBookingDate(): ?\DateTime
     {
         return $this->bookingDate;
     }
@@ -105,7 +105,7 @@ class Transaction
      *
      * @return \DateTime|null
      */
-    public function getValutaDate()
+    public function getValutaDate(): ?\DateTime
     {
         return $this->valutaDate;
     }
@@ -143,7 +143,7 @@ class Transaction
      *
      * @return float
      */
-    public function getAmount()
+    public function getAmount(): float
     {
         return $this->amount;
     }
@@ -155,7 +155,7 @@ class Transaction
      *
      * @return $this
      */
-    public function setBooked($booked)
+    public function setBooked(bool $booked)
     {
         $this->booked = $booked;
 
@@ -169,7 +169,7 @@ class Transaction
      *
      * @return $this
      */
-    public function setAmount($amount)
+    public function setAmount(float $amount)
     {
         $this->amount = (float) $amount;
 
@@ -181,7 +181,7 @@ class Transaction
      *
      * @return string
      */
-    public function getCreditDebit()
+    public function getCreditDebit(): string
     {
         return $this->creditDebit;
     }
@@ -193,7 +193,7 @@ class Transaction
      *
      * @return $this
      */
-    public function setCreditDebit($creditDebit)
+    public function setCreditDebit(string $creditDebit)
     {
         $this->creditDebit = $creditDebit;
 
@@ -205,7 +205,7 @@ class Transaction
      *
      * @return string
      */
-    public function getBookingCode()
+    public function getBookingCode(): string
     {
         return $this->bookingCode;
     }
@@ -217,7 +217,7 @@ class Transaction
      *
      * @return $this
      */
-    public function setBookingCode($bookingCode)
+    public function setBookingCode(string $bookingCode)
     {
         $this->bookingCode = (string) $bookingCode;
 
@@ -229,7 +229,7 @@ class Transaction
      *
      * @return string
      */
-    public function getBookingText()
+    public function getBookingText(): string
     {
         return $this->bookingText;
     }
@@ -241,7 +241,7 @@ class Transaction
      *
      * @return $this
      */
-    public function setBookingText($bookingText)
+    public function setBookingText(string $bookingText)
     {
         $this->bookingText = (string) $bookingText;
 
@@ -253,7 +253,7 @@ class Transaction
      *
      * @return string
      */
-    public function getDescription1()
+    public function getDescription1(): string
     {
         return $this->description1;
     }
@@ -265,7 +265,7 @@ class Transaction
      *
      * @return $this
      */
-    public function setDescription1($description1)
+    public function setDescription1(string $description1)
     {
         $this->description1 = (string) $description1;
 
@@ -277,7 +277,7 @@ class Transaction
      *
      * @return string
      */
-    public function getDescription2()
+    public function getDescription2(): string
     {
         return $this->description2;
     }
@@ -289,7 +289,7 @@ class Transaction
      *
      * @return $this
      */
-    public function setDescription2($description2)
+    public function setDescription2(string $description2)
     {
         $this->description2 = (string) $description2;
 
@@ -301,7 +301,7 @@ class Transaction
      *
      * @return string[]
      */
-    public function getStructuredDescription()
+    public function getStructuredDescription(): array
     {
         return $this->structuredDescription;
     }
@@ -313,7 +313,7 @@ class Transaction
      *
      * @return $this
      */
-    public function setStructuredDescription($structuredDescription)
+    public function setStructuredDescription(array $structuredDescription)
     {
         $this->structuredDescription = $structuredDescription;
 
@@ -325,7 +325,7 @@ class Transaction
      *
      * @return string
      */
-    public function getMainDescription()
+    public function getMainDescription(): string
     {
         if (array_key_exists('SVWZ', $this->structuredDescription)) {
             return $this->structuredDescription['SVWZ'];
@@ -339,7 +339,7 @@ class Transaction
      *
      * @return string
      */
-    public function getEndToEndID()
+    public function getEndToEndID(): string
     {
         if (array_key_exists('EREF', $this->structuredDescription)) {
             return $this->structuredDescription['EREF'];
@@ -353,7 +353,7 @@ class Transaction
      *
      * @return string
      */
-    public function getBankCode()
+    public function getBankCode(): string
     {
         return $this->bankCode;
     }
@@ -365,7 +365,7 @@ class Transaction
      *
      * @return $this
      */
-    public function setBankCode($bankCode)
+    public function setBankCode(string $bankCode)
     {
         $this->bankCode = (string) $bankCode;
 
@@ -377,7 +377,7 @@ class Transaction
      *
      * @return string
      */
-    public function getAccountNumber()
+    public function getAccountNumber(): string
     {
         return $this->accountNumber;
     }
@@ -389,7 +389,7 @@ class Transaction
      *
      * @return $this
      */
-    public function setAccountNumber($accountNumber)
+    public function setAccountNumber(string $accountNumber)
     {
         $this->accountNumber = (string) $accountNumber;
 
@@ -401,7 +401,7 @@ class Transaction
      *
      * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }
@@ -411,7 +411,7 @@ class Transaction
      *
      * @return bool
      */
-    public function getBooked()
+    public function getBooked(): bool
     {
         return $this->booked;
     }
@@ -423,7 +423,7 @@ class Transaction
      *
      * @return $this
      */
-    public function setName($name)
+    public function setName(string $name)
     {
         $this->name = (string) $name;
 
@@ -435,7 +435,7 @@ class Transaction
      *
      * @return int
      */
-    public function getPN()
+    public function getPN(): int
     {
         return $this->pn;
     }
@@ -447,7 +447,7 @@ class Transaction
      *
      * @return $this
      */
-    public function setPN($nr)
+    public function setPN(int $nr)
     {
         $this->pn = (int) $nr;
         return $this;

--- a/lib/Fhp/Model/StatementOfAccount/Transaction.php
+++ b/lib/Fhp/Model/StatementOfAccount/Transaction.php
@@ -388,11 +388,12 @@ class Transaction
     /**
      * Set primanota number
      *
+     * @param int|mixed $nr Will be parsed to an int.
      * @return $this
      */
-    public function setPN(int $nr)
+    public function setPN($nr)
     {
-        $this->pn = (int) $nr;
+        $this->pn = intval($nr);
         return $this;
     }
 }

--- a/lib/Fhp/Model/TanMedium.php
+++ b/lib/Fhp/Model/TanMedium.php
@@ -15,12 +15,12 @@ interface TanMedium
      * @return string A user-readable name for this TAN medium, which serves as its identifier at the same time. This is
      *     what the application needs to persist when it wants to remember the users decision for future transactions.
      */
-    public function getName();
+    public function getName(): string;
 
     /**
      * @return string|null In case this is a mobileTAN/smsTAN medium, this is its (possibly obfuscated) phone number.
      */
-    public function getPhoneNumber();
+    public function getPhoneNumber(): ?string;
 
     // TODO Consider making more information from TanMediumListeV4 available here.
 }

--- a/lib/Fhp/Model/TanMode.php
+++ b/lib/Fhp/Model/TanMode.php
@@ -27,40 +27,40 @@ interface TanMode
      * @return int The ID of this TanMode. This is what the application needs to persist when it wants to remember
      *     the users decision for future transactions.
      */
-    public function getId();
+    public function getId(): int;
 
     /**
      * @return string A user-readable name, e.g. for display in a list.
      */
-    public function getName();
+    public function getName(): string;
 
     /**
      * @return string A user-readable label for the text field that displays the challenge to the user.
      */
-    public function getChallengeLabel();
+    public function getChallengeLabel(): string;
 
     /**
      * @return int The maximum length of the challenge. The application can use this to appropriately resize the
      *     text field that displays the challenge to the user.
      */
-    public function getMaxChallengeLength();
+    public function getMaxChallengeLength(): int;
 
     /**
      * @return int The maximum length of TANs entered in this mode. The application can use this to restrict the TAN
      *     input field or to do client-side validation.
      */
-    public function getMaxTanLength();
+    public function getMaxTanLength(): int;
 
     /**
      * @return int The allowed TAN format. See the FORMAT_* constants above. The application can use this to
      *     restrict the TAN input field or to do client-side validation.
      */
-    public function getTanFormat();
+    public function getTanFormat(): int;
 
     /**
      * @return bool If true, there are potentially multiple {@link TanMedium} choices (e.g. multiple mobile phones)
      *     associated with this TanMode (e.g. if it's the smsTAN mode), and the user needs to pick the medium in
      *     addition to and after picking this TanMode.
      */
-    public function needsTanMedium();
+    public function needsTanMedium(): bool;
 }

--- a/lib/Fhp/Model/TanRequest.php
+++ b/lib/Fhp/Model/TanRequest.php
@@ -12,16 +12,16 @@ interface TanRequest
     /**
      * @return string An identifier used by the bank to match the provided TAN with the original request.
      */
-    public function getProcessId();
+    public function getProcessId(): string;
 
     /**
      * @return string A challenge to be displayed to the user.
      */
-    public function getChallenge();
+    public function getChallenge(): string;
 
     /**
      * @return string|null Possibly the name of the {@link TanMedium} to be used. If present, this should be displayed
      *     to the user, so that they know what to do.
      */
-    public function getTanMediumName();
+    public function getTanMediumName(): ?string;
 }

--- a/lib/Fhp/Protocol/BPD.php
+++ b/lib/Fhp/Protocol/BPD.php
@@ -79,7 +79,7 @@ class BPD
      * @return BaseSegment|null The latest parameter segment that is explicitly implemented in this library (never an
      *     AnonymousSegment), or null if none exists.
      */
-    public function getLatestSupportedParameters($type)
+    public function getLatestSupportedParameters(string $type): ?BaseSegment
     {
         if (!array_key_exists($type, $this->parameters)) {
             return null;
@@ -97,7 +97,7 @@ class BPD
      * @return BaseSegment The latest parameter segment, never null.
      * @throws UnexpectedResponseException If no version exists.
      */
-    public function requireLatestSupportedParameters($type)
+    public function requireLatestSupportedParameters(string $type): BaseSegment
     {
         $result = $this->getLatestSupportedParameters($type);
         if ($result === null) {
@@ -112,7 +112,7 @@ class BPD
      * @param int $version The segment version of the business transaction.
      * @return bool If that version of the given transaction type is supported by the bank.
      */
-    public function supportsParameters($type, $version)
+    public function supportsParameters(string $type, int $version): bool
     {
         foreach ($this->parameters[$type] as $segment) {
             if ($segment->getVersion() === $version) {
@@ -126,7 +126,7 @@ class BPD
      * @param SegmentInterface[] $requestSegments The segments that shall be sent to the bank.
      * @return bool True if any of the given segments requires a TAN according to HIPINS.
      */
-    public function tanRequiredForRequest($requestSegments)
+    public function tanRequiredForRequest(array $requestSegments): bool
     {
         foreach ($requestSegments as $segment) {
             if ($this->tanRequired[$segment->getName()] ?? false) {
@@ -141,7 +141,7 @@ class BPD
      * @param FinTsOptions $options See {@link FinTsOptions}.
      * @return BPD A new BPD instance with the extracted configuration data.
      */
-    public static function extractFromResponse($response, $options)
+    public static function extractFromResponse(Message $response, FinTsOptions $options): BPD
     {
         $bpd = new BPD();
         $bpd->hibpa = $response->requireSegment(HIBPAv3::class);

--- a/lib/Fhp/Protocol/DialogInitialization.php
+++ b/lib/Fhp/Protocol/DialogInitialization.php
@@ -82,8 +82,6 @@ class DialogInitialization extends BaseAction
     private $upd;
 
     /**
-     * @param FinTsOptions $options
-     * @param Credentials $credentials
      * @param TanMode|null $tanMode The TAN mode selected by the user.
      * @param string|null $tanMedium Possibly a TAN medium selected by the user.
      * @param string|null $kundensystemId The current Kundensystem-ID, if the client already has one.
@@ -167,33 +165,21 @@ class DialogInitialization extends BaseAction
         return $this->hktanRef === 'HKIDN';
     }
 
-    /**
-     * @return string|null
-     */
     public function getKundensystemId(): ?string
     {
         return $this->kundensystemId;
     }
 
-    /**
-     * @return int|null
-     */
     public function getMessageNumber(): ?int
     {
         return $this->messageNumber;
     }
 
-    /**
-     * @param int|null $messageNumber
-     */
     public function setMessageNumber(?int $messageNumber): void
     {
         $this->messageNumber = $messageNumber;
     }
 
-    /**
-     * @return string|null
-     */
     public function getDialogId(): ?string
     {
         return $this->dialogId;
@@ -201,16 +187,12 @@ class DialogInitialization extends BaseAction
 
     /**
      * To be called when a TAN is required for login, but we need to intermittently store the Dialog-ID.
-     * @param string|null $dialogId
      */
     public function setDialogId(?string $dialogId): void
     {
         $this->dialogId = $dialogId;
     }
 
-    /**
-     * @return UPD|null
-     */
     public function getUpd(): ?UPD
     {
         return $this->upd;

--- a/lib/Fhp/Protocol/DialogInitialization.php
+++ b/lib/Fhp/Protocol/DialogInitialization.php
@@ -104,7 +104,7 @@ class DialogInitialization extends BaseAction
         $this->hktanRef = $hktanRef;
     }
 
-    public function serialize()
+    public function serialize(): string
     {
         return serialize([
             parent::serialize(),
@@ -128,7 +128,7 @@ class DialogInitialization extends BaseAction
     }
 
     /** {@inheritdoc} */
-    public function createRequest($bpd, $upd)
+    public function createRequest(BPD $bpd, UPD $upd)
     {
         $request = [
             HKIDNv2::create($this->options->bankCode, $this->credentials, $this->kundensystemId ?? '0'),
@@ -143,7 +143,7 @@ class DialogInitialization extends BaseAction
         return $request;
     }
 
-    public function processResponse($response)
+    public function processResponse(Message$response)
     {
         parent::processResponse($response);
         $this->dialogId = $response->header->dialogId;

--- a/lib/Fhp/Protocol/DialogInitialization.php
+++ b/lib/Fhp/Protocol/DialogInitialization.php
@@ -126,7 +126,7 @@ class DialogInitialization extends BaseAction
     }
 
     /** {@inheritdoc} */
-    public function createRequest(BPD $bpd, UPD $upd)
+    public function createRequest(BPD $bpd, ?UPD $upd)
     {
         $request = [
             HKIDNv2::create($this->options->bankCode, $this->credentials, $this->kundensystemId ?? '0'),

--- a/lib/Fhp/Protocol/DialogInitialization.php
+++ b/lib/Fhp/Protocol/DialogInitialization.php
@@ -94,7 +94,7 @@ class DialogInitialization extends BaseAction
      *     If it is one of the special PIN/TAN management segments (e.g. HKTAB), then the dialog does not have strong
      *     authentication (no TAN required) and can only be used for that one particular transaction.
      */
-    public function __construct($options, $credentials, $tanMode, $tanMedium, $kundensystemId, $hktanRef = 'HKIDN')
+    public function __construct(FinTsOptions $options, Credentials $credentials, ?TanMode $tanMode, ?string $tanMedium, ?string $kundensystemId, ?string $hktanRef = 'HKIDN')
     {
         $this->options = $options;
         $this->credentials = $credentials;

--- a/lib/Fhp/Protocol/DialogInitialization.php
+++ b/lib/Fhp/Protocol/DialogInitialization.php
@@ -143,7 +143,7 @@ class DialogInitialization extends BaseAction
         return $request;
     }
 
-    public function processResponse(Message$response)
+    public function processResponse(Message $response)
     {
         parent::processResponse($response);
         $this->dialogId = $response->header->dialogId;

--- a/lib/Fhp/Protocol/GetTanMedia.php
+++ b/lib/Fhp/Protocol/GetTanMedia.php
@@ -18,7 +18,7 @@ class GetTanMedia extends BaseAction
     private $tanMedia;
 
     /** {@inheritdoc} */
-    public function createRequest($bpd, $upd)
+    public function createRequest(BPD $bpd, UPD $upd)
     {
         // Prepare the HKTAB request.
         $hitabs = $bpd->requireLatestSupportedParameters('HITABS');
@@ -33,7 +33,7 @@ class GetTanMedia extends BaseAction
     }
 
     /** {@inheritdoc} */
-    public function processResponse($response)
+    public function processResponse(Message $response)
     {
         parent::processResponse($response);
         /** @var HITAB $hitab */

--- a/lib/Fhp/Protocol/GetTanMedia.php
+++ b/lib/Fhp/Protocol/GetTanMedia.php
@@ -18,7 +18,7 @@ class GetTanMedia extends BaseAction
     private $tanMedia;
 
     /** {@inheritdoc} */
-    public function createRequest(BPD $bpd, UPD $upd)
+    public function createRequest(BPD $bpd, ?UPD $upd)
     {
         // Prepare the HKTAB request.
         $hitabs = $bpd->requireLatestSupportedParameters('HITABS');

--- a/lib/Fhp/Protocol/Message.php
+++ b/lib/Fhp/Protocol/Message.php
@@ -106,7 +106,7 @@ class Message
      * @param string $segmentType The PHP type (class name or interface) of the segment(s).
      * @return BaseSegment[] All segments of this type (possibly an empty array).
      */
-    public function findSegments($segmentType)
+    public function findSegments(string $segmentType): array
     {
         return array_values(array_filter($this->plainSegments, function ($segment) use ($segmentType) {
             /* @var BaseSegment $segment */
@@ -118,7 +118,7 @@ class Message
      * @param string $segmentType The PHP type (class name or interface) of the segment.
      * @return BaseSegment|null The segment, or null if it was found.
      */
-    public function findSegment($segmentType)
+    public function findSegment(string $segmentType): ?BaseSegment
     {
         $matchedSegments = $this->findSegments($segmentType);
         if (count($matchedSegments) > 1) {
@@ -131,7 +131,7 @@ class Message
      * @param string $segmentType The PHP type (class name or interface) of the segment.
      * @return bool Whether any such segment exists.
      */
-    public function hasSegment($segmentType)
+    public function hasSegment(string $segmentType): bool
     {
         return $this->findSegment($segmentType) !== null;
     }
@@ -141,7 +141,7 @@ class Message
      * @return BaseSegment The segment, never null.
      * @throws UnexpectedResponseException If the segment was not found.
      */
-    public function requireSegment($segmentType)
+    public function requireSegment(string $segmentType): BaseSegment
     {
         $matchedSegment = $this->findSegment($segmentType);
         if ($matchedSegment === null) {
@@ -154,7 +154,7 @@ class Message
      * @param int $segmentNumber The segment number to search for.
      * @return BaseSegment|null The segment with that number, or null if there is none.
      */
-    public function findSegmentByNumber($segmentNumber)
+    public function findSegmentByNumber(int $segmentNumber): ?BaseSegment
     {
         foreach ($this->getAllSegments() as $segment) {
             if ($segment->getSegmentNumber() === $segmentNumber) {
@@ -169,7 +169,7 @@ class Message
      * @return Message A new message that just contains the plain segment from $this message which refer to one
      *     of the given $referenceSegments.
      */
-    public function filterByReferenceSegments($referenceNumbers)
+    public function filterByReferenceSegments(array $referenceNumbers): Message
     {
         $result = new Message();
         if (count($referenceNumbers) === 0) {
@@ -191,7 +191,7 @@ class Message
      * @param int $code The response code to search for.
      * @return Rueckmeldung|null The corresponding Rueckmeldung instance, or null if not found.
      */
-    public function findRueckmeldung($code)
+    public function findRueckmeldung(int $code): ?Rueckmeldung
     {
         foreach ($this->plainSegments as $segment) {
             if ($segment instanceof RueckmeldungContainer) {
@@ -207,7 +207,7 @@ class Message
     /**
      * @return string The HBCI/FinTS wire format for this message, ISO-8859-1 encoded.
      */
-    public function serialize()
+    public function serialize(): string
     {
         $result = '';
         foreach ($this->wrapperSegments as $segment) {
@@ -227,7 +227,7 @@ class Message
      * @param string|null The TAN to be sent to the server (in HNSHA). If this is present, $tanMode must be present.
      * @return Message The built message, ready to be sent to the server through {@link FinTsNew::sendMessage()}.
      */
-    public static function createWrappedMessage($plainSegments, $options, $kundensystemId, $credentials, $tanMode, $tan)
+    public static function createWrappedMessage($plainSegments, FinTsOptions $options, string $kundensystemId, Credentials $credentials, ?TanMode $tanMode, $tan): Message
     {
         $message = new Message();
         $message->plainSegments = $plainSegments instanceof MessageBuilder ? $plainSegments->segments : $plainSegments;
@@ -259,7 +259,7 @@ class Message
      * @param BaseSegment[]|MessageBuilder $segments
      * @return Message The built message, ready to be sent to the server through {@link FinTsNew::sendMessage()}.
      */
-    public static function createPlainMessage($segments)
+    public static function createPlainMessage($segments): Message
     {
         $message = new Message();
         $message->plainSegments = $segments instanceof MessageBuilder ? $segments->segments : $segments;
@@ -280,7 +280,7 @@ class Message
      * @return Message The parsed message.
      * @throws \InvalidArgumentException When the parsing fails.
      */
-    public static function parse($rawMessage)
+    public static function parse(string $rawMessage): Message
     {
         $result = new Message();
         $segments = Parser::parseSegments($rawMessage);
@@ -337,7 +337,7 @@ class Message
      * @param int $segmentNumber The number for the *first* segment, subsequent segment get the subsequent integers.
      * @return BaseSegment[] The same array, for chaining.
      */
-    private static function setSegmentNumbers($segments, $segmentNumber)
+    private static function setSegmentNumbers(array $segments, int $segmentNumber): array
     {
         foreach ($segments as $segment) {
             $segment->segmentkopf->segmentnummer = $segmentNumber;

--- a/lib/Fhp/Protocol/MessageBuilder.php
+++ b/lib/Fhp/Protocol/MessageBuilder.php
@@ -16,7 +16,7 @@ class MessageBuilder
     public $segments = [];
 
     /** @return MessageBuilder A new instance. */
-    public static function create()
+    public static function create(): MessageBuilder
     {
         return new MessageBuilder();
     }

--- a/lib/Fhp/Protocol/ServerException.php
+++ b/lib/Fhp/Protocol/ServerException.php
@@ -31,8 +31,6 @@ class ServerException extends \Exception
      * @param Rueckmeldung[] $errors
      * @param Rueckmeldung[] $warnings
      * @param string[] $requestSegments (already serialized and sanitized)
-     * @param Message $request
-     * @param Message $response
      */
     public function __construct(array $errors, array $warnings, array $requestSegments, Message $request, Message $response)
     {

--- a/lib/Fhp/Protocol/ServerException.php
+++ b/lib/Fhp/Protocol/ServerException.php
@@ -34,7 +34,7 @@ class ServerException extends \Exception
      * @param Message $request
      * @param Message $response
      */
-    public function __construct($errors, $warnings, $requestSegments, $request, $response)
+    public function __construct(array $errors, array $warnings, array $requestSegments, Message $request, Message $response)
     {
         $this->errors = $errors;
         $this->warnings = $warnings;
@@ -54,7 +54,7 @@ class ServerException extends \Exception
      * @return ServerException|null The part of the exception that pertains to the given reference segments, or null if
      *     none of the errors refer to them.
      */
-    public function extractErrorsForReference($referenceNumbers)
+    public function extractErrorsForReference(array $referenceNumbers): ?ServerException
     {
         if (count($referenceNumbers) === 0) {
             return null;
@@ -103,7 +103,7 @@ class ServerException extends \Exception
      * @param int $code A Rueckmeldungscode to look for.
      * @return bool Whether an error with this code is present.
      */
-    public function hasError($code)
+    public function hasError(int $code): bool
     {
         foreach ($this->errors as $error) {
             if ($error->rueckmeldungscode === $code) {
@@ -132,7 +132,7 @@ class ServerException extends \Exception
      * @return bool True if the {@link Credentials} used to make this request are wrong. If this returns true, the
      *     application should ask the user to re-enter the credentials before making any further requests to the bank.
      */
-    public function indicatesBadLoginData()
+    public function indicatesBadLoginData(): bool
     {
         return $this->hasError(Rueckmeldungscode::PIN_UNGUELTIG);
     }
@@ -143,7 +143,7 @@ class ServerException extends \Exception
      *     refrain from logging in / using that account in any automated way before getting confirmation from the user
      *     that it has been unlocked.
      */
-    public function indicatesLocked()
+    public function indicatesLocked(): bool
     {
         return $this->hasError(Rueckmeldungscode::PIN_GESPERRT)
             || $this->hasError(Rueckmeldungscode::TEILNEHMER_GESPERRT)
@@ -154,7 +154,7 @@ class ServerException extends \Exception
      * @return bool True if the provided TAN is invalid (including entirely wrong, used for another transaction already,
      *     or exceeded its expiration time).
      */
-    public function indicatesBadTan()
+    public function indicatesBadTan(): bool
     {
         return $this->hasError(Rueckmeldungscode::TAN_UNGUELTIG)
             || $this->hasError(Rueckmeldungscode::TAN_BEREITS_VERBRAUCHT)
@@ -167,7 +167,7 @@ class ServerException extends \Exception
      *     refer to, for ease of debugging.
      * @throws ServerException In case the response indicates an error.
      */
-    public static function detectAndThrowErrors($response, $request)
+    public static function detectAndThrowErrors(Message $response, Message $request)
     {
         /** @var HIRMGv2[]|HIRMSv2[] $segments */
         $segments = array_merge(

--- a/lib/Fhp/Protocol/TanRequiredException.php
+++ b/lib/Fhp/Protocol/TanRequiredException.php
@@ -15,7 +15,7 @@ class TanRequiredException extends \RuntimeException
     /**
      * @param TanRequest $tanRequest
      */
-    public function __construct($tanRequest)
+    public function __construct(TanRequest $tanRequest)
     {
         parent::__construct('This action requires a TAN to be completed.');
         $this->tanRequest = $tanRequest;

--- a/lib/Fhp/Protocol/TanRequiredException.php
+++ b/lib/Fhp/Protocol/TanRequiredException.php
@@ -12,9 +12,6 @@ class TanRequiredException extends \RuntimeException
     /** @var TanRequest $hitan */
     private $tanRequest;
 
-    /**
-     * @param TanRequest $tanRequest
-     */
     public function __construct(TanRequest $tanRequest)
     {
         parent::__construct('This action requires a TAN to be completed.');

--- a/lib/Fhp/Protocol/UPD.php
+++ b/lib/Fhp/Protocol/UPD.php
@@ -28,7 +28,7 @@ class UPD
      * @return bool True if the UPD data is contained in the response and {@link #extractFromResponse()} would
      *     succeed.
      */
-    public static function containedInResponse($response)
+    public static function containedInResponse(Message $response): bool
     {
         return $response->hasSegment(HIUPAv4::class);
     }
@@ -38,7 +38,7 @@ class UPD
      *     data.
      * @return UPD A new UPD instance with the extracted configuration data.
      */
-    public static function extractFromResponse($response)
+    public static function extractFromResponse(Message $response): UPD
     {
         $upd = new UPD();
         $upd->hiupa = $response->requireSegment(HIUPAv4::class);
@@ -50,7 +50,7 @@ class UPD
      * @param SEPAAccount $account An account.
      * @return HIUPD|null The HIUPD segment for this account, or null if none exists for this account.
      */
-    public function findHiupd(SEPAAccount $account)
+    public function findHiupd(SEPAAccount $account): ?HIUPD
     {
         foreach ($this->hiupd as $hiupd) {
             if ($hiupd->matchesAccount($account)) {
@@ -65,7 +65,7 @@ class UPD
      * @param string $requestName The request that shall be sent to the bank.
      * @return bool True if the given request can be used by the current user for the given account.
      */
-    public function isRequestSupportedForAccount(SEPAAccount $account, $requestName)
+    public function isRequestSupportedForAccount(SEPAAccount $account, string $requestName): bool
     {
         $hiupd = $this->findHiupd($account);
         if ($hiupd !== null) {

--- a/lib/Fhp/Protocol/UnexpectedResponseException.php
+++ b/lib/Fhp/Protocol/UnexpectedResponseException.php
@@ -13,7 +13,7 @@ class UnexpectedResponseException extends \RuntimeException
      * @param int $code
      * @param \Exception|null $previous
      */
-    public function __construct($message, $code = 0, \Exception $previous = null)
+    public function __construct(string $message, int $code = 0, \Exception $previous = null)
     {
         parent::__construct($message, $code, $previous);
     }

--- a/lib/Fhp/Protocol/UnexpectedResponseException.php
+++ b/lib/Fhp/Protocol/UnexpectedResponseException.php
@@ -8,11 +8,6 @@ namespace Fhp\Protocol;
  */
 class UnexpectedResponseException extends \RuntimeException
 {
-    /**
-     * @param string $message
-     * @param int $code
-     * @param \Exception|null $previous
-     */
     public function __construct(string $message, int $code = 0, \Exception $previous = null)
     {
         parent::__construct($message, $code, $previous);

--- a/lib/Fhp/Response/GetAccounts.php
+++ b/lib/Fhp/Response/GetAccounts.php
@@ -32,7 +32,6 @@ class GetAccounts extends Response
     /**
      * Creates a Account model from array.
      *
-     * @param array $array
      * @return Account
      */
     protected function createModelFromArray(array $array)

--- a/lib/Fhp/Response/GetSEPAAccounts.php
+++ b/lib/Fhp/Response/GetSEPAAccounts.php
@@ -35,7 +35,6 @@ class GetSEPAAccounts extends Response
     /**
      * Creates a SEPAAccount model from array.
      *
-     * @param array $array
      * @return SEPAAccount
      */
     protected function createModelFromArray(array $array)

--- a/lib/Fhp/Response/GetSaldo.php
+++ b/lib/Fhp/Response/GetSaldo.php
@@ -33,7 +33,6 @@ class GetSaldo extends Response
     /**
      * Creates a Saldo model from array.
      *
-     * @param array $array
      * @return Saldo
      * @throws \Exception
      */

--- a/lib/Fhp/Response/GetStatementOfAccount.php
+++ b/lib/Fhp/Response/GetStatementOfAccount.php
@@ -30,8 +30,6 @@ class GetStatementOfAccount extends Response
     /**
      * Adds statements to an existing StatementOfAccount object.
      *
-     * @param array $array
-     * @param StatementOfAccount $statementOfAccount
      * @return StatementOfAccount
      */
     public static function addFromArray(array $array, StatementOfAccount $statementOfAccount)
@@ -88,7 +86,6 @@ class GetStatementOfAccount extends Response
     /**
      * Creates a StatementOfAccount model from array.
      *
-     * @param array $array
      * @return StatementOfAccount
      */
     public static function createModelFromArray(array $array)

--- a/lib/Fhp/Response/Response.php
+++ b/lib/Fhp/Response/Response.php
@@ -131,8 +131,6 @@ class Response
     /**
      * Some kind of HBCI pagination.
      *
-     * @param AbstractMessage $message
-     *
      * @return array
      */
     public function getTouchDowns(AbstractMessage $message)
@@ -319,7 +317,6 @@ class Response
 
     /**
      * @param string           $name
-     * @param SegmentInterface $reference
      *
      * @return string|null
      */

--- a/lib/Fhp/Segment/AbstractSegment.php
+++ b/lib/Fhp/Segment/AbstractSegment.php
@@ -78,7 +78,7 @@ abstract class AbstractSegment implements SegmentInterface
      * @param bool $translateCodes
      * @return string
      */
-    public function humanReadable($translateCodes = false)
+    public function humanReadable(bool $translateCodes = false)
     {
         return str_replace(
             ["'", '+'],

--- a/lib/Fhp/Segment/AbstractSegment.php
+++ b/lib/Fhp/Segment/AbstractSegment.php
@@ -69,7 +69,7 @@ abstract class AbstractSegment implements SegmentInterface
     /**
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return $this->toString();
     }
@@ -92,7 +92,7 @@ abstract class AbstractSegment implements SegmentInterface
     /**
      * @return int
      */
-    public function getSegmentNumber()
+    public function getSegmentNumber(): int
     {
         return $this->segmentNumber;
     }
@@ -100,7 +100,7 @@ abstract class AbstractSegment implements SegmentInterface
     /**
      * @return int
      */
-    public function getVersion()
+    public function getVersion(): int
     {
         return $this->version;
     }

--- a/lib/Fhp/Segment/AbstractSegment.php
+++ b/lib/Fhp/Segment/AbstractSegment.php
@@ -22,7 +22,6 @@ abstract class AbstractSegment implements SegmentInterface
      * @param $type
      * @param $segmentNumber
      * @param $version
-     * @param array $dataElements
      */
     public function __construct($type, $segmentNumber, $version, array $dataElements = [])
     {
@@ -32,9 +31,6 @@ abstract class AbstractSegment implements SegmentInterface
         $this->dataElements = $dataElements;
     }
 
-    /**
-     * @param array $dataElements
-     */
     public function setDataElements(array $dataElements = [])
     {
         $this->dataElements = $dataElements;
@@ -66,16 +62,12 @@ abstract class AbstractSegment implements SegmentInterface
         return $string . static::SEGMENT_SEPARATOR;
     }
 
-    /**
-     * @return string
-     */
     public function __toString(): string
     {
         return $this->toString();
     }
 
     /**
-     * @param bool $translateCodes
      * @return string
      */
     public function humanReadable(bool $translateCodes = false)
@@ -89,17 +81,11 @@ abstract class AbstractSegment implements SegmentInterface
         );
     }
 
-    /**
-     * @return int
-     */
     public function getSegmentNumber(): int
     {
         return $this->segmentNumber;
     }
 
-    /**
-     * @return int
-     */
     public function getVersion(): int
     {
         return $this->version;

--- a/lib/Fhp/Segment/AnonymousSegment.php
+++ b/lib/Fhp/Segment/AnonymousSegment.php
@@ -30,7 +30,6 @@ final class AnonymousSegment extends BaseSegment implements \Serializable
     private $elements = [];
 
     /**
-     * @param Segmentkopf $segmentkopf
      * @param string[]|string[][] $elements
      */
     public function __construct(Segmentkopf $segmentkopf, array $elements)

--- a/lib/Fhp/Segment/AnonymousSegment.php
+++ b/lib/Fhp/Segment/AnonymousSegment.php
@@ -40,7 +40,7 @@ final class AnonymousSegment extends BaseSegment implements \Serializable
         $this->elements = $elements;
     }
 
-    public function getDescriptor()
+    public function getDescriptor(): SegmentDescriptor
     {
         throw new \RuntimeException('AnonymousSegments do not have a descriptor');
     }
@@ -50,7 +50,7 @@ final class AnonymousSegment extends BaseSegment implements \Serializable
         // Do nothing, anonymous segments are always valid.
     }
 
-    public function serialize()
+    public function serialize(): string
     {
         return $this->segmentkopf->serialize() . Delimiter::ELEMENT .
             implode(Delimiter::ELEMENT, array_map(function ($element) {
@@ -76,7 +76,7 @@ final class AnonymousSegment extends BaseSegment implements \Serializable
     /**
      * Just to override the super factory.
      */
-    public static function createEmpty()
+    public static function createEmpty(): self
     {
         // Note: createEmpty() normally runs the constructor and then fills the Segmentkopf, but that is not possible
         // for AnonymousSegment. Callers should just call the constructor itself.

--- a/lib/Fhp/Segment/AnonymousSegment.php
+++ b/lib/Fhp/Segment/AnonymousSegment.php
@@ -33,7 +33,7 @@ final class AnonymousSegment extends BaseSegment implements \Serializable
      * @param Segmentkopf $segmentkopf
      * @param string[]|string[][] $elements
      */
-    public function __construct($segmentkopf, $elements)
+    public function __construct(Segmentkopf $segmentkopf, array $elements)
     {
         $this->segmentkopf = $segmentkopf;
         $this->type = $segmentkopf->segmentkennung . 'v' . $segmentkopf->segmentversion;

--- a/lib/Fhp/Segment/AnonymousSegment.php
+++ b/lib/Fhp/Segment/AnonymousSegment.php
@@ -76,7 +76,7 @@ final class AnonymousSegment extends BaseSegment implements \Serializable
     /**
      * Just to override the super factory.
      */
-    public static function createEmpty(): self
+    public static function createEmpty()
     {
         // Note: createEmpty() normally runs the constructor and then fills the Segmentkopf, but that is not possible
         // for AnonymousSegment. Callers should just call the constructor itself.

--- a/lib/Fhp/Segment/BaseDeg.php
+++ b/lib/Fhp/Segment/BaseDeg.php
@@ -20,7 +20,7 @@ abstract class BaseDeg implements \Serializable
     /**
      * @return DegDescriptor The descriptor for this Deg type.
      */
-    public function getDescriptor()
+    public function getDescriptor(): DegDescriptor
     {
         if ($this->descriptor === null) {
             $this->descriptor = DegDescriptor::get(static::class);
@@ -47,7 +47,7 @@ abstract class BaseDeg implements \Serializable
      * Short-hand for {@link Serializer#serializeDeg()}.
      * @return string The HBCI wire format representation of this DEG.
      */
-    public function serialize()
+    public function serialize(): string
     {
         return Serializer::serializeDeg($this, $this->getDescriptor());
     }
@@ -56,7 +56,7 @@ abstract class BaseDeg implements \Serializable
      * Parses into the current instance.
      * @param string $serialized The HBCI wire format for a DEG of this type.
      */
-    public function unserialize($serialized)
+    public function unserialize(string $serialized)
     {
         Parser::parseDeg($serialized, $this);
     }
@@ -67,7 +67,7 @@ abstract class BaseDeg implements \Serializable
      * @param string $rawElements The serialized wire format for a data element group.
      * @return static The parsed value.
      */
-    public static function parse($rawElements)
+    public static function parse(string $rawElements): self
     {
         if (static::class === BaseDeg::class) {
             throw new UnsupportedException('Must not call BaseDeg::parse() on the base class');

--- a/lib/Fhp/Segment/BaseDeg.php
+++ b/lib/Fhp/Segment/BaseDeg.php
@@ -56,7 +56,7 @@ abstract class BaseDeg implements \Serializable
      * Parses into the current instance.
      * @param string $serialized The HBCI wire format for a DEG of this type.
      */
-    public function unserialize(string $serialized)
+    public function unserialize($serialized)
     {
         Parser::parseDeg($serialized, $this);
     }

--- a/lib/Fhp/Segment/BaseDeg.php
+++ b/lib/Fhp/Segment/BaseDeg.php
@@ -67,7 +67,7 @@ abstract class BaseDeg implements \Serializable
      * @param string $rawElements The serialized wire format for a data element group.
      * @return static The parsed value.
      */
-    public static function parse(string $rawElements): self
+    public static function parse(string $rawElements)
     {
         if (static::class === BaseDeg::class) {
             throw new UnsupportedException('Must not call BaseDeg::parse() on the base class');

--- a/lib/Fhp/Segment/BaseDescriptor.php
+++ b/lib/Fhp/Segment/BaseDescriptor.php
@@ -99,7 +99,7 @@ abstract class BaseDescriptor
      * @throws \InvalidArgumentException If any of the fields in the given object is not valid according to the schema
      *     defined by this descriptor.
      */
-    public function validateObject(object $obj)
+    public function validateObject($obj)
     {
         if (!is_a($obj, $this->class)) {
             throw new \InvalidArgumentException("Expected $this->class, got " . gettype($obj));

--- a/lib/Fhp/Segment/BaseDescriptor.php
+++ b/lib/Fhp/Segment/BaseDescriptor.php
@@ -33,7 +33,7 @@ abstract class BaseDescriptor
     /**
      * @param \ReflectionClass $clazz
      */
-    protected function __construct($clazz)
+    protected function __construct(\ReflectionClass $clazz)
     {
         // Use reflection to map PHP class fields to elements in the segment/Deg.
         $implicitIndex = true;
@@ -99,7 +99,7 @@ abstract class BaseDescriptor
      * @throws \InvalidArgumentException If any of the fields in the given object is not valid according to the schema
      *     defined by this descriptor.
      */
-    public function validateObject($obj)
+    public function validateObject(object $obj)
     {
         if (!is_a($obj, $this->class)) {
             throw new \InvalidArgumentException("Expected $this->class, got " . gettype($obj));
@@ -114,7 +114,7 @@ abstract class BaseDescriptor
      * @return \Generator|\ReflectionProperty[] All non-static public properties of the given class and its parents, but
      *     with the parents' properties *first*.
      */
-    private static function enumerateProperties($clazz)
+    private static function enumerateProperties(\ReflectionClass $clazz)
     {
         if ($clazz->getParentClass() !== false) {
             yield from static::enumerateProperties($clazz->getParentClass());
@@ -133,7 +133,7 @@ abstract class BaseDescriptor
      * @param string $docComment The documentation string of a PHP field.
      * @return string|null The content of the annotation, or null if absent.
      */
-    private static function getAnnotation($name, $docComment)
+    private static function getAnnotation(string $name, string $docComment): ?string
     {
         $ret = preg_match("/@$name\\((.*?)\\)/", $docComment, $match);
         if ($ret === false) {
@@ -148,7 +148,7 @@ abstract class BaseDescriptor
      * @param string $docComment The documentation string of a PHP field.
      * @return int|null The value of the annotation as an integer, or null if absent.
      */
-    private static function getIntAnnotation($name, $docComment)
+    private static function getIntAnnotation(string $name, string $docComment): ?int
     {
         $val = static::getAnnotation($name, $docComment);
         if ($val === null) {
@@ -165,7 +165,7 @@ abstract class BaseDescriptor
      * @param string $docComment The documentation string of a PHP field.
      * @return bool Whether the annotation with the given name is present.
      */
-    private static function getBoolAnnotation($name, $docComment)
+    private static function getBoolAnnotation(string $name, string $docComment): bool
     {
         return strpos("@$name ", $docComment) !== false
             || strpos("@$name())", $docComment) !== false;
@@ -176,7 +176,7 @@ abstract class BaseDescriptor
      * @param string $docComment The documentation string of a PHP field.
      * @return string|null The value of the {@}var annotation, or null if absent.
      */
-    private static function getVarAnnotation($docComment)
+    private static function getVarAnnotation(string $docComment): ?string
     {
         $ret = preg_match('/@var ([^\\s]+)/', $docComment, $match);
         if ($ret === false) {
@@ -192,7 +192,7 @@ abstract class BaseDescriptor
      *     classes in the same package.
      * @return string|\ReflectionClass The class that the type name refers to, or the scalar type name as a string.
      */
-    private static function resolveType($typeName, $contextClass)
+    private static function resolveType(string $typeName, \ReflectionClass $contextClass)
     {
         if (ElementDescriptor::isScalarType($typeName)) {
             return $typeName;

--- a/lib/Fhp/Segment/BaseDescriptor.php
+++ b/lib/Fhp/Segment/BaseDescriptor.php
@@ -30,9 +30,6 @@ abstract class BaseDescriptor
      */
     public $maxIndex;
 
-    /**
-     * @param \ReflectionClass $clazz
-     */
     protected function __construct(\ReflectionClass $clazz)
     {
         // Use reflection to map PHP class fields to elements in the segment/Deg.

--- a/lib/Fhp/Segment/BaseSegment.php
+++ b/lib/Fhp/Segment/BaseSegment.php
@@ -27,7 +27,7 @@ abstract class BaseSegment implements SegmentInterface, \Serializable
     /**
      * @return SegmentDescriptor The descriptor for this segment's type.
      */
-    public function getDescriptor()
+    public function getDescriptor(): SegmentDescriptor
     {
         if ($this->descriptor === null) {
             $this->descriptor = SegmentDescriptor::get(static::class);
@@ -54,7 +54,7 @@ abstract class BaseSegment implements SegmentInterface, \Serializable
      * @param int $segmentNumber The new segment number.
      * @return $this The same instance.
      */
-    public function setSegmentNumber($segmentNumber)
+    public function setSegmentNumber(int $segmentNumber)
     {
         $this->segmentkopf->segmentnummer = $segmentNumber;
         return $this;
@@ -73,7 +73,7 @@ abstract class BaseSegment implements SegmentInterface, \Serializable
      * @return string The HBCI wire format representation of this segment, in ISO-8859-1 encoding, terminated by the
      *     segment delimiter.
      */
-    public function serialize()
+    public function serialize(): string
     {
         return Serializer::serializeSegment($this);
     }
@@ -101,7 +101,7 @@ abstract class BaseSegment implements SegmentInterface, \Serializable
      *     the end). This should be ISO-8859-1-encoded.
      * @return static The parsed segment.
      */
-    public static function parse($rawSegment)
+    public static function parse(string $rawSegment): self
     {
         if (static::class === BaseSegment::class) {
             // Called as BaseSegment::parse(), so we need to determine the right segment type/class.
@@ -115,7 +115,7 @@ abstract class BaseSegment implements SegmentInterface, \Serializable
     /**
      * @return static A new segment of the type on which this function was called, with the Segmentkopf initialized.
      */
-    public static function createEmpty()
+    public static function createEmpty(): self
     {
         if (static::class === BaseSegment::class) {
             throw new \InvalidArgumentException('Must not call BaseSegment::createEmpty() on the super class');

--- a/lib/Fhp/Segment/BaseSegment.php
+++ b/lib/Fhp/Segment/BaseSegment.php
@@ -35,17 +35,17 @@ abstract class BaseSegment implements SegmentInterface, \Serializable
         return $this->descriptor;
     }
 
-    public function getName()
+    public function getName(): string
     {
         return $this->segmentkopf->segmentkennung;
     }
 
-    public function getVersion()
+    public function getVersion(): int
     {
         return $this->segmentkopf->segmentversion;
     }
 
-    public function getSegmentNumber()
+    public function getSegmentNumber(): int
     {
         return $this->segmentkopf->segmentnummer;
     }
@@ -83,7 +83,7 @@ abstract class BaseSegment implements SegmentInterface, \Serializable
         Parser::parseSegment($serialized, $this);
     }
 
-    public function __toString()
+    public function __toString(): string
     {
         return $this->serialize();
     }

--- a/lib/Fhp/Segment/BaseSegment.php
+++ b/lib/Fhp/Segment/BaseSegment.php
@@ -101,7 +101,7 @@ abstract class BaseSegment implements SegmentInterface, \Serializable
      *     the end). This should be ISO-8859-1-encoded.
      * @return static The parsed segment.
      */
-    public static function parse(string $rawSegment): self
+    public static function parse(string $rawSegment)
     {
         if (static::class === BaseSegment::class) {
             // Called as BaseSegment::parse(), so we need to determine the right segment type/class.
@@ -115,7 +115,7 @@ abstract class BaseSegment implements SegmentInterface, \Serializable
     /**
      * @return static A new segment of the type on which this function was called, with the Segmentkopf initialized.
      */
-    public static function createEmpty(): self
+    public static function createEmpty()
     {
         if (static::class === BaseSegment::class) {
             throw new \InvalidArgumentException('Must not call BaseSegment::createEmpty() on the super class');

--- a/lib/Fhp/Segment/CAZ/HICAZv1.php
+++ b/lib/Fhp/Segment/CAZ/HICAZv1.php
@@ -17,7 +17,7 @@ class HICAZv1 extends BaseSegment
 {
     /**
      * Kontoverbindung international
-     * @var Fhp\Segment\Common\Kti
+     * @var \Fhp\Segment\Common\Kti
      */
     public $kontoverbindungInternational;
 
@@ -47,9 +47,9 @@ class HICAZv1 extends BaseSegment
     public $nichtGebuchteUmsaetze;
 
     /**
-     * @return Fhp\Segment\Common\Kti
+     * @return \Fhp\Segment\Common\Kti
      */
-    public function getKontoverbindungInternational(): Fhp\Segment\Common\Kti
+    public function getKontoverbindungInternational(): \Fhp\Segment\Common\Kti
     {
         return $this->kontoverbindungInternational;
     }
@@ -63,7 +63,7 @@ class HICAZv1 extends BaseSegment
     }
 
     /**
-     * @return string
+     * @return Bin
      */
     public function getGebuchteUmsaetze(): Bin
     {

--- a/lib/Fhp/Segment/CAZ/HICAZv1.php
+++ b/lib/Fhp/Segment/CAZ/HICAZv1.php
@@ -46,33 +46,21 @@ class HICAZv1 extends BaseSegment
      */
     public $nichtGebuchteUmsaetze;
 
-    /**
-     * @return \Fhp\Segment\Common\Kti
-     */
     public function getKontoverbindungInternational(): \Fhp\Segment\Common\Kti
     {
         return $this->kontoverbindungInternational;
     }
 
-    /**
-     * @return string
-     */
     public function getCamtDescriptor(): string
     {
         return $this->camtDescriptor;
     }
 
-    /**
-     * @return Bin
-     */
     public function getGebuchteUmsaetze(): Bin
     {
         return $this->gebuchteUmsaetze;
     }
 
-    /**
-     * @return Bin|null
-     */
     public function getNichtGebuchteUmsaetze(): ?Bin
     {
         return $this->nichtGebuchteUmsaetze;

--- a/lib/Fhp/Segment/CAZ/HKCAZv1.php
+++ b/lib/Fhp/Segment/CAZ/HKCAZv1.php
@@ -3,7 +3,6 @@
 namespace Fhp\Segment\CAZ;
 
 use Fhp\Segment\BaseSegment;
-use Fhp\Segment\Common\Kti;
 
 /**
  * Segment: Kontoumsätze/Zeitraum (camt)
@@ -30,7 +29,8 @@ class HKCAZv1 extends BaseSegment
     /** @var string|null Max length: 35 */
     public $aufsetzpunkt;
 
-    public static function create(Kti $kti, UnterstuetzteCamtMessages $unterstuetzteCamtMessages, bool $alleKonten, ?\DateTime $vonDatum, ?\DateTime $bisDatum, ?string $aufsetzpunkt = null): HKCAZv1
+    public static function create(\Fhp\Segment\Common\Kti $kti, UnterstuetzteCamtMessages $unterstuetzteCamtMessages,
+                                  bool $alleKonten, ?\DateTime $vonDatum, ?\DateTime $bisDatum, ?string $aufsetzpunkt = null): HKCAZv1
     {
         $result = HKCAZv1::createEmpty();
         $result->kontoverbindungInternational = $kti;

--- a/lib/Fhp/Segment/CAZ/ParameterKontoumsaetzeCamt.php
+++ b/lib/Fhp/Segment/CAZ/ParameterKontoumsaetzeCamt.php
@@ -15,9 +15,6 @@ class ParameterKontoumsaetzeCamt extends ParameterKontoumsaetzeV2
     /** @var UnterstuetzteCamtMessages $unterstuetzteCamtMessages */
     public $unterstuetzteCamtMessages;
 
-    /**
-     * @return UnterstuetzteCamtMessages
-     */
     public function getUnterstuetzteCamtMessages(): UnterstuetzteCamtMessages
     {
         return $this->unterstuetzteCamtMessages;

--- a/lib/Fhp/Segment/Common/Kik.php
+++ b/lib/Fhp/Segment/Common/Kik.php
@@ -28,10 +28,7 @@ class Kik extends BaseDeg
         }
     }
 
-    /**
-     * @return Kik
-     */
-    public static function create(string $kreditinstitutscode)
+    public static function create(string $kreditinstitutscode): Kik
     {
         $result = new Kik();
         $result->laenderkennzeichen = static::DEFAULT_COUNTRY_CODE;

--- a/lib/Fhp/Segment/Common/Kik.php
+++ b/lib/Fhp/Segment/Common/Kik.php
@@ -32,7 +32,7 @@ class Kik extends BaseDeg
      * @param string $kreditinstitutscode
      * @return Kik
      */
-    public static function create($kreditinstitutscode)
+    public static function create(string $kreditinstitutscode)
     {
         $result = new Kik();
         $result->laenderkennzeichen = static::DEFAULT_COUNTRY_CODE;

--- a/lib/Fhp/Segment/Common/Kik.php
+++ b/lib/Fhp/Segment/Common/Kik.php
@@ -29,7 +29,6 @@ class Kik extends BaseDeg
     }
 
     /**
-     * @param string $kreditinstitutscode
      * @return Kik
      */
     public static function create(string $kreditinstitutscode)

--- a/lib/Fhp/Segment/Common/Kti.php
+++ b/lib/Fhp/Segment/Common/Kti.php
@@ -47,7 +47,7 @@ class Kti extends BaseDeg
      * @param string $bic
      * @return Kti
      */
-    public static function create($iban, $bic)
+    public static function create(string $iban, string $bic)
     {
         $result = new Kti();
         $result->iban = $iban;
@@ -59,7 +59,7 @@ class Kti extends BaseDeg
      * @param SEPAAccount $account
      * @return Kti
      */
-    public static function fromAccount($account)
+    public static function fromAccount(SEPAAccount $account)
     {
         $result = static::create($account->getIban(), $account->getBic());
         $result->kontonummer = $account->getAccountNumber();

--- a/lib/Fhp/Segment/Common/Kti.php
+++ b/lib/Fhp/Segment/Common/Kti.php
@@ -43,8 +43,6 @@ class Kti extends BaseDeg
     }
 
     /**
-     * @param string $iban
-     * @param string $bic
      * @return Kti
      */
     public static function create(string $iban, string $bic)
@@ -56,7 +54,6 @@ class Kti extends BaseDeg
     }
 
     /**
-     * @param SEPAAccount $account
      * @return Kti
      */
     public static function fromAccount(SEPAAccount $account)

--- a/lib/Fhp/Segment/Common/Kti.php
+++ b/lib/Fhp/Segment/Common/Kti.php
@@ -42,10 +42,7 @@ class Kti extends BaseDeg
         }
     }
 
-    /**
-     * @return Kti
-     */
-    public static function create(string $iban, string $bic)
+    public static function create(string $iban, string $bic): Kti
     {
         $result = new Kti();
         $result->iban = $iban;
@@ -53,10 +50,7 @@ class Kti extends BaseDeg
         return $result;
     }
 
-    /**
-     * @return Kti
-     */
-    public static function fromAccount(SEPAAccount $account)
+    public static function fromAccount(SEPAAccount $account): Kti
     {
         $result = static::create($account->getIban(), $account->getBic());
         $result->kontonummer = $account->getAccountNumber();

--- a/lib/Fhp/Segment/Common/Kto.php
+++ b/lib/Fhp/Segment/Common/Kto.php
@@ -24,7 +24,7 @@ class Kto extends BaseDeg
      * @param Kik $kik
      * @return Kto
      */
-    public static function create($kontonummer, $kik)
+    public static function create(string $kontonummer, Kik $kik): Kto
     {
         $result = new Kto();
         $result->kontonummer = $kontonummer;
@@ -36,7 +36,7 @@ class Kto extends BaseDeg
      * @param SEPAAccount $account
      * @return Kto
      */
-    public static function fromAccount($account)
+    public static function fromAccount(SEPAAccount $account): Kto
     {
         return static::create($account->getAccountNumber(), Kik::create($account->getBlz()));
     }

--- a/lib/Fhp/Segment/Common/Kto.php
+++ b/lib/Fhp/Segment/Common/Kto.php
@@ -19,11 +19,6 @@ class Kto extends BaseDeg
     /** @var Kik */
     public $kik;
 
-    /**
-     * @param string $kontonummer
-     * @param Kik $kik
-     * @return Kto
-     */
     public static function create(string $kontonummer, Kik $kik): Kto
     {
         $result = new Kto();
@@ -32,10 +27,6 @@ class Kto extends BaseDeg
         return $result;
     }
 
-    /**
-     * @param SEPAAccount $account
-     * @return Kto
-     */
     public static function fromAccount(SEPAAccount $account): Kto
     {
         return static::create($account->getAccountNumber(), Kik::create($account->getBlz()));

--- a/lib/Fhp/Segment/Common/KtvV3.php
+++ b/lib/Fhp/Segment/Common/KtvV3.php
@@ -31,7 +31,7 @@ class KtvV3 extends BaseDeg
      * @param Kik $kik
      * @return KtvV3
      */
-    public static function create($kontonummer, $unterkontomerkmal, $kik)
+    public static function create(string $kontonummer, ?string $unterkontomerkmal, Kik $kik): KtvV3
     {
         $result = new KtvV3();
         $result->kontonummer = $kontonummer;
@@ -44,7 +44,7 @@ class KtvV3 extends BaseDeg
      * @param SEPAAccount $account
      * @return KtvV3
      */
-    public static function fromAccount($account)
+    public static function fromAccount(SEPAAccount $account): KtvV3
     {
         return static::create($account->getAccountNumber(), $account->getSubAccount(), Kik::create($account->getBlz()));
     }

--- a/lib/Fhp/Segment/Common/KtvV3.php
+++ b/lib/Fhp/Segment/Common/KtvV3.php
@@ -25,12 +25,6 @@ class KtvV3 extends BaseDeg
     /** @var Kik */
     public $kik;
 
-    /**
-     * @param string $kontonummer
-     * @param string|null $unterkontomerkmal
-     * @param Kik $kik
-     * @return KtvV3
-     */
     public static function create(string $kontonummer, ?string $unterkontomerkmal, Kik $kik): KtvV3
     {
         $result = new KtvV3();
@@ -40,10 +34,6 @@ class KtvV3 extends BaseDeg
         return $result;
     }
 
-    /**
-     * @param SEPAAccount $account
-     * @return KtvV3
-     */
     public static function fromAccount(SEPAAccount $account): KtvV3
     {
         return static::create($account->getAccountNumber(), $account->getSubAccount(), Kik::create($account->getBlz()));

--- a/lib/Fhp/Segment/DME/HIDXES.php
+++ b/lib/Fhp/Segment/DME/HIDXES.php
@@ -4,6 +4,5 @@ namespace Fhp\Segment\DME;
 
 interface HIDXES
 {
-    /** @returns SEPADirectDebitMinimalLeadTimeProvider */
-    public function getParameter();
+    public function getParameter(): SEPADirectDebitMinimalLeadTimeProvider;
 }

--- a/lib/Fhp/Segment/DME/MinimaleVorlaufzeitSEPALastschrift.php
+++ b/lib/Fhp/Segment/DME/MinimaleVorlaufzeitSEPALastschrift.php
@@ -36,7 +36,8 @@ class MinimaleVorlaufzeitSEPALastschrift
     /** @var string After this time the request will fail when the value of $minimaleSEPAVorlaufzeit is used, for example 130000 meaning 1pm */
     public $cutOffZeit;
 
-    public static function create(int $minimaleSEPAVorlaufzeit, string $cutOffZeit, int $unterstuetzteSEPALastschriftartenCodiert = null, int $sequenceTypeCodiert = null)
+    public static function create(int $minimaleSEPAVorlaufzeit, string $cutOffZeit,int $unterstuetzteSEPALastschriftartenCodiert = null,
+                                  int $sequenceTypeCodiert = null): MinimaleVorlaufzeitSEPALastschrift
     {
         $result = new MinimaleVorlaufzeitSEPALastschrift();
         $result->unterstuetzteSEPALastschriftartenCodiert = $unterstuetzteSEPALastschriftartenCodiert;
@@ -48,7 +49,7 @@ class MinimaleVorlaufzeitSEPALastschrift
     }
 
     /** @return MinimaleVorlaufzeitSEPALastschrift[][]|array */
-    public static function parseCoded(string $coded)
+    public static function parseCoded(string $coded): array
     {
         $result = [];
         foreach (array_chunk(explode(';', $coded), 4) as list($unterstuetzteSEPALastschriftartenCodiert, $sequenceTypeCodiert, $minimaleSEPAVorlaufzeit, $cutOffZeit)) {

--- a/lib/Fhp/Segment/DegDescriptor.php
+++ b/lib/Fhp/Segment/DegDescriptor.php
@@ -15,7 +15,7 @@ class DegDescriptor extends BaseDescriptor
      * @param string $class The name of a sub-class of {@link BaseDeg}.
      * @return DegDescriptor The descriptor for the class.
      */
-    public static function get($class)
+    public static function get(string $class): DegDescriptor
     {
         if (!array_key_exists($class, static::$descriptors)) {
             static::$descriptors[$class] = new DegDescriptor($class);
@@ -27,7 +27,7 @@ class DegDescriptor extends BaseDescriptor
      * Please use the factory above.
      * @param string $class The name of a sub-class of {@link BaseDeg}.
      */
-    protected function __construct($class)
+    protected function __construct(string $class)
     {
         $this->class = $class;
         try {

--- a/lib/Fhp/Segment/ElementDescriptor.php
+++ b/lib/Fhp/Segment/ElementDescriptor.php
@@ -42,7 +42,7 @@ class ElementDescriptor
      * @param object $obj The object whose $field will be validated.
      * @throws \InvalidArgumentException If $obj->$field does not correspond to the schema in this descriptor.
      */
-    public function validateField(object $obj)
+    public function validateField($obj)
     {
         if (!isset($obj->{$this->field})) {
             if ($this->optional) {

--- a/lib/Fhp/Segment/ElementDescriptor.php
+++ b/lib/Fhp/Segment/ElementDescriptor.php
@@ -42,7 +42,7 @@ class ElementDescriptor
      * @param object $obj The object whose $field will be validated.
      * @throws \InvalidArgumentException If $obj->$field does not correspond to the schema in this descriptor.
      */
-    public function validateField($obj)
+    public function validateField(object $obj)
     {
         if (!isset($obj->{$this->field})) {
             if ($this->optional) {
@@ -77,7 +77,7 @@ class ElementDescriptor
      * @param string $type A potential PHP scalar type.
      * @return bool True if parseDataElement() would understand it.
      */
-    public static function isScalarType($type)
+    public static function isScalarType(string $type): bool
     {
         return array_key_exists($type, static::TYPE_MAP);
     }

--- a/lib/Fhp/Segment/HIRMS/FindRueckmeldungTrait.php
+++ b/lib/Fhp/Segment/HIRMS/FindRueckmeldungTrait.php
@@ -12,7 +12,7 @@ trait FindRueckmeldungTrait
      * @param int $code The value of Rueckmeldung.rueckmeldungscode to search for.
      * @return Rueckmeldung|null The corresponding Rueckmeldung instance, or null if not found.
      */
-    public function findRueckmeldung($code)
+    public function findRueckmeldung(int $code): ?Rueckmeldung
     {
         $matches = array_values(array_filter($this->rueckmeldung, function ($rueckmeldung) use ($code) {
             return $rueckmeldung->rueckmeldungscode === $code;

--- a/lib/Fhp/Segment/HIRMS/RueckmeldungContainer.php
+++ b/lib/Fhp/Segment/HIRMS/RueckmeldungContainer.php
@@ -11,5 +11,5 @@ interface RueckmeldungContainer
      * @param int $code The value of Rueckmeldung.rueckmeldungscode to search for.
      * @return Rueckmeldung|null The corresponding Rueckmeldung instance, or null if not found.
      */
-    public function findRueckmeldung($code);
+    public function findRueckmeldung(int $code): ?Rueckmeldung;
 }

--- a/lib/Fhp/Segment/HIRMS/Rueckmeldungscode.php
+++ b/lib/Fhp/Segment/HIRMS/Rueckmeldungscode.php
@@ -14,7 +14,7 @@ abstract class Rueckmeldungscode
      * @param int $code A code received from the server.
      * @return bool Whether it is a success code (indicating that the action was executed normally).
      */
-    public static function isSuccess($code)
+    public static function isSuccess(int $code): bool
     {
         return 0 < $code && $code < 1000;
     }
@@ -26,7 +26,7 @@ abstract class Rueckmeldungscode
      * @return bool Whether it is a warning code (indicating that the action was executed, but there may have been a
      *     problem in doing so).
      */
-    public static function isWarning($code)
+    public static function isWarning(int $code): bool
     {
         return 3000 < $code && $code < 4000;
     }
@@ -35,7 +35,7 @@ abstract class Rueckmeldungscode
      * @param int $code A code received from the server.
      * @return bool Whether it is a warning code (indicating that the action was rejected).
      */
-    public static function isError($code)
+    public static function isError(int $code): bool
     {
         return 9000 < $code && $code < 9999;
     }

--- a/lib/Fhp/Segment/HISYN/HISYNv4.php
+++ b/lib/Fhp/Segment/HISYN/HISYNv4.php
@@ -1,5 +1,7 @@
 <?php
 
+/** @noinspection PhpUnused */
+
 namespace Fhp\Segment\HISYN;
 
 use Fhp\Segment\BaseSegment;

--- a/lib/Fhp/Segment/HITANS/HITANS.php
+++ b/lib/Fhp/Segment/HITANS/HITANS.php
@@ -12,5 +12,5 @@ use Fhp\Segment\SegmentInterface;
 interface HITANS extends SegmentInterface
 {
     /** @return ParameterZweiSchrittTanEinreichung */
-    public function getParameterZweiSchrittTanEinreichung();
+    public function getParameterZweiSchrittTanEinreichung(): ParameterZweiSchrittTanEinreichung;
 }

--- a/lib/Fhp/Segment/HITANS/HITANSv1.php
+++ b/lib/Fhp/Segment/HITANS/HITANSv1.php
@@ -18,7 +18,7 @@ class HITANSv1 extends BaseGeschaeftsvorfallparameter implements HITANS
     public $parameterZweiSchrittTanEinreichung;
 
     /** @return ParameterZweiSchrittTanEinreichungV1 */
-    public function getParameterZweiSchrittTanEinreichung()
+    public function getParameterZweiSchrittTanEinreichung(): ParameterZweiSchrittTanEinreichungV1
     {
         return $this->parameterZweiSchrittTanEinreichung;
     }

--- a/lib/Fhp/Segment/HITANS/HITANSv1.php
+++ b/lib/Fhp/Segment/HITANS/HITANSv1.php
@@ -18,7 +18,7 @@ class HITANSv1 extends BaseGeschaeftsvorfallparameter implements HITANS
     public $parameterZweiSchrittTanEinreichung;
 
     /** @return ParameterZweiSchrittTanEinreichungV1 */
-    public function getParameterZweiSchrittTanEinreichung(): ParameterZweiSchrittTanEinreichungV1
+    public function getParameterZweiSchrittTanEinreichung(): ParameterZweiSchrittTanEinreichung
     {
         return $this->parameterZweiSchrittTanEinreichung;
     }

--- a/lib/Fhp/Segment/HITANS/HITANSv2.php
+++ b/lib/Fhp/Segment/HITANS/HITANSv2.php
@@ -18,7 +18,7 @@ class HITANSv2 extends BaseGeschaeftsvorfallparameter implements HITANS
     public $parameterZweiSchrittTanEinreichung;
 
     /** @return ParameterZweiSchrittTanEinreichungV2 */
-    public function getParameterZweiSchrittTanEinreichung()
+    public function getParameterZweiSchrittTanEinreichung(): ParameterZweiSchrittTanEinreichungV2
     {
         return $this->parameterZweiSchrittTanEinreichung;
     }

--- a/lib/Fhp/Segment/HITANS/HITANSv2.php
+++ b/lib/Fhp/Segment/HITANS/HITANSv2.php
@@ -18,7 +18,7 @@ class HITANSv2 extends BaseGeschaeftsvorfallparameter implements HITANS
     public $parameterZweiSchrittTanEinreichung;
 
     /** @return ParameterZweiSchrittTanEinreichungV2 */
-    public function getParameterZweiSchrittTanEinreichung(): ParameterZweiSchrittTanEinreichungV2
+    public function getParameterZweiSchrittTanEinreichung(): ParameterZweiSchrittTanEinreichung
     {
         return $this->parameterZweiSchrittTanEinreichung;
     }

--- a/lib/Fhp/Segment/HITANS/HITANSv3.php
+++ b/lib/Fhp/Segment/HITANS/HITANSv3.php
@@ -18,7 +18,7 @@ class HITANSv3 extends BaseGeschaeftsvorfallparameter implements HITANS
     public $parameterZweiSchrittTanEinreichung;
 
     /** @return ParameterZweiSchrittTanEinreichungV3 */
-    public function getParameterZweiSchrittTanEinreichung(): ParameterZweiSchrittTanEinreichungV3
+    public function getParameterZweiSchrittTanEinreichung(): ParameterZweiSchrittTanEinreichung
     {
         return $this->parameterZweiSchrittTanEinreichung;
     }

--- a/lib/Fhp/Segment/HITANS/HITANSv3.php
+++ b/lib/Fhp/Segment/HITANS/HITANSv3.php
@@ -18,7 +18,7 @@ class HITANSv3 extends BaseGeschaeftsvorfallparameter implements HITANS
     public $parameterZweiSchrittTanEinreichung;
 
     /** @return ParameterZweiSchrittTanEinreichungV3 */
-    public function getParameterZweiSchrittTanEinreichung()
+    public function getParameterZweiSchrittTanEinreichung(): ParameterZweiSchrittTanEinreichungV3
     {
         return $this->parameterZweiSchrittTanEinreichung;
     }

--- a/lib/Fhp/Segment/HITANS/HITANSv4.php
+++ b/lib/Fhp/Segment/HITANS/HITANSv4.php
@@ -18,7 +18,7 @@ class HITANSv4 extends BaseGeschaeftsvorfallparameter implements HITANS
     public $parameterZweiSchrittTanEinreichung;
 
     /** @return ParameterZweiSchrittTanEinreichungV4 */
-    public function getParameterZweiSchrittTanEinreichung(): ParameterZweiSchrittTanEinreichungV4
+    public function getParameterZweiSchrittTanEinreichung(): ParameterZweiSchrittTanEinreichung
     {
         return $this->parameterZweiSchrittTanEinreichung;
     }

--- a/lib/Fhp/Segment/HITANS/HITANSv4.php
+++ b/lib/Fhp/Segment/HITANS/HITANSv4.php
@@ -18,7 +18,7 @@ class HITANSv4 extends BaseGeschaeftsvorfallparameter implements HITANS
     public $parameterZweiSchrittTanEinreichung;
 
     /** @return ParameterZweiSchrittTanEinreichungV4 */
-    public function getParameterZweiSchrittTanEinreichung()
+    public function getParameterZweiSchrittTanEinreichung(): ParameterZweiSchrittTanEinreichungV4
     {
         return $this->parameterZweiSchrittTanEinreichung;
     }

--- a/lib/Fhp/Segment/HITANS/HITANSv5.php
+++ b/lib/Fhp/Segment/HITANS/HITANSv5.php
@@ -18,7 +18,7 @@ class HITANSv5 extends BaseGeschaeftsvorfallparameter implements HITANS
     public $parameterZweiSchrittTanEinreichung;
 
     /** @return ParameterZweiSchrittTanEinreichungV5 */
-    public function getParameterZweiSchrittTanEinreichung()
+    public function getParameterZweiSchrittTanEinreichung(): ParameterZweiSchrittTanEinreichungV5
     {
         return $this->parameterZweiSchrittTanEinreichung;
     }

--- a/lib/Fhp/Segment/HITANS/HITANSv5.php
+++ b/lib/Fhp/Segment/HITANS/HITANSv5.php
@@ -18,7 +18,7 @@ class HITANSv5 extends BaseGeschaeftsvorfallparameter implements HITANS
     public $parameterZweiSchrittTanEinreichung;
 
     /** @return ParameterZweiSchrittTanEinreichungV5 */
-    public function getParameterZweiSchrittTanEinreichung(): ParameterZweiSchrittTanEinreichungV5
+    public function getParameterZweiSchrittTanEinreichung(): ParameterZweiSchrittTanEinreichung
     {
         return $this->parameterZweiSchrittTanEinreichung;
     }

--- a/lib/Fhp/Segment/HITANS/HITANSv6.php
+++ b/lib/Fhp/Segment/HITANS/HITANSv6.php
@@ -21,7 +21,7 @@ class HITANSv6 extends BaseGeschaeftsvorfallparameter implements HITANS
     public $parameterZweiSchrittTanEinreichung;
 
     /** @return ParameterZweiSchrittTanEinreichungV6 */
-    public function getParameterZweiSchrittTanEinreichung(): ParameterZweiSchrittTanEinreichungV6
+    public function getParameterZweiSchrittTanEinreichung(): ParameterZweiSchrittTanEinreichung
     {
         return $this->parameterZweiSchrittTanEinreichung;
     }

--- a/lib/Fhp/Segment/HITANS/HITANSv6.php
+++ b/lib/Fhp/Segment/HITANS/HITANSv6.php
@@ -21,7 +21,7 @@ class HITANSv6 extends BaseGeschaeftsvorfallparameter implements HITANS
     public $parameterZweiSchrittTanEinreichung;
 
     /** @return ParameterZweiSchrittTanEinreichungV6 */
-    public function getParameterZweiSchrittTanEinreichung()
+    public function getParameterZweiSchrittTanEinreichung(): ParameterZweiSchrittTanEinreichungV6
     {
         return $this->parameterZweiSchrittTanEinreichung;
     }

--- a/lib/Fhp/Segment/HITANS/ParameterZweiSchrittTanEinreichung.php
+++ b/lib/Fhp/Segment/HITANS/ParameterZweiSchrittTanEinreichung.php
@@ -5,8 +5,8 @@ namespace Fhp\Segment\HITANS;
 interface ParameterZweiSchrittTanEinreichung
 {
     /** @return bool */
-    public function getEinschrittVerfahrenErlaubt();
+    public function getEinschrittVerfahrenErlaubt(): bool;
 
     /** @return VerfahrensparameterZweiSchrittVerfahren[] */
-    public function getVerfahrensparameterZweiSchrittVerfahren();
+    public function getVerfahrensparameterZweiSchrittVerfahren(): array;
 }

--- a/lib/Fhp/Segment/HITANS/ParameterZweiSchrittTanEinreichungV1.php
+++ b/lib/Fhp/Segment/HITANS/ParameterZweiSchrittTanEinreichungV1.php
@@ -28,13 +28,13 @@ class ParameterZweiSchrittTanEinreichungV1 extends BaseDeg implements ParameterZ
     public $verfahrensparameterZweiSchrittVerfahren;
 
     /** @return bool */
-    public function getEinschrittVerfahrenErlaubt()
+    public function getEinschrittVerfahrenErlaubt(): bool
     {
         return $this->einschrittVerfahrenErlaubt;
     }
 
     /** @return VerfahrensparameterZweiSchrittVerfahrenV1[] */
-    public function getVerfahrensparameterZweiSchrittVerfahren()
+    public function getVerfahrensparameterZweiSchrittVerfahren(): array
     {
         return $this->verfahrensparameterZweiSchrittVerfahren;
     }

--- a/lib/Fhp/Segment/HITANS/ParameterZweiSchrittTanEinreichungV2.php
+++ b/lib/Fhp/Segment/HITANS/ParameterZweiSchrittTanEinreichungV2.php
@@ -21,13 +21,13 @@ class ParameterZweiSchrittTanEinreichungV2 extends BaseDeg implements ParameterZ
     public $verfahrensparameterZweiSchrittVerfahren;
 
     /** @return bool */
-    public function getEinschrittVerfahrenErlaubt()
+    public function getEinschrittVerfahrenErlaubt(): bool
     {
         return $this->einschrittVerfahrenErlaubt;
     }
 
     /** @return VerfahrensparameterZweiSchrittVerfahrenV2[] */
-    public function getVerfahrensparameterZweiSchrittVerfahren()
+    public function getVerfahrensparameterZweiSchrittVerfahren(): array
     {
         return $this->verfahrensparameterZweiSchrittVerfahren;
     }

--- a/lib/Fhp/Segment/HITANS/ParameterZweiSchrittTanEinreichungV3.php
+++ b/lib/Fhp/Segment/HITANS/ParameterZweiSchrittTanEinreichungV3.php
@@ -21,13 +21,13 @@ class ParameterZweiSchrittTanEinreichungV3 extends BaseDeg implements ParameterZ
     public $verfahrensparameterZweiSchrittVerfahren;
 
     /** @return bool */
-    public function getEinschrittVerfahrenErlaubt()
+    public function getEinschrittVerfahrenErlaubt(): bool
     {
         return $this->einschrittVerfahrenErlaubt;
     }
 
     /** @return VerfahrensparameterZweiSchrittVerfahrenV3[] */
-    public function getVerfahrensparameterZweiSchrittVerfahren()
+    public function getVerfahrensparameterZweiSchrittVerfahren(): array
     {
         return $this->verfahrensparameterZweiSchrittVerfahren;
     }

--- a/lib/Fhp/Segment/HITANS/ParameterZweiSchrittTanEinreichungV4.php
+++ b/lib/Fhp/Segment/HITANS/ParameterZweiSchrittTanEinreichungV4.php
@@ -21,13 +21,13 @@ class ParameterZweiSchrittTanEinreichungV4 extends BaseDeg implements ParameterZ
     public $verfahrensparameterZweiSchrittVerfahren;
 
     /** @return bool */
-    public function getEinschrittVerfahrenErlaubt()
+    public function getEinschrittVerfahrenErlaubt(): bool
     {
         return $this->einschrittVerfahrenErlaubt;
     }
 
     /** @return VerfahrensparameterZweiSchrittVerfahrenV4[] */
-    public function getVerfahrensparameterZweiSchrittVerfahren()
+    public function getVerfahrensparameterZweiSchrittVerfahren(): array
     {
         return $this->verfahrensparameterZweiSchrittVerfahren;
     }

--- a/lib/Fhp/Segment/HITANS/ParameterZweiSchrittTanEinreichungV5.php
+++ b/lib/Fhp/Segment/HITANS/ParameterZweiSchrittTanEinreichungV5.php
@@ -21,13 +21,13 @@ class ParameterZweiSchrittTanEinreichungV5 extends BaseDeg implements ParameterZ
     public $verfahrensparameterZweiSchrittVerfahren;
 
     /** @return bool */
-    public function getEinschrittVerfahrenErlaubt()
+    public function getEinschrittVerfahrenErlaubt(): bool
     {
         return $this->einschrittVerfahrenErlaubt;
     }
 
     /** @return VerfahrensparameterZweiSchrittVerfahrenV5[] */
-    public function getVerfahrensparameterZweiSchrittVerfahren()
+    public function getVerfahrensparameterZweiSchrittVerfahren(): array
     {
         return $this->verfahrensparameterZweiSchrittVerfahren;
     }

--- a/lib/Fhp/Segment/HITANS/ParameterZweiSchrittTanEinreichungV6.php
+++ b/lib/Fhp/Segment/HITANS/ParameterZweiSchrittTanEinreichungV6.php
@@ -21,13 +21,13 @@ class ParameterZweiSchrittTanEinreichungV6 extends BaseDeg implements ParameterZ
     public $verfahrensparameterZweiSchrittVerfahren;
 
     /** @return bool */
-    public function getEinschrittVerfahrenErlaubt()
+    public function getEinschrittVerfahrenErlaubt(): bool
     {
         return $this->einschrittVerfahrenErlaubt;
     }
 
     /** @return VerfahrensparameterZweiSchrittVerfahrenV6[] */
-    public function getVerfahrensparameterZweiSchrittVerfahren()
+    public function getVerfahrensparameterZweiSchrittVerfahren(): array
     {
         return $this->verfahrensparameterZweiSchrittVerfahren;
     }

--- a/lib/Fhp/Segment/HITANS/VerfahrensparameterZweiSchrittVerfahren.php
+++ b/lib/Fhp/Segment/HITANS/VerfahrensparameterZweiSchrittVerfahren.php
@@ -7,20 +7,20 @@ use Fhp\Model\TanMode;
 interface VerfahrensparameterZweiSchrittVerfahren extends TanMode
 {
     /** @return int */
-    public function getId();
+    public function getId(): int;
 
     /** @return string */
-    public function getName();
+    public function getName(): string;
 
     /** @return bool */
-    public function getSmsAbbuchungskontoErforderlich();
+    public function getSmsAbbuchungskontoErforderlich(): bool;
 
     /** @return bool */
-    public function getAuftraggeberkontoErforderlich();
+    public function getAuftraggeberkontoErforderlich(): bool;
 
     /** @return bool */
-    public function getChallengeKlasseErforderlich();
+    public function getChallengeKlasseErforderlich(): bool;
 
     /** @return bool */
-    public function getAntwortHhdUcErforderlich();
+    public function getAntwortHhdUcErforderlich(): bool;
 }

--- a/lib/Fhp/Segment/HITANS/VerfahrensparameterZweiSchrittVerfahrenV1.php
+++ b/lib/Fhp/Segment/HITANS/VerfahrensparameterZweiSchrittVerfahrenV1.php
@@ -30,67 +30,67 @@ class VerfahrensparameterZweiSchrittVerfahrenV1 extends BaseDeg implements Verfa
     public $tanZeitversetztDialoguebergreifendErlaubt;
 
     /** {@inheritdoc} */
-    public function getId()
+    public function getId(): int
     {
         return $this->sicherheitsfunktion;
     }
 
     /** {@inheritdoc} */
-    public function getName()
+    public function getName(): string
     {
         return $this->nameDesZweiSchrittVerfahrens;
     }
 
     /** {@inheritdoc} */
-    public function getSmsAbbuchungskontoErforderlich()
+    public function getSmsAbbuchungskontoErforderlich(): bool
     {
         return false;
     }
 
     /** {@inheritdoc} */
-    public function getAuftraggeberkontoErforderlich()
+    public function getAuftraggeberkontoErforderlich(): bool
     {
         return false;
     }
 
     /** {@inheritdoc} */
-    public function getChallengeKlasseErforderlich()
+    public function getChallengeKlasseErforderlich(): bool
     {
         return false;
     }
 
     /** {@inheritdoc} */
-    public function getAntwortHhdUcErforderlich()
+    public function getAntwortHhdUcErforderlich(): bool
     {
         return false;
     }
 
     /** {@inheritdoc} */
-    public function getChallengeLabel()
+    public function getChallengeLabel(): string
     {
         return $this->textZurBelegungDesRueckgabewertes;
     }
 
     /** {@inheritdoc} */
-    public function getMaxChallengeLength()
+    public function getMaxChallengeLength(): int
     {
         return $this->maximaleLaengeDesRueckgabewertes;
     }
 
     /** {@inheritdoc} */
-    public function getMaxTanLength()
+    public function getMaxTanLength(): int
     {
         return $this->maximaleLaengeDesTanEingabewertes;
     }
 
     /** {@inheritdoc} */
-    public function getTanFormat()
+    public function getTanFormat(): int
     {
         return $this->erlaubtesFormat;
     }
 
     /** {@inheritdoc} */
-    public function needsTanMedium()
+    public function needsTanMedium(): bool
     {
         return false;
     }

--- a/lib/Fhp/Segment/HITANS/VerfahrensparameterZweiSchrittVerfahrenV2.php
+++ b/lib/Fhp/Segment/HITANS/VerfahrensparameterZweiSchrittVerfahrenV2.php
@@ -44,67 +44,67 @@ class VerfahrensparameterZweiSchrittVerfahrenV2 extends BaseDeg implements Verfa
     public $challengeBetragErforderlich;
 
     /** {@inheritdoc} */
-    public function getId()
+    public function getId(): int
     {
         return $this->sicherheitsfunktion;
     }
 
     /** {@inheritdoc} */
-    public function getName()
+    public function getName(): string
     {
         return $this->nameDesZweiSchrittVerfahrens;
     }
 
     /** {@inheritdoc} */
-    public function getSmsAbbuchungskontoErforderlich()
+    public function getSmsAbbuchungskontoErforderlich(): bool
     {
         return false;
     }
 
     /** {@inheritdoc} */
-    public function getAuftraggeberkontoErforderlich()
+    public function getAuftraggeberkontoErforderlich(): bool
     {
         return false;
     }
 
     /** {@inheritdoc} */
-    public function getChallengeKlasseErforderlich()
+    public function getChallengeKlasseErforderlich(): bool
     {
         return $this->challengeKlasseErforderlich;
     }
 
     /** {@inheritdoc} */
-    public function getAntwortHhdUcErforderlich()
+    public function getAntwortHhdUcErforderlich(): bool
     {
         return false;
     }
 
     /** {@inheritdoc} */
-    public function getChallengeLabel()
+    public function getChallengeLabel(): string
     {
         return $this->textZurBelegungDesRueckgabewertes;
     }
 
     /** {@inheritdoc} */
-    public function getMaxChallengeLength()
+    public function getMaxChallengeLength(): int
     {
         return $this->maximaleLaengeDesRueckgabewertes;
     }
 
     /** {@inheritdoc} */
-    public function getMaxTanLength()
+    public function getMaxTanLength(): int
     {
         return $this->maximaleLaengeDesTanEingabewertes;
     }
 
     /** {@inheritdoc} */
-    public function getTanFormat()
+    public function getTanFormat(): int
     {
         return $this->erlaubtesFormat;
     }
 
     /** {@inheritdoc} */
-    public function needsTanMedium()
+    public function needsTanMedium(): bool
     {
         return false;
     }

--- a/lib/Fhp/Segment/HITANS/VerfahrensparameterZweiSchrittVerfahrenV3.php
+++ b/lib/Fhp/Segment/HITANS/VerfahrensparameterZweiSchrittVerfahrenV3.php
@@ -50,67 +50,67 @@ class VerfahrensparameterZweiSchrittVerfahrenV3 extends BaseDeg implements Verfa
     public $anzahlUnterstuetzterAktiverTanMedien;
 
     /** {@inheritdoc} */
-    public function getId()
+    public function getId(): int
     {
         return $this->sicherheitsfunktion;
     }
 
     /** {@inheritdoc} */
-    public function getName()
+    public function getName(): string
     {
         return $this->nameDesZweiSchrittVerfahrens;
     }
 
     /** {@inheritdoc} */
-    public function getSmsAbbuchungskontoErforderlich()
+    public function getSmsAbbuchungskontoErforderlich(): bool
     {
         return false;
     }
 
     /** {@inheritdoc} */
-    public function getAuftraggeberkontoErforderlich()
+    public function getAuftraggeberkontoErforderlich(): bool
     {
         return false;
     }
 
     /** {@inheritdoc} */
-    public function getChallengeKlasseErforderlich()
+    public function getChallengeKlasseErforderlich(): bool
     {
         return $this->challengeKlasseErforderlich;
     }
 
     /** {@inheritdoc} */
-    public function getAntwortHhdUcErforderlich()
+    public function getAntwortHhdUcErforderlich(): bool
     {
         return false;
     }
 
     /** {@inheritdoc} */
-    public function getChallengeLabel()
+    public function getChallengeLabel(): string
     {
         return $this->textZurBelegungDesRueckgabewertes;
     }
 
     /** {@inheritdoc} */
-    public function getMaxChallengeLength()
+    public function getMaxChallengeLength(): int
     {
         return $this->maximaleLaengeDesRueckgabewertes;
     }
 
     /** {@inheritdoc} */
-    public function getMaxTanLength()
+    public function getMaxTanLength(): int
     {
         return $this->maximaleLaengeDesTanEingabewertes;
     }
 
     /** {@inheritdoc} */
-    public function getTanFormat()
+    public function getTanFormat(): int
     {
         return $this->erlaubtesFormat;
     }
 
     /** {@inheritdoc} */
-    public function needsTanMedium()
+    public function needsTanMedium(): bool
     {
         return $this->bezeichnungDesTanMediumsErforderlich === 2 && $this->anzahlUnterstuetzterAktiverTanMedien > 0;
     }

--- a/lib/Fhp/Segment/HITANS/VerfahrensparameterZweiSchrittVerfahrenV4.php
+++ b/lib/Fhp/Segment/HITANS/VerfahrensparameterZweiSchrittVerfahrenV4.php
@@ -58,67 +58,67 @@ class VerfahrensparameterZweiSchrittVerfahrenV4 extends BaseDeg implements Verfa
     public $anzahlUnterstuetzterAktiverTanMedien;
 
     /** {@inheritdoc} */
-    public function getId()
+    public function getId(): int
     {
         return $this->sicherheitsfunktion;
     }
 
     /** {@inheritdoc} */
-    public function getName()
+    public function getName(): string
     {
         return $this->nameDesZweiSchrittVerfahrens;
     }
 
     /** {@inheritdoc} */
-    public function getSmsAbbuchungskontoErforderlich()
+    public function getSmsAbbuchungskontoErforderlich(): bool
     {
         return $this->smsAbbuchungskontoErforderlich;
     }
 
     /** {@inheritdoc} */
-    public function getAuftraggeberkontoErforderlich()
+    public function getAuftraggeberkontoErforderlich(): bool
     {
         return false;
     }
 
     /** {@inheritdoc} */
-    public function getChallengeKlasseErforderlich()
+    public function getChallengeKlasseErforderlich(): bool
     {
         return $this->challengeKlasseErforderlich;
     }
 
     /** {@inheritdoc} */
-    public function getAntwortHhdUcErforderlich()
+    public function getAntwortHhdUcErforderlich(): bool
     {
         return false;
     }
 
     /** {@inheritdoc} */
-    public function getChallengeLabel()
+    public function getChallengeLabel(): string
     {
         return $this->textZurBelegungDesRueckgabewertes;
     }
 
     /** {@inheritdoc} */
-    public function getMaxChallengeLength()
+    public function getMaxChallengeLength(): int
     {
         return $this->maximaleLaengeDesRueckgabewertes;
     }
 
     /** {@inheritdoc} */
-    public function getMaxTanLength()
+    public function getMaxTanLength(): int
     {
         return $this->maximaleLaengeDesTanEingabewertes;
     }
 
     /** {@inheritdoc} */
-    public function getTanFormat()
+    public function getTanFormat(): int
     {
         return $this->erlaubtesFormat;
     }
 
     /** {@inheritdoc} */
-    public function needsTanMedium()
+    public function needsTanMedium(): bool
     {
         return $this->bezeichnungDesTanMediumsErforderlich === 2 && $this->anzahlUnterstuetzterAktiverTanMedien > 0;
     }

--- a/lib/Fhp/Segment/HITANS/VerfahrensparameterZweiSchrittVerfahrenV5.php
+++ b/lib/Fhp/Segment/HITANS/VerfahrensparameterZweiSchrittVerfahrenV5.php
@@ -58,67 +58,67 @@ class VerfahrensparameterZweiSchrittVerfahrenV5 extends BaseDeg implements Verfa
     public $anzahlUnterstuetzterAktiverTanMedien;
 
     /** {@inheritdoc} */
-    public function getId()
+    public function getId(): int
     {
         return $this->sicherheitsfunktion;
     }
 
     /** {@inheritdoc} */
-    public function getName()
+    public function getName(): string
     {
         return $this->nameDesZweiSchrittVerfahrens;
     }
 
     /** {@inheritdoc} */
-    public function getSmsAbbuchungskontoErforderlich()
+    public function getSmsAbbuchungskontoErforderlich(): bool
     {
         return $this->smsAbbuchungskontoErforderlich === 2;
     }
 
     /** {@inheritdoc} */
-    public function getAuftraggeberkontoErforderlich()
+    public function getAuftraggeberkontoErforderlich(): bool
     {
         return $this->auftraggeberkontoErforderlich === 2;
     }
 
     /** {@inheritdoc} */
-    public function getChallengeKlasseErforderlich()
+    public function getChallengeKlasseErforderlich(): bool
     {
         return $this->challengeKlasseErforderlich;
     }
 
     /** {@inheritdoc} */
-    public function getAntwortHhdUcErforderlich()
+    public function getAntwortHhdUcErforderlich(): bool
     {
         return false;
     }
 
     /** {@inheritdoc} */
-    public function getChallengeLabel()
+    public function getChallengeLabel(): string
     {
         return $this->textZurBelegungDesRueckgabewertes;
     }
 
     /** {@inheritdoc} */
-    public function getMaxChallengeLength()
+    public function getMaxChallengeLength(): int
     {
         return $this->maximaleLaengeDesRueckgabewertes;
     }
 
     /** {@inheritdoc} */
-    public function getMaxTanLength()
+    public function getMaxTanLength(): int
     {
         return $this->maximaleLaengeDesTanEingabewertes;
     }
 
     /** {@inheritdoc} */
-    public function getTanFormat()
+    public function getTanFormat(): int
     {
         return $this->erlaubtesFormat;
     }
 
     /** {@inheritdoc} */
-    public function needsTanMedium()
+    public function needsTanMedium(): bool
     {
         return $this->bezeichnungDesTanMediumsErforderlich === 2 && $this->anzahlUnterstuetzterAktiverTanMedien > 0;
     }

--- a/lib/Fhp/Segment/HITANS/VerfahrensparameterZweiSchrittVerfahrenV6.php
+++ b/lib/Fhp/Segment/HITANS/VerfahrensparameterZweiSchrittVerfahrenV6.php
@@ -60,67 +60,67 @@ class VerfahrensparameterZweiSchrittVerfahrenV6 extends BaseDeg implements Verfa
     public $anzahlUnterstuetzterAktiverTanMedien;
 
     /** {@inheritdoc} */
-    public function getId()
+    public function getId(): int
     {
         return $this->sicherheitsfunktion;
     }
 
     /** {@inheritdoc} */
-    public function getName()
+    public function getName(): string
     {
         return $this->nameDesZweiSchrittVerfahrens;
     }
 
     /** {@inheritdoc} */
-    public function getSmsAbbuchungskontoErforderlich()
+    public function getSmsAbbuchungskontoErforderlich(): bool
     {
         return $this->smsAbbuchungskontoErforderlich === 2;
     }
 
     /** {@inheritdoc} */
-    public function getAuftraggeberkontoErforderlich()
+    public function getAuftraggeberkontoErforderlich(): bool
     {
         return $this->auftraggeberkontoErforderlich === 2;
     }
 
     /** {@inheritdoc} */
-    public function getChallengeKlasseErforderlich()
+    public function getChallengeKlasseErforderlich(): bool
     {
         return $this->challengeKlasseErforderlich;
     }
 
     /** {@inheritdoc} */
-    public function getAntwortHhdUcErforderlich()
+    public function getAntwortHhdUcErforderlich(): bool
     {
         return $this->antwortHhdUcErforderlich;
     }
 
     /** {@inheritdoc} */
-    public function getChallengeLabel()
+    public function getChallengeLabel(): string
     {
         return $this->textZurBelegungDesRueckgabewertes;
     }
 
     /** {@inheritdoc} */
-    public function getMaxChallengeLength()
+    public function getMaxChallengeLength(): int
     {
         return $this->maximaleLaengeDesRueckgabewertes;
     }
 
     /** {@inheritdoc} */
-    public function getMaxTanLength()
+    public function getMaxTanLength(): int
     {
         return $this->maximaleLaengeDesTanEingabewertes;
     }
 
     /** {@inheritdoc} */
-    public function getTanFormat()
+    public function getTanFormat(): int
     {
         return $this->erlaubtesFormat;
     }
 
     /** {@inheritdoc} */
-    public function needsTanMedium()
+    public function needsTanMedium(): bool
     {
         return $this->bezeichnungDesTanMediumsErforderlich === 2 && $this->anzahlUnterstuetzterAktiverTanMedien > 0;
     }

--- a/lib/Fhp/Segment/HIUPD/ErlaubteGeschaeftsvorfaelle.php
+++ b/lib/Fhp/Segment/HIUPD/ErlaubteGeschaeftsvorfaelle.php
@@ -8,5 +8,5 @@ namespace Fhp\Segment\HIUPD;
 interface ErlaubteGeschaeftsvorfaelle
 {
     /** @return string References a segment type name (Segmentkennung) */
-    public function getGeschaeftsvorfall();
+    public function getGeschaeftsvorfall(): string;
 }

--- a/lib/Fhp/Segment/HIUPD/ErlaubteGeschaeftsvorfaelleV1.php
+++ b/lib/Fhp/Segment/HIUPD/ErlaubteGeschaeftsvorfaelleV1.php
@@ -23,7 +23,7 @@ class ErlaubteGeschaeftsvorfaelleV1 extends BaseDeg implements ErlaubteGeschaeft
     public $limitTage;
 
     /** {@inheritdoc} */
-    public function getGeschaeftsvorfall()
+    public function getGeschaeftsvorfall(): string
     {
         return $this->geschaeftsvorfall;
     }

--- a/lib/Fhp/Segment/HIUPD/ErlaubteGeschaeftsvorfaelleV2.php
+++ b/lib/Fhp/Segment/HIUPD/ErlaubteGeschaeftsvorfaelleV2.php
@@ -22,7 +22,7 @@ class ErlaubteGeschaeftsvorfaelleV2 extends BaseDeg implements ErlaubteGeschaeft
     public $limitTage;
 
     /** {@inheritdoc} */
-    public function getGeschaeftsvorfall()
+    public function getGeschaeftsvorfall(): string
     {
         return $this->geschaeftsvorfall;
     }

--- a/lib/Fhp/Segment/HIUPD/HIUPD.php
+++ b/lib/Fhp/Segment/HIUPD/HIUPD.php
@@ -15,10 +15,10 @@ interface HIUPD
      * @param SEPAAccount $account An account.
      * @return bool True if this HIUPD segment pertains to the given account.
      */
-    public function matchesAccount(SEPAAccount $account);
+    public function matchesAccount(SEPAAccount $account): bool;
 
     /**
      * @return ErlaubteGeschaeftsvorfaelle[]
      */
-    public function getErlaubteGeschaeftsvorfaelle();
+    public function getErlaubteGeschaeftsvorfaelle(): array;
 }

--- a/lib/Fhp/Segment/HIUPD/HIUPDv4.php
+++ b/lib/Fhp/Segment/HIUPD/HIUPDv4.php
@@ -36,14 +36,14 @@ class HIUPDv4 extends BaseSegment implements HIUPD
     public $erlaubteGeschaeftsvorfaelle;
 
     /** {@inheritdoc} */
-    public function matchesAccount(SEPAAccount $account)
+    public function matchesAccount(SEPAAccount $account): bool
     {
         return !is_null($this->kontoverbindung) && !is_null($this->kontoverbindung->kontonummer)
             && $this->kontoverbindung->kontonummer == $account->getAccountNumber();
     }
 
     /** {@inheritdoc} */
-    public function getErlaubteGeschaeftsvorfaelle()
+    public function getErlaubteGeschaeftsvorfaelle(): array
     {
         return $this->erlaubteGeschaeftsvorfaelle ?? [];
     }

--- a/lib/Fhp/Segment/HIUPD/HIUPDv6.php
+++ b/lib/Fhp/Segment/HIUPD/HIUPDv6.php
@@ -58,13 +58,13 @@ class HIUPDv6 extends BaseSegment implements HIUPD
     public $erweiterungKontobezogen;
 
     /** {@inheritdoc} */
-    public function matchesAccount(SEPAAccount $account)
+    public function matchesAccount(SEPAAccount $account): bool
     {
         return !is_null($this->iban) && $this->iban == $account->getIban();
     }
 
     /** {@inheritdoc} */
-    public function getErlaubteGeschaeftsvorfaelle()
+    public function getErlaubteGeschaeftsvorfaelle(): array
     {
         return $this->erlaubteGeschaeftsvorfaelle ?? [];
     }

--- a/lib/Fhp/Segment/HKCAZ.php
+++ b/lib/Fhp/Segment/HKCAZ.php
@@ -22,14 +22,6 @@ class HKCAZ extends AbstractSegment
 
     /**
      * HKCAZ constructor.
-     * @param int $version
-     * @param int $segmentNumber
-     * @param Kti $kti
-     * @param string $camtFormat
-     * @param array $allAccounts
-     * @param \DateTime $from
-     * @param \DateTime $to
-     * @param string|null $touchdown
      */
     public function __construct(
         int $version,
@@ -57,9 +49,6 @@ class HKCAZ extends AbstractSegment
         );
     }
 
-    /**
-     * @return string
-     */
     public function getName(): string
     {
         return static::NAME;

--- a/lib/Fhp/Segment/HKCAZ.php
+++ b/lib/Fhp/Segment/HKCAZ.php
@@ -32,14 +32,14 @@ class HKCAZ extends AbstractSegment
      * @param string|null $touchdown
      */
     public function __construct(
-        $version,
-        $segmentNumber,
-        $kti,
-        $camtFormat,
-        $allAccounts,
+        int $version,
+        int $segmentNumber,
+        Kti $kti,
+        string $camtFormat,
+        array $allAccounts,
         \DateTime $from,
         \DateTime $to,
-        $touchdown = null
+        ?string $touchdown = null
     ) {
         parent::__construct(
             static::NAME,
@@ -60,7 +60,7 @@ class HKCAZ extends AbstractSegment
     /**
      * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         return static::NAME;
     }

--- a/lib/Fhp/Segment/HKCCS.php
+++ b/lib/Fhp/Segment/HKCCS.php
@@ -20,11 +20,6 @@ class HKCCS extends AbstractSegment
 
     /**
      * HKCCS constructor.
-     * @param int $version
-     * @param int $segmentNumber
-     * @param Kti $kti
-     * @param string $SEPADescriptor
-     * @param string $painMessage
      */
     public function __construct(int $version, int $segmentNumber, Kti $kti, string $SEPADescriptor, string $painMessage)
     {
@@ -40,9 +35,6 @@ class HKCCS extends AbstractSegment
         );
     }
 
-    /**
-     * @return string
-     */
     public function getName(): string
     {
         return static::NAME;

--- a/lib/Fhp/Segment/HKCCS.php
+++ b/lib/Fhp/Segment/HKCCS.php
@@ -26,7 +26,7 @@ class HKCCS extends AbstractSegment
      * @param string $SEPADescriptor
      * @param string $painMessage
      */
-    public function __construct($version, $segmentNumber, $kti, $SEPADescriptor, $painMessage)
+    public function __construct(int $version, int $segmentNumber, Kti $kti, string $SEPADescriptor, string $painMessage)
     {
         parent::__construct(
             static::NAME,
@@ -43,7 +43,7 @@ class HKCCS extends AbstractSegment
     /**
      * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         return static::NAME;
     }

--- a/lib/Fhp/Segment/HKCDB.php
+++ b/lib/Fhp/Segment/HKCDB.php
@@ -20,10 +20,6 @@ class HKCDB extends AbstractSegment
 
     /**
      * HKCDB constructor.
-     * @param int $version
-     * @param int $segmentNumber
-     * @param Kti $kti
-     * @param array $supportedPain
      */
     public function __construct(int $version, int $segmentNumber, Kti $kti, array $supportedPain)
     {
@@ -43,9 +39,6 @@ class HKCDB extends AbstractSegment
         );
     }
 
-    /**
-     * @return string
-     */
     public function getName(): string
     {
         return static::NAME;

--- a/lib/Fhp/Segment/HKCDB.php
+++ b/lib/Fhp/Segment/HKCDB.php
@@ -25,7 +25,7 @@ class HKCDB extends AbstractSegment
      * @param Kti $kti
      * @param array $supportedPain
      */
-    public function __construct($version, $segmentNumber, $kti, $supportedPain)
+    public function __construct(int $version, int $segmentNumber, Kti $kti, array $supportedPain)
     {
         $deg = new Deg();
         foreach ($supportedPain as $pain) {
@@ -46,7 +46,7 @@ class HKCDB extends AbstractSegment
     /**
      * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         return static::NAME;
     }

--- a/lib/Fhp/Segment/HKCDL.php
+++ b/lib/Fhp/Segment/HKCDL.php
@@ -27,7 +27,7 @@ class HKCDL extends AbstractSegment
      * @param string $SEPADescriptor
      * @param SEPAStandingOrder $SEPAStandingOrder
      */
-    public function __construct($version, $segmentNumber, $kti, $SEPADescriptor, SEPAStandingOrder $SEPAStandingOrder)
+    public function __construct(int $version, int $segmentNumber, Kti $kti, string $SEPADescriptor, SEPAStandingOrder $SEPAStandingOrder)
     {
         $deg = new \Fhp\Deg();
         $deg->addDataElement($SEPAStandingOrder->getFirstExecution());
@@ -53,7 +53,7 @@ class HKCDL extends AbstractSegment
     /**
      * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         return static::NAME;
     }

--- a/lib/Fhp/Segment/HKCDL.php
+++ b/lib/Fhp/Segment/HKCDL.php
@@ -21,11 +21,6 @@ class HKCDL extends AbstractSegment
 
     /**
      * HKCDL constructor.
-     * @param int $version
-     * @param int $segmentNumber
-     * @param Kti $kti
-     * @param string $SEPADescriptor
-     * @param SEPAStandingOrder $SEPAStandingOrder
      */
     public function __construct(int $version, int $segmentNumber, Kti $kti, string $SEPADescriptor, SEPAStandingOrder $SEPAStandingOrder)
     {
@@ -50,9 +45,6 @@ class HKCDL extends AbstractSegment
         );
     }
 
-    /**
-     * @return string
-     */
     public function getName(): string
     {
         return static::NAME;

--- a/lib/Fhp/Segment/HKDSC.php
+++ b/lib/Fhp/Segment/HKDSC.php
@@ -26,7 +26,7 @@ class HKDSC extends AbstractSegment
      * @param string $SEPADescriptor
      * @param string $painMessage
      */
-    public function __construct($version, $segmentNumber, $kti, $SEPADescriptor, $painMessage)
+    public function __construct(int $version, int $segmentNumber, Kti $kti, string $SEPADescriptor, string $painMessage)
     {
         parent::__construct(
             static::NAME,
@@ -43,7 +43,7 @@ class HKDSC extends AbstractSegment
     /**
      * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         return static::NAME;
     }

--- a/lib/Fhp/Segment/HKDSC.php
+++ b/lib/Fhp/Segment/HKDSC.php
@@ -20,11 +20,6 @@ class HKDSC extends AbstractSegment
 
     /**
      * HKDSC constructor.
-     * @param int $version
-     * @param int $segmentNumber
-     * @param Kti $kti
-     * @param string $SEPADescriptor
-     * @param string $painMessage
      */
     public function __construct(int $version, int $segmentNumber, Kti $kti, string $SEPADescriptor, string $painMessage)
     {
@@ -40,9 +35,6 @@ class HKDSC extends AbstractSegment
         );
     }
 
-    /**
-     * @return string
-     */
     public function getName(): string
     {
         return static::NAME;

--- a/lib/Fhp/Segment/HKDSE.php
+++ b/lib/Fhp/Segment/HKDSE.php
@@ -20,11 +20,6 @@ class HKDSE extends AbstractSegment
 
     /**
      * HKDSE constructor.
-     * @param int $version
-     * @param int $segmentNumber
-     * @param Kti $kti
-     * @param string $SEPADescriptor
-     * @param string $painMessage
      */
     public function __construct(int $version, int $segmentNumber, Kti $kti, string $SEPADescriptor, string $painMessage)
     {
@@ -40,9 +35,6 @@ class HKDSE extends AbstractSegment
         );
     }
 
-    /**
-     * @return string
-     */
     public function getName(): string
     {
         return static::NAME;

--- a/lib/Fhp/Segment/HKDSE.php
+++ b/lib/Fhp/Segment/HKDSE.php
@@ -26,7 +26,7 @@ class HKDSE extends AbstractSegment
      * @param string $SEPADescriptor
      * @param string $painMessage
      */
-    public function __construct($version, $segmentNumber, $kti, $SEPADescriptor, $painMessage)
+    public function __construct(int $version, int $segmentNumber, Kti $kti, string $SEPADescriptor, string $painMessage)
     {
         parent::__construct(
             static::NAME,
@@ -43,7 +43,7 @@ class HKDSE extends AbstractSegment
     /**
      * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         return static::NAME;
     }

--- a/lib/Fhp/Segment/HKEND.php
+++ b/lib/Fhp/Segment/HKEND.php
@@ -34,7 +34,7 @@ class HKEND extends AbstractSegment
     /**
      * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         return static::NAME;
     }

--- a/lib/Fhp/Segment/HKEND.php
+++ b/lib/Fhp/Segment/HKEND.php
@@ -31,9 +31,6 @@ class HKEND extends AbstractSegment
         );
     }
 
-    /**
-     * @return string
-     */
     public function getName(): string
     {
         return static::NAME;

--- a/lib/Fhp/Segment/HKEND/HKENDv1.php
+++ b/lib/Fhp/Segment/HKEND/HKENDv1.php
@@ -15,10 +15,6 @@ class HKENDv1 extends BaseSegment
     /** @var string */
     public $dialogId;
 
-    /**
-     * @param string $dialogId
-     * @return HKENDv1
-     */
     public static function create(string $dialogId): HKENDv1
     {
         $result = HKENDv1::createEmpty();

--- a/lib/Fhp/Segment/HKEND/HKENDv1.php
+++ b/lib/Fhp/Segment/HKEND/HKENDv1.php
@@ -19,7 +19,7 @@ class HKENDv1 extends BaseSegment
      * @param string $dialogId
      * @return HKENDv1
      */
-    public static function create($dialogId)
+    public static function create(string $dialogId): HKENDv1
     {
         $result = HKENDv1::createEmpty();
         $result->dialogId = $dialogId;

--- a/lib/Fhp/Segment/HKIDN.php
+++ b/lib/Fhp/Segment/HKIDN.php
@@ -24,7 +24,7 @@ class HKIDN extends AbstractSegment
      * @param string $userName
      * @param int $systemId
      */
-    public function __construct($segmentNumber, $bankCode, $userName, $systemId = 0)
+    public function __construct(int $segmentNumber, string $bankCode, string $userName, int $systemId = 0)
     {
         parent::__construct(
             static::NAME,
@@ -42,7 +42,7 @@ class HKIDN extends AbstractSegment
     /**
      * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         return static::NAME;
     }

--- a/lib/Fhp/Segment/HKIDN.php
+++ b/lib/Fhp/Segment/HKIDN.php
@@ -19,10 +19,6 @@ class HKIDN extends AbstractSegment
 
     /**
      * HKIDN constructor.
-     * @param int $segmentNumber
-     * @param string $bankCode
-     * @param string $userName
-     * @param int $systemId
      */
     public function __construct(int $segmentNumber, string $bankCode, string $userName, int $systemId = 0)
     {
@@ -39,9 +35,6 @@ class HKIDN extends AbstractSegment
         );
     }
 
-    /**
-     * @return string
-     */
     public function getName(): string
     {
         return static::NAME;

--- a/lib/Fhp/Segment/HKIDN/HKIDNv2.php
+++ b/lib/Fhp/Segment/HKIDN/HKIDNv2.php
@@ -40,7 +40,7 @@ class HKIDNv2 extends BaseSegment
      * @param string $kundensystemId
      * @return HKIDNv2
      */
-    public static function create($kreditinstitutionscode, $credentials, $kundensystemId)
+    public static function create(string $kreditinstitutionscode, Credentials $credentials, string $kundensystemId): HKIDNv2
     {
         $result = HKIDNv2::createEmpty();
         $result->kreditinstitutskennung = \Fhp\Segment\Common\Kik::create($kreditinstitutionscode);
@@ -54,7 +54,7 @@ class HKIDNv2 extends BaseSegment
      * @param string $kreditinstitutionscode
      * @return HKIDNv2
      */
-    public static function createAnonymous($kreditinstitutionscode)
+    public static function createAnonymous(string $kreditinstitutionscode): HKIDNv2
     {
         $result = HKIDNv2::createEmpty();
         $result->kreditinstitutskennung = \Fhp\Segment\Common\Kik::create($kreditinstitutionscode);

--- a/lib/Fhp/Segment/HKIDN/HKIDNv2.php
+++ b/lib/Fhp/Segment/HKIDN/HKIDNv2.php
@@ -34,12 +34,6 @@ class HKIDNv2 extends BaseSegment
      */
     public $kundensystemStatus = 1; // This library only supports PIN/TAN, hence 1 is the right choice.
 
-    /**
-     * @param string $kreditinstitutionscode
-     * @param Credentials $credentials
-     * @param string $kundensystemId
-     * @return HKIDNv2
-     */
     public static function create(string $kreditinstitutionscode, Credentials $credentials, string $kundensystemId): HKIDNv2
     {
         $result = HKIDNv2::createEmpty();
@@ -50,10 +44,6 @@ class HKIDNv2 extends BaseSegment
         return $result;
     }
 
-    /**
-     * @param string $kreditinstitutionscode
-     * @return HKIDNv2
-     */
     public static function createAnonymous(string $kreditinstitutionscode): HKIDNv2
     {
         $result = HKIDNv2::createEmpty();

--- a/lib/Fhp/Segment/HKKAZ.php
+++ b/lib/Fhp/Segment/HKKAZ.php
@@ -19,13 +19,7 @@ class HKKAZ extends AbstractSegment
 
     /**
      * HKKAZ constructor.
-     * @param int $version
-     * @param int $segmentNumber
      * @param mixed $ktv
-     * @param array $allAccounts
-     * @param \DateTime $from
-     * @param \DateTime $to
-     * @param string|null $touchdown
      */
     public function __construct(
         int $version,
@@ -51,9 +45,6 @@ class HKKAZ extends AbstractSegment
         );
     }
 
-    /**
-     * @return string
-     */
     public function getName(): string
     {
         return static::NAME;

--- a/lib/Fhp/Segment/HKKAZ.php
+++ b/lib/Fhp/Segment/HKKAZ.php
@@ -28,13 +28,13 @@ class HKKAZ extends AbstractSegment
      * @param string|null $touchdown
      */
     public function __construct(
-        $version,
-        $segmentNumber,
+        int $version,
+        int $segmentNumber,
         $ktv,
-        $allAccounts,
+        array $allAccounts,
         \DateTime $from,
         \DateTime $to,
-        $touchdown = null
+        ?string $touchdown = null
     ) {
         parent::__construct(
             static::NAME,
@@ -54,7 +54,7 @@ class HKKAZ extends AbstractSegment
     /**
      * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         return static::NAME;
     }

--- a/lib/Fhp/Segment/HKSAL.php
+++ b/lib/Fhp/Segment/HKSAL.php
@@ -18,10 +18,7 @@ class HKSAL extends AbstractSegment
 
     /**
      * HKSAL constructor.
-     * @param int $version
-     * @param int $segmentNumber
      * @param mixed $ktv
-     * @param bool $allAccounts
      */
     public function __construct(int $version, int $segmentNumber, $ktv, bool $allAccounts)
     {
@@ -36,9 +33,6 @@ class HKSAL extends AbstractSegment
         );
     }
 
-    /**
-     * @return string
-     */
     public function getName(): string
     {
         return static::NAME;

--- a/lib/Fhp/Segment/HKSAL.php
+++ b/lib/Fhp/Segment/HKSAL.php
@@ -23,7 +23,7 @@ class HKSAL extends AbstractSegment
      * @param mixed $ktv
      * @param bool $allAccounts
      */
-    public function __construct($version, $segmentNumber, $ktv, $allAccounts)
+    public function __construct(int $version, int $segmentNumber, $ktv, bool $allAccounts)
     {
         parent::__construct(
             static::NAME,
@@ -39,7 +39,7 @@ class HKSAL extends AbstractSegment
     /**
      * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         return static::NAME;
     }

--- a/lib/Fhp/Segment/HKSPA.php
+++ b/lib/Fhp/Segment/HKSPA.php
@@ -21,7 +21,7 @@ class HKSPA extends AbstractSegment
      * @param int $segmentNumber
      * @param Ktv|null $ktv
      */
-    public function __construct($segmentNumber, Ktv $ktv = null)
+    public function __construct(int $segmentNumber, Ktv $ktv = null)
     {
         parent::__construct(
             static::NAME,
@@ -34,7 +34,7 @@ class HKSPA extends AbstractSegment
     /**
      * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         return static::NAME;
     }

--- a/lib/Fhp/Segment/HKSPA.php
+++ b/lib/Fhp/Segment/HKSPA.php
@@ -18,8 +18,6 @@ class HKSPA extends AbstractSegment
 
     /**
      * HKSPA constructor.
-     * @param int $segmentNumber
-     * @param Ktv|null $ktv
      */
     public function __construct(int $segmentNumber, Ktv $ktv = null)
     {
@@ -31,9 +29,6 @@ class HKSPA extends AbstractSegment
         );
     }
 
-    /**
-     * @return string
-     */
     public function getName(): string
     {
         return static::NAME;

--- a/lib/Fhp/Segment/HKSYN.php
+++ b/lib/Fhp/Segment/HKSYN.php
@@ -20,8 +20,6 @@ class HKSYN extends AbstractSegment
 
     /**
      * HKSYN constructor.
-     * @param int $segmentNumber
-     * @param int $syncMode
      */
     public function __construct(
         int $segmentNumber,
@@ -35,9 +33,6 @@ class HKSYN extends AbstractSegment
         );
     }
 
-    /**
-     * @return string
-     */
     public function getName(): string
     {
         return static::NAME;

--- a/lib/Fhp/Segment/HKSYN.php
+++ b/lib/Fhp/Segment/HKSYN.php
@@ -24,8 +24,8 @@ class HKSYN extends AbstractSegment
      * @param int $syncMode
      */
     public function __construct(
-        $segmentNumber,
-        $syncMode = self::SYNC_MODE_NEW_CUSTOMER_ID
+        int $segmentNumber,
+        int $syncMode = self::SYNC_MODE_NEW_CUSTOMER_ID
     ) {
         parent::__construct(
             static::NAME,
@@ -38,7 +38,7 @@ class HKSYN extends AbstractSegment
     /**
      * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         return static::NAME;
     }

--- a/lib/Fhp/Segment/HKSYN/HKSYNv3.php
+++ b/lib/Fhp/Segment/HKSYN/HKSYNv3.php
@@ -1,5 +1,7 @@
 <?php
 
+/** @noinspection PhpUnused */
+
 namespace Fhp\Segment\HKSYN;
 
 use Fhp\Segment\BaseSegment;

--- a/lib/Fhp/Segment/HKTAB.php
+++ b/lib/Fhp/Segment/HKTAB.php
@@ -13,7 +13,6 @@ class HKTAB extends AbstractSegment
 
     /**
      * HKTAB constructor.
-     * @param int $segmentNumber
      */
     public function __construct(int $segmentNumber)
     {
@@ -28,9 +27,6 @@ class HKTAB extends AbstractSegment
         );
     }
 
-    /**
-     * @return string
-     */
     public function getName(): string
     {
         return static::NAME;

--- a/lib/Fhp/Segment/HKTAB.php
+++ b/lib/Fhp/Segment/HKTAB.php
@@ -15,7 +15,7 @@ class HKTAB extends AbstractSegment
      * HKTAB constructor.
      * @param int $segmentNumber
      */
-    public function __construct($segmentNumber)
+    public function __construct(int $segmentNumber)
     {
         parent::__construct(
             static::NAME,
@@ -31,7 +31,7 @@ class HKTAB extends AbstractSegment
     /**
      * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         return static::NAME;
     }

--- a/lib/Fhp/Segment/HKTAN.php
+++ b/lib/Fhp/Segment/HKTAN.php
@@ -23,7 +23,7 @@ class HKTAN extends AbstractSegment
      * @param int $version
      * @param int $segmentNumber
      */
-    public function __construct($version, $segmentNumber, $processID = null, $tanMediaName = '')
+    public function __construct(int $version, int $segmentNumber, $processID = null, $tanMediaName = '')
     {
         /*
         if($processID){

--- a/lib/Fhp/Segment/HKTAN.php
+++ b/lib/Fhp/Segment/HKTAN.php
@@ -20,8 +20,6 @@ class HKTAN extends AbstractSegment
 
     /**
      * HKCDL constructor.
-     * @param int $version
-     * @param int $segmentNumber
      */
     public function __construct(int $version, int $segmentNumber, $processID = null, $tanMediaName = '')
     {

--- a/lib/Fhp/Segment/HKVVB.php
+++ b/lib/Fhp/Segment/HKVVB.php
@@ -35,12 +35,12 @@ class HKVVB extends AbstractSegment
      * @param string $productVersion
      */
     public function __construct(
-        $segmentNumber,
-        $bpdVersion = self::DEFAULT_BPD_VERSION,
-        $updVersion = self::DEFAULT_UPD_VERSION,
-        $dialogLanguage = self::LANG_DEFAULT,
-        $productName = self::DEFAULT_PRODUCT_NAME,
-        $productVersion = self::DEFAULT_PRODUCT_VERSION
+        int $segmentNumber,
+        int $bpdVersion = self::DEFAULT_BPD_VERSION,
+        int $updVersion = self::DEFAULT_UPD_VERSION,
+        int $dialogLanguage = self::LANG_DEFAULT,
+        string $productName = self::DEFAULT_PRODUCT_NAME,
+        string $productVersion = self::DEFAULT_PRODUCT_VERSION
     ) {
         parent::__construct(
             static::NAME,
@@ -59,7 +59,7 @@ class HKVVB extends AbstractSegment
     /**
      * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         return static::NAME;
     }

--- a/lib/Fhp/Segment/HKVVB.php
+++ b/lib/Fhp/Segment/HKVVB.php
@@ -27,12 +27,6 @@ class HKVVB extends AbstractSegment
 
     /**
      * HKVVB constructor.
-     * @param int $segmentNumber
-     * @param int $bpdVersion
-     * @param int $updVersion
-     * @param int $dialogLanguage
-     * @param string $productName
-     * @param string $productVersion
      */
     public function __construct(
         int $segmentNumber,
@@ -56,9 +50,6 @@ class HKVVB extends AbstractSegment
         );
     }
 
-    /**
-     * @return string
-     */
     public function getName(): string
     {
         return static::NAME;

--- a/lib/Fhp/Segment/HKVVB/HKVVBv3.php
+++ b/lib/Fhp/Segment/HKVVB/HKVVBv3.php
@@ -32,10 +32,7 @@ class HKVVBv3 extends BaseSegment
     /** @var string Max length: 5 */
     public $produktversion;
 
-    /**
-     * @return HKVVBv3
-     */
-    public static function create(FinTsOptions $options, ?BPD $bpd, ?UPD $upd)
+    public static function create(FinTsOptions $options, ?BPD $bpd, ?UPD $upd): HKVVBv3
     {
         $result = HKVVBv3::createEmpty();
         $result->bpdVersion = $bpd === null ? 0 : $bpd->getVersion();

--- a/lib/Fhp/Segment/HKVVB/HKVVBv3.php
+++ b/lib/Fhp/Segment/HKVVB/HKVVBv3.php
@@ -38,7 +38,7 @@ class HKVVBv3 extends BaseSegment
      * @param UPD|null $upd
      * @return HKVVBv3
      */
-    public static function create($options, $bpd, $upd)
+    public static function create(FinTsOptions $options, ?BPD $bpd, ?UPD $upd)
     {
         $result = HKVVBv3::createEmpty();
         $result->bpdVersion = $bpd === null ? 0 : $bpd->getVersion();

--- a/lib/Fhp/Segment/HKVVB/HKVVBv3.php
+++ b/lib/Fhp/Segment/HKVVB/HKVVBv3.php
@@ -33,9 +33,6 @@ class HKVVBv3 extends BaseSegment
     public $produktversion;
 
     /**
-     * @param FinTsOptions $options
-     * @param BPD|null $bpd
-     * @param UPD|null $upd
      * @return HKVVBv3
      */
     public static function create(FinTsOptions $options, ?BPD $bpd, ?UPD $upd)

--- a/lib/Fhp/Segment/HNHBK.php
+++ b/lib/Fhp/Segment/HNHBK.php
@@ -19,9 +19,6 @@ class HNHBK extends AbstractSegment
 
     /**
      * HNHBK constructor.
-     * @param string $messageLength
-     * @param string $dialogId
-     * @param int $messageNumber
      */
     public function __construct(string $messageLength, string $dialogId, int $messageNumber)
     {
@@ -42,9 +39,6 @@ class HNHBK extends AbstractSegment
         );
     }
 
-    /**
-     * @return string
-     */
     public function getName(): string
     {
         return static::NAME;

--- a/lib/Fhp/Segment/HNHBK.php
+++ b/lib/Fhp/Segment/HNHBK.php
@@ -23,7 +23,7 @@ class HNHBK extends AbstractSegment
      * @param string $dialogId
      * @param int $messageNumber
      */
-    public function __construct($messageLength, $dialogId, $messageNumber)
+    public function __construct(string $messageLength, string $dialogId, int $messageNumber)
     {
         if (strlen($messageLength) != 12) {
             $messageLength = str_pad((int) $messageLength + static::HEADER_LENGTH + strlen($dialogId) + strlen($messageNumber), 12, '0', STR_PAD_LEFT);
@@ -45,7 +45,7 @@ class HNHBK extends AbstractSegment
     /**
      * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         return static::NAME;
     }

--- a/lib/Fhp/Segment/HNHBK/HNHBKv3.php
+++ b/lib/Fhp/Segment/HNHBK/HNHBKv3.php
@@ -38,7 +38,7 @@ class HNHBKv3 extends BaseSegment
     /**
      * @return int
      */
-    public function getNachrichtengroesse()
+    public function getNachrichtengroesse(): int
     {
         return intval($this->nachrichtengroesse);
     }
@@ -46,7 +46,7 @@ class HNHBKv3 extends BaseSegment
     /**
      * @param int $nachrichtengroesse Length of the entire message in bytes.
      */
-    public function setNachrichtengroesse($nachrichtengroesse)
+    public function setNachrichtengroesse(int $nachrichtengroesse)
     {
         $this->nachrichtengroesse = str_pad($nachrichtengroesse, static::NACHRICHTENGROESSE_LENGTH, '0', STR_PAD_LEFT);
     }

--- a/lib/Fhp/Segment/HNHBK/HNHBKv3.php
+++ b/lib/Fhp/Segment/HNHBK/HNHBKv3.php
@@ -35,9 +35,6 @@ class HNHBKv3 extends BaseSegment
     /** @var BezugsnachrichtV1|null Never sent to server, but always present in responses. */
     public $bezugsnachricht;
 
-    /**
-     * @return int
-     */
     public function getNachrichtengroesse(): int
     {
         return intval($this->nachrichtengroesse);

--- a/lib/Fhp/Segment/HNHBS.php
+++ b/lib/Fhp/Segment/HNHBS.php
@@ -16,8 +16,6 @@ class HNHBS extends AbstractSegment
 
     /**
      * HNHBS constructor.
-     * @param int $segmentNumber
-     * @param int $messageNumber
      */
     public function __construct(
         int $segmentNumber,
@@ -31,9 +29,6 @@ class HNHBS extends AbstractSegment
         );
     }
 
-    /**
-     * @return string
-     */
     public function getName(): string
     {
         return static::NAME;

--- a/lib/Fhp/Segment/HNHBS.php
+++ b/lib/Fhp/Segment/HNHBS.php
@@ -20,8 +20,8 @@ class HNHBS extends AbstractSegment
      * @param int $messageNumber
      */
     public function __construct(
-        $segmentNumber,
-        $messageNumber
+        int $segmentNumber,
+        int $messageNumber
     ) {
         parent::__construct(
             static::NAME,
@@ -34,7 +34,7 @@ class HNHBS extends AbstractSegment
     /**
      * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         return static::NAME;
     }

--- a/lib/Fhp/Segment/HNSHA.php
+++ b/lib/Fhp/Segment/HNSHA.php
@@ -18,9 +18,6 @@ class HNSHA extends AbstractSegment
 
     /**
      * HNSHA constructor.
-     * @param int $segmentNumber
-     * @param string $securityControlReference
-     * @param string $pin
      */
     public function __construct(
         int $segmentNumber,
@@ -46,9 +43,6 @@ class HNSHA extends AbstractSegment
         );
     }
 
-    /**
-     * @return string
-     */
     public function getName(): string
     {
         return static::NAME;

--- a/lib/Fhp/Segment/HNSHA.php
+++ b/lib/Fhp/Segment/HNSHA.php
@@ -23,9 +23,9 @@ class HNSHA extends AbstractSegment
      * @param string $pin
      */
     public function __construct(
-        $segmentNumber,
-        $securityControlReference,
-        $pin,
+        int $segmentNumber,
+        string $securityControlReference,
+        string $pin,
         $tan = null
     ) {
         $deg = new Deg();
@@ -49,7 +49,7 @@ class HNSHA extends AbstractSegment
     /**
      * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         return static::NAME;
     }

--- a/lib/Fhp/Segment/HNSHA/BenutzerdefinierteSignaturV1.php
+++ b/lib/Fhp/Segment/HNSHA/BenutzerdefinierteSignaturV1.php
@@ -17,11 +17,6 @@ class BenutzerdefinierteSignaturV1 extends BaseDeg
     /** @var string|null Max length: 99 */
     public $tan;
 
-    /**
-     * @param string $pin
-     * @param string|null $tan
-     * @return BenutzerdefinierteSignaturV1
-     */
     public static function create(string $pin, ?string $tan): BenutzerdefinierteSignaturV1
     {
         $result = new BenutzerdefinierteSignaturV1();

--- a/lib/Fhp/Segment/HNSHA/BenutzerdefinierteSignaturV1.php
+++ b/lib/Fhp/Segment/HNSHA/BenutzerdefinierteSignaturV1.php
@@ -22,7 +22,7 @@ class BenutzerdefinierteSignaturV1 extends BaseDeg
      * @param string|null $tan
      * @return BenutzerdefinierteSignaturV1
      */
-    public static function create($pin, $tan)
+    public static function create(string $pin, ?string $tan): BenutzerdefinierteSignaturV1
     {
         $result = new BenutzerdefinierteSignaturV1();
         $result->pin = $pin;

--- a/lib/Fhp/Segment/HNSHA/HNSHAv2.php
+++ b/lib/Fhp/Segment/HNSHA/HNSHAv2.php
@@ -24,7 +24,7 @@ class HNSHAv2 extends BaseSegment
      * @param BenutzerdefinierteSignaturV1 $benutzerdefinierteSignatur Contains PIN, and optionally the TAN
      * @return HNSHAv2
      */
-    public static function create($sicherheitskontrollreferenz, $benutzerdefinierteSignatur)
+    public static function create(string $sicherheitskontrollreferenz, BenutzerdefinierteSignaturV1 $benutzerdefinierteSignatur): HNSHAv2
     {
         $result = HNSHAv2::createEmpty();
         $result->sicherheitskontrollreferenz = $sicherheitskontrollreferenz;

--- a/lib/Fhp/Segment/HNSHA/HNSHAv2.php
+++ b/lib/Fhp/Segment/HNSHA/HNSHAv2.php
@@ -22,7 +22,6 @@ class HNSHAv2 extends BaseSegment
     /**
      * @param string $sicherheitskontrollreferenz The same number that was passed to HNSHK.
      * @param BenutzerdefinierteSignaturV1 $benutzerdefinierteSignatur Contains PIN, and optionally the TAN
-     * @return HNSHAv2
      */
     public static function create(string $sicherheitskontrollreferenz, BenutzerdefinierteSignaturV1 $benutzerdefinierteSignatur): HNSHAv2
     {

--- a/lib/Fhp/Segment/HNSHK.php
+++ b/lib/Fhp/Segment/HNSHK.php
@@ -35,16 +35,6 @@ class HNSHK extends AbstractSegment
 
     /**
      * HNSHK constructor.
-     * @param int $segmentNumber
-     * @param string $securityReference
-     * @param string $countryCode
-     * @param string $bankCode
-     * @param string $userName
-     * @param int $systemId
-     * @param int $securityFunction
-     * @param int $securityBoundary
-     * @param int $securitySupplierRole
-     * @param int $pinTanVersion
      */
     public function __construct(
         int $segmentNumber,
@@ -78,9 +68,6 @@ class HNSHK extends AbstractSegment
         );
     }
 
-    /**
-     * @return string
-     */
     public function getName(): string
     {
         return static::NAME;

--- a/lib/Fhp/Segment/HNSHK.php
+++ b/lib/Fhp/Segment/HNSHK.php
@@ -47,16 +47,16 @@ class HNSHK extends AbstractSegment
      * @param int $pinTanVersion
      */
     public function __construct(
-        $segmentNumber,
-        $securityReference,
-        $countryCode,
-        $bankCode,
-        $userName,
-        $systemId = 0,
-        $securityFunction = self::SECURITY_FUNC_999,
-        $securityBoundary = self::SECURITY_BOUNDARY_SHM,
-        $securitySupplierRole = self::SECURITY_SUPPLIER_ROLE_ISS,
-        $pinTanVersion = SecurityProfile::PROFILE_VERSION_1
+        int $segmentNumber,
+        string $securityReference,
+        string $countryCode,
+        string $bankCode,
+        string $userName,
+        int $systemId = 0,
+        int $securityFunction = self::SECURITY_FUNC_999,
+        int $securityBoundary = self::SECURITY_BOUNDARY_SHM,
+        int $securitySupplierRole = self::SECURITY_SUPPLIER_ROLE_ISS,
+        int $pinTanVersion = SecurityProfile::PROFILE_VERSION_1
     ) {
         parent::__construct(
             static::NAME,
@@ -81,7 +81,7 @@ class HNSHK extends AbstractSegment
     /**
      * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         return static::NAME;
     }

--- a/lib/Fhp/Segment/HNSHK/HNSHKv4.php
+++ b/lib/Fhp/Segment/HNSHK/HNSHKv4.php
@@ -68,7 +68,7 @@ class HNSHKv4 extends BaseSegment
      * @param string $kundensystemId See {@link SicherheitsidentifikationDetailsV2#identifizierungDerPartei}.
      * @return HNSHKv4
      */
-    public static function create($sicherheitskontrollreferenz, $options, $credentials, $tanMode, $kundensystemId)
+    public static function create(string $sicherheitskontrollreferenz, FinTsOptions $options, Credentials $credentials, ?TanMode $tanMode, string $kundensystemId): HNSHKv4
     {
         $result = HNSHKv4::createEmpty();
         $result->sicherheitsprofil =

--- a/lib/Fhp/Segment/HNSHK/HNSHKv4.php
+++ b/lib/Fhp/Segment/HNSHK/HNSHKv4.php
@@ -66,7 +66,6 @@ class HNSHKv4 extends BaseSegment
      * @param Credentials $credentials See {@link Credentials}.
      * @param TanMode|null $tanMode Optionally specifies which two-step TAN mode to use, defaults to 999 (single step).
      * @param string $kundensystemId See {@link SicherheitsidentifikationDetailsV2#identifizierungDerPartei}.
-     * @return HNSHKv4
      */
     public static function create(string $sicherheitskontrollreferenz, FinTsOptions $options, Credentials $credentials, ?TanMode $tanMode, string $kundensystemId): HNSHKv4
     {

--- a/lib/Fhp/Segment/HNVSD.php
+++ b/lib/Fhp/Segment/HNVSD.php
@@ -18,8 +18,6 @@ class HNVSD extends AbstractSegment
 
     /**
      * HNVSD constructor.
-     * @param int $segmentNumber
-     * @param string $encodedData
      */
     public function __construct(int $segmentNumber, string $encodedData)
     {
@@ -31,9 +29,6 @@ class HNVSD extends AbstractSegment
         );
     }
 
-    /**
-     * @return Bin
-     */
     public function getEncodedData(): Bin
     {
         $des = $this->getDataElements();
@@ -41,17 +36,11 @@ class HNVSD extends AbstractSegment
         return $des[0];
     }
 
-    /**
-     * @param string $data
-     */
     public function setEncodedData(string $data)
     {
         $this->setDataElements([new Bin($data)]);
     }
 
-    /**
-     * @return string
-     */
     public function getName(): string
     {
         return static::NAME;

--- a/lib/Fhp/Segment/HNVSD.php
+++ b/lib/Fhp/Segment/HNVSD.php
@@ -21,7 +21,7 @@ class HNVSD extends AbstractSegment
      * @param int $segmentNumber
      * @param string $encodedData
      */
-    public function __construct($segmentNumber, $encodedData)
+    public function __construct(int $segmentNumber, string $encodedData)
     {
         parent::__construct(
             static::NAME,
@@ -34,7 +34,7 @@ class HNVSD extends AbstractSegment
     /**
      * @return Bin
      */
-    public function getEncodedData()
+    public function getEncodedData(): Bin
     {
         $des = $this->getDataElements();
 
@@ -44,7 +44,7 @@ class HNVSD extends AbstractSegment
     /**
      * @param string $data
      */
-    public function setEncodedData($data)
+    public function setEncodedData(string $data)
     {
         $this->setDataElements([new Bin($data)]);
     }
@@ -52,7 +52,7 @@ class HNVSD extends AbstractSegment
     /**
      * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         return static::NAME;
     }

--- a/lib/Fhp/Segment/HNVSD/HNVSDv1.php
+++ b/lib/Fhp/Segment/HNVSD/HNVSDv1.php
@@ -32,7 +32,7 @@ class HNVSDv1 extends BaseSegment
      * @param BaseSegment[] $segments Some segments that will be serialized into the data field.
      * @return HNVSDv1
      */
-    public static function create($segments)
+    public static function create(array $segments): HNVSDv1
     {
         $result = HNVSDv1::createEmpty();
         $result->segmentkopf->segmentnummer = static::SEGMENT_NUMBER;

--- a/lib/Fhp/Segment/HNVSD/HNVSDv1.php
+++ b/lib/Fhp/Segment/HNVSD/HNVSDv1.php
@@ -30,7 +30,6 @@ class HNVSDv1 extends BaseSegment
 
     /**
      * @param BaseSegment[] $segments Some segments that will be serialized into the data field.
-     * @return HNVSDv1
      */
     public static function create(array $segments): HNVSDv1
     {

--- a/lib/Fhp/Segment/HNVSK.php
+++ b/lib/Fhp/Segment/HNVSK.php
@@ -46,14 +46,14 @@ class HNVSK extends AbstractSegment
      * @param int $pinTanVersion
      */
     public function __construct(
-        $segmentNumber,
-        $bankCode,
-        $userName,
-        $systemId = 0,
-        $securitySupplierRole = self::SECURITY_SUPPLIER_ROLE_ISS,
-        $countryCode = self::DEFAULT_COUNTRY_CODE,
-        $compression = self::COMPRESSION_NONE,
-        $pinTanVersion = SecurityProfile::PROFILE_VERSION_1
+        int $segmentNumber,
+        string $bankCode,
+        string $userName,
+        int $systemId = 0,
+        int $securitySupplierRole = self::SECURITY_SUPPLIER_ROLE_ISS,
+        int $countryCode = self::DEFAULT_COUNTRY_CODE,
+        int $compression = self::COMPRESSION_NONE,
+        int $pinTanVersion = SecurityProfile::PROFILE_VERSION_1
     ) {
         parent::__construct(
             static::NAME,
@@ -75,7 +75,7 @@ class HNVSK extends AbstractSegment
     /**
      * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         return static::NAME;
     }

--- a/lib/Fhp/Segment/HNVSK.php
+++ b/lib/Fhp/Segment/HNVSK.php
@@ -36,14 +36,6 @@ class HNVSK extends AbstractSegment
 
     /**
      * HNVSK constructor.
-     * @param int $segmentNumber
-     * @param string $bankCode
-     * @param string $userName
-     * @param int $systemId
-     * @param int $securitySupplierRole
-     * @param int $countryCode
-     * @param int $compression
-     * @param int $pinTanVersion
      */
     public function __construct(
         int $segmentNumber,
@@ -72,9 +64,6 @@ class HNVSK extends AbstractSegment
         );
     }
 
-    /**
-     * @return string
-     */
     public function getName(): string
     {
         return static::NAME;

--- a/lib/Fhp/Segment/HNVSK/HNVSKv3.php
+++ b/lib/Fhp/Segment/HNVSK/HNVSKv3.php
@@ -72,7 +72,6 @@ class HNVSKv3 extends BaseSegment
      * @param Credentials $credentials See {@link Credentials}.
      * @param string $kundensystemId See {@link SicherheitsidentifikationDetailsV2#identifizierungDerPartei}.
      * @param TanMode|null $tanMode Optionally specifies which two-step TAN mode to use, defaults to 999 (single step).
-     * @return HNVSKv3
      */
     public static function create(FinTsOptions $options, Credentials $credentials, string $kundensystemId, ?TanMode $tanMode): HNVSKv3
     {

--- a/lib/Fhp/Segment/HNVSK/HNVSKv3.php
+++ b/lib/Fhp/Segment/HNVSK/HNVSKv3.php
@@ -74,7 +74,7 @@ class HNVSKv3 extends BaseSegment
      * @param TanMode|null $tanMode Optionally specifies which two-step TAN mode to use, defaults to 999 (single step).
      * @return HNVSKv3
      */
-    public static function create($options, $credentials, $kundensystemId, $tanMode)
+    public static function create(FinTsOptions $options, Credentials $credentials, string $kundensystemId, ?TanMode $tanMode): HNVSKv3
     {
         $result = HNVSKv3::createEmpty();
         $result->segmentkopf->segmentnummer = static::SEGMENT_NUMBER;

--- a/lib/Fhp/Segment/HNVSK/SchluesselnameV3.php
+++ b/lib/Fhp/Segment/HNVSK/SchluesselnameV3.php
@@ -43,7 +43,7 @@ class SchluesselnameV3 extends BaseDeg
      * @param string $schluesselart
      * @return SchluesselnameV3
      */
-    public static function create($kik, $benutzerkennung, $schluesselart)
+    public static function create(\Fhp\Segment\Common\Kik $kik, string $benutzerkennung, string $schluesselart): SchluesselnameV3
     {
         $result = new SchluesselnameV3();
         $result->kreditinstitutskennung = $kik;

--- a/lib/Fhp/Segment/HNVSK/SchluesselnameV3.php
+++ b/lib/Fhp/Segment/HNVSK/SchluesselnameV3.php
@@ -37,12 +37,6 @@ class SchluesselnameV3 extends BaseDeg
     /** @var int */
     public $schluesselversion = 0; // Dummy value for PIN/TAN.
 
-    /**
-     * @param \Fhp\Segment\Common\Kik $kik
-     * @param string $benutzerkennung
-     * @param string $schluesselart
-     * @return SchluesselnameV3
-     */
     public static function create(\Fhp\Segment\Common\Kik $kik, string $benutzerkennung, string $schluesselart): SchluesselnameV3
     {
         $result = new SchluesselnameV3();

--- a/lib/Fhp/Segment/HNVSK/SicherheitsdatumUndUhrzeitV2.php
+++ b/lib/Fhp/Segment/HNVSK/SicherheitsdatumUndUhrzeitV2.php
@@ -28,7 +28,7 @@ class SicherheitsdatumUndUhrzeitV2 extends BaseDeg
     /**
      * @return SicherheitsdatumUndUhrzeitV2 For the current time.
      */
-    public static function now()
+    public static function now(): SicherheitsdatumUndUhrzeitV2
     {
         $result = new SicherheitsdatumUndUhrzeitV2();
         try {

--- a/lib/Fhp/Segment/HNVSK/SicherheitsidentifikationDetailsV2.php
+++ b/lib/Fhp/Segment/HNVSK/SicherheitsidentifikationDetailsV2.php
@@ -28,7 +28,7 @@ class SicherheitsidentifikationDetailsV2 extends BaseDeg
      *     synchronization.
      * @return SicherheitsidentifikationDetailsV2
      */
-    public static function createForSender($kundensystemId)
+    public static function createForSender(string $kundensystemId): SicherheitsidentifikationDetailsV2
     {
         $result = new SicherheitsidentifikationDetailsV2();
         $result->identifizierungDerPartei = $kundensystemId;

--- a/lib/Fhp/Segment/HNVSK/SicherheitsidentifikationDetailsV2.php
+++ b/lib/Fhp/Segment/HNVSK/SicherheitsidentifikationDetailsV2.php
@@ -26,7 +26,6 @@ class SicherheitsidentifikationDetailsV2 extends BaseDeg
     /**
      * @param string $kundensystemId The Kundensystem-ID as retrieved from the bank previously, or '0' during
      *     synchronization.
-     * @return SicherheitsidentifikationDetailsV2
      */
     public static function createForSender(string $kundensystemId): SicherheitsidentifikationDetailsV2
     {

--- a/lib/Fhp/Segment/HNVSK/SicherheitsprofilV1.php
+++ b/lib/Fhp/Segment/HNVSK/SicherheitsprofilV1.php
@@ -28,7 +28,7 @@ class SicherheitsprofilV1 extends BaseDeg
      * @param TanMode|null $tanMode Optionally specifies which two-step TAN mode to use, defaults to 999 (single step).
      * @return SicherheitsprofilV1
      */
-    public static function createPIN($tanMode)
+    public static function createPIN(?TanMode $tanMode): SicherheitsprofilV1
     {
         $result = new SicherheitsprofilV1();
         $result->sicherheitsverfahren = 'PIN';

--- a/lib/Fhp/Segment/HNVSK/SicherheitsprofilV1.php
+++ b/lib/Fhp/Segment/HNVSK/SicherheitsprofilV1.php
@@ -26,7 +26,6 @@ class SicherheitsprofilV1 extends BaseDeg
 
     /**
      * @param TanMode|null $tanMode Optionally specifies which two-step TAN mode to use, defaults to 999 (single step).
-     * @return SicherheitsprofilV1
      */
     public static function createPIN(?TanMode $tanMode): SicherheitsprofilV1
     {

--- a/lib/Fhp/Segment/HNVSK/VerschluesselungsalgorithmusV2.php
+++ b/lib/Fhp/Segment/HNVSK/VerschluesselungsalgorithmusV2.php
@@ -43,9 +43,6 @@ class VerschluesselungsalgorithmusV2 extends BaseDeg
     /** @var string|null Max length: 512 Not allowed for PIN/TAN */
     public $wertDesAlgorithmusparametersIv;
 
-    /**
-     * @return VerschluesselungsalgorithmusV2
-     */
     public static function create(): VerschluesselungsalgorithmusV2
     {
         $result = new VerschluesselungsalgorithmusV2();

--- a/lib/Fhp/Segment/HNVSK/VerschluesselungsalgorithmusV2.php
+++ b/lib/Fhp/Segment/HNVSK/VerschluesselungsalgorithmusV2.php
@@ -46,7 +46,7 @@ class VerschluesselungsalgorithmusV2 extends BaseDeg
     /**
      * @return VerschluesselungsalgorithmusV2
      */
-    public static function create()
+    public static function create(): VerschluesselungsalgorithmusV2
     {
         $result = new VerschluesselungsalgorithmusV2();
         // Note: The correct representation of the value that the specification recommends is "\0\0\0\0\0\0\0\0". But

--- a/lib/Fhp/Segment/KAZ/HIKAZ.php
+++ b/lib/Fhp/Segment/KAZ/HIKAZ.php
@@ -10,5 +10,5 @@ use Fhp\DataTypes\Bin;
 interface HIKAZ
 {
     /** @return Bin */
-    public function getGebuchteUmsaetze();
+    public function getGebuchteUmsaetze(): Bin;
 }

--- a/lib/Fhp/Segment/KAZ/HIKAZS.php
+++ b/lib/Fhp/Segment/KAZ/HIKAZS.php
@@ -10,5 +10,5 @@ use Fhp\Segment\SegmentInterface;
 interface HIKAZS extends SegmentInterface
 {
     /** @return ParameterKontoumsaetze */
-    public function getParameter();
+    public function getParameter(): ParameterKontoumsaetze;
 }

--- a/lib/Fhp/Segment/KAZ/HIKAZSv4.php
+++ b/lib/Fhp/Segment/KAZ/HIKAZSv4.php
@@ -16,7 +16,7 @@ class HIKAZSv4 extends BaseGeschaeftsvorfallparameterOld implements HIKAZS
     /** @var ParameterKontoumsaetzeV1 */
     public $parameter;
 
-    public function getParameter()
+    public function getParameter(): ParameterKontoumsaetze
     {
         return $this->parameter;
     }

--- a/lib/Fhp/Segment/KAZ/HIKAZSv5.php
+++ b/lib/Fhp/Segment/KAZ/HIKAZSv5.php
@@ -16,7 +16,7 @@ class HIKAZSv5 extends BaseGeschaeftsvorfallparameterOld implements HIKAZS
     /** @var ParameterKontoumsaetzeV2 */
     public $parameter;
 
-    public function getParameter()
+    public function getParameter(): ParameterKontoumsaetze
     {
         return $this->parameter;
     }

--- a/lib/Fhp/Segment/KAZ/HIKAZSv6.php
+++ b/lib/Fhp/Segment/KAZ/HIKAZSv6.php
@@ -15,7 +15,7 @@ class HIKAZSv6 extends BaseGeschaeftsvorfallparameter implements HIKAZS
     /** @var ParameterKontoumsaetzeV2 */
     public $parameter;
 
-    public function getParameter()
+    public function getParameter(): ParameterKontoumsaetze
     {
         return $this->parameter;
     }

--- a/lib/Fhp/Segment/KAZ/HIKAZv4.php
+++ b/lib/Fhp/Segment/KAZ/HIKAZv4.php
@@ -21,7 +21,7 @@ class HIKAZv4 extends BaseSegment implements HIKAZ
     /** @var Bin|null Uses SWIFT format MT942, version SRG 2001 */
     public $nichtGebuchteUmsaetze;
 
-    public function getGebuchteUmsaetze()
+    public function getGebuchteUmsaetze(): Bin
     {
         return $this->gebuchteUmsaetze;
     }

--- a/lib/Fhp/Segment/KAZ/HKKAZv4.php
+++ b/lib/Fhp/Segment/KAZ/HKKAZv4.php
@@ -27,10 +27,6 @@ class HKKAZv4 extends BaseSegment
     public $aufsetzpunkt;
 
     /**
-     * @param \Fhp\Segment\Common\Kto $kto
-     * @param \DateTime|null $vonDatum
-     * @param \DateTime|null $bisDatum
-     * @param string|null $aufsetzpunkt
      * @return HKKAZv4
      */
     public static function create(\Fhp\Segment\Common\Kto $kto, ?\DateTime $vonDatum, ?\DateTime $bisDatum, ?string $aufsetzpunkt = null)

--- a/lib/Fhp/Segment/KAZ/HKKAZv4.php
+++ b/lib/Fhp/Segment/KAZ/HKKAZv4.php
@@ -26,10 +26,7 @@ class HKKAZv4 extends BaseSegment
     /** @var string|null Max length: 35 */
     public $aufsetzpunkt;
 
-    /**
-     * @return HKKAZv4
-     */
-    public static function create(\Fhp\Segment\Common\Kto $kto, ?\DateTime $vonDatum, ?\DateTime $bisDatum, ?string $aufsetzpunkt = null)
+    public static function create(\Fhp\Segment\Common\Kto $kto, ?\DateTime $vonDatum, ?\DateTime $bisDatum, ?string $aufsetzpunkt = null): HKKAZv4
     {
         $result = HKKAZv4::createEmpty();
         $result->kontoverbindungAuftraggeber = $kto;

--- a/lib/Fhp/Segment/KAZ/HKKAZv4.php
+++ b/lib/Fhp/Segment/KAZ/HKKAZv4.php
@@ -33,7 +33,7 @@ class HKKAZv4 extends BaseSegment
      * @param string|null $aufsetzpunkt
      * @return HKKAZv4
      */
-    public static function create($kto, $vonDatum, $bisDatum, $aufsetzpunkt = null)
+    public static function create(\Fhp\Segment\Common\Kto $kto, ?\DateTime $vonDatum, ?\DateTime $bisDatum, ?string $aufsetzpunkt = null)
     {
         $result = HKKAZv4::createEmpty();
         $result->kontoverbindungAuftraggeber = $kto;

--- a/lib/Fhp/Segment/KAZ/HKKAZv5.php
+++ b/lib/Fhp/Segment/KAZ/HKKAZv5.php
@@ -26,10 +26,7 @@ class HKKAZv5 extends BaseSegment
     /** @var string|null Max length: 35 */
     public $aufsetzpunkt;
 
-    /**
-     * @return HKKAZv5
-     */
-    public static function create(\Fhp\Segment\Common\KtvV3 $ktv, bool $alleKonten, ?\DateTime $vonDatum, ?\DateTime $bisDatum, ?string $aufsetzpunkt = null)
+    public static function create(\Fhp\Segment\Common\KtvV3 $ktv, bool $alleKonten, ?\DateTime $vonDatum, ?\DateTime $bisDatum, ?string $aufsetzpunkt = null): HKKAZv5
     {
         $result = HKKAZv5::createEmpty();
         $result->kontoverbindungAuftraggeber = $ktv;

--- a/lib/Fhp/Segment/KAZ/HKKAZv5.php
+++ b/lib/Fhp/Segment/KAZ/HKKAZv5.php
@@ -34,7 +34,7 @@ class HKKAZv5 extends BaseSegment
      * @param string|null $aufsetzpunkt
      * @return HKKAZv5
      */
-    public static function create($ktv, $alleKonten, $vonDatum, $bisDatum, $aufsetzpunkt = null)
+    public static function create(\Fhp\Segment\Common\KtvV3 $ktv, bool $alleKonten, ?\DateTime $vonDatum, ?\DateTime $bisDatum, ?string $aufsetzpunkt = null)
     {
         $result = HKKAZv5::createEmpty();
         $result->kontoverbindungAuftraggeber = $ktv;

--- a/lib/Fhp/Segment/KAZ/HKKAZv5.php
+++ b/lib/Fhp/Segment/KAZ/HKKAZv5.php
@@ -27,11 +27,6 @@ class HKKAZv5 extends BaseSegment
     public $aufsetzpunkt;
 
     /**
-     * @param \Fhp\Segment\Common\KtvV3 $ktv
-     * @param bool $alleKonten
-     * @param \DateTime|null $vonDatum
-     * @param \DateTime|null $bisDatum
-     * @param string|null $aufsetzpunkt
      * @return HKKAZv5
      */
     public static function create(\Fhp\Segment\Common\KtvV3 $ktv, bool $alleKonten, ?\DateTime $vonDatum, ?\DateTime $bisDatum, ?string $aufsetzpunkt = null)

--- a/lib/Fhp/Segment/KAZ/HKKAZv6.php
+++ b/lib/Fhp/Segment/KAZ/HKKAZv6.php
@@ -33,7 +33,7 @@ class HKKAZv6 extends BaseSegment
      * @param string|null $aufsetzpunkt
      * @return HKKAZv6
      */
-    public static function create($ktv, $alleKonten, $vonDatum, $bisDatum, $aufsetzpunkt = null)
+    public static function create(\Fhp\Segment\Common\KtvV3 $ktv, bool $alleKonten, ?\DateTime $vonDatum, ?\DateTime $bisDatum, ?string $aufsetzpunkt = null)
     {
         $result = HKKAZv6::createEmpty();
         $result->kontoverbindungAuftraggeber = $ktv;

--- a/lib/Fhp/Segment/KAZ/HKKAZv6.php
+++ b/lib/Fhp/Segment/KAZ/HKKAZv6.php
@@ -25,10 +25,7 @@ class HKKAZv6 extends BaseSegment
     /** @var string|null Max length: 35 */
     public $aufsetzpunkt;
 
-    /**
-     * @return HKKAZv6
-     */
-    public static function create(\Fhp\Segment\Common\KtvV3 $ktv, bool $alleKonten, ?\DateTime $vonDatum, ?\DateTime $bisDatum, ?string $aufsetzpunkt = null)
+    public static function create(\Fhp\Segment\Common\KtvV3 $ktv, bool $alleKonten, ?\DateTime $vonDatum, ?\DateTime $bisDatum, ?string $aufsetzpunkt = null): HKKAZv6
     {
         $result = HKKAZv6::createEmpty();
         $result->kontoverbindungAuftraggeber = $ktv;

--- a/lib/Fhp/Segment/KAZ/HKKAZv6.php
+++ b/lib/Fhp/Segment/KAZ/HKKAZv6.php
@@ -26,11 +26,6 @@ class HKKAZv6 extends BaseSegment
     public $aufsetzpunkt;
 
     /**
-     * @param \Fhp\Segment\Common\KtvV3 $ktv
-     * @param bool $alleKonten
-     * @param \DateTime|null $vonDatum
-     * @param \DateTime|null $bisDatum
-     * @param string|null $aufsetzpunkt
      * @return HKKAZv6
      */
     public static function create(\Fhp\Segment\Common\KtvV3 $ktv, bool $alleKonten, ?\DateTime $vonDatum, ?\DateTime $bisDatum, ?string $aufsetzpunkt = null)

--- a/lib/Fhp/Segment/KAZ/HKKAZv7.php
+++ b/lib/Fhp/Segment/KAZ/HKKAZv7.php
@@ -26,11 +26,6 @@ class HKKAZv7 extends BaseSegment
     public $aufsetzpunkt;
 
     /**
-     * @param \Fhp\Segment\Common\Kti $kti
-     * @param bool $alleKonten
-     * @param \DateTime|null $vonDatum
-     * @param \DateTime|null $bisDatum
-     * @param string|null $aufsetzpunkt
      * @return HKKAZv7
      */
     public static function create(\Fhp\Segment\Common\Kti $kti, bool $alleKonten, ?\DateTime $vonDatum, ?\DateTime $bisDatum, ?string $aufsetzpunkt = null)

--- a/lib/Fhp/Segment/KAZ/HKKAZv7.php
+++ b/lib/Fhp/Segment/KAZ/HKKAZv7.php
@@ -33,7 +33,7 @@ class HKKAZv7 extends BaseSegment
      * @param string|null $aufsetzpunkt
      * @return HKKAZv7
      */
-    public static function create($kti, $alleKonten, $vonDatum, $bisDatum, $aufsetzpunkt = null)
+    public static function create(\Fhp\Segment\Common\Kti $kti, bool $alleKonten, ?\DateTime $vonDatum, ?\DateTime $bisDatum, ?string $aufsetzpunkt = null)
     {
         $result = HKKAZv7::createEmpty();
         $result->kontoverbindungInternational = $kti;

--- a/lib/Fhp/Segment/KAZ/HKKAZv7.php
+++ b/lib/Fhp/Segment/KAZ/HKKAZv7.php
@@ -25,10 +25,7 @@ class HKKAZv7 extends BaseSegment
     /** @var string|null Max length: 35 */
     public $aufsetzpunkt;
 
-    /**
-     * @return HKKAZv7
-     */
-    public static function create(\Fhp\Segment\Common\Kti $kti, bool $alleKonten, ?\DateTime $vonDatum, ?\DateTime $bisDatum, ?string $aufsetzpunkt = null)
+    public static function create(\Fhp\Segment\Common\Kti $kti, bool $alleKonten, ?\DateTime $vonDatum, ?\DateTime $bisDatum, ?string $aufsetzpunkt = null): HKKAZv7
     {
         $result = HKKAZv7::createEmpty();
         $result->kontoverbindungInternational = $kti;

--- a/lib/Fhp/Segment/KAZ/ParameterKontoumsaetze.php
+++ b/lib/Fhp/Segment/KAZ/ParameterKontoumsaetze.php
@@ -8,5 +8,5 @@ namespace Fhp\Segment\KAZ;
 interface ParameterKontoumsaetze
 {
     /** @return bool */
-    public function getAlleKontenErlaubt();
+    public function getAlleKontenErlaubt(): bool;
 }

--- a/lib/Fhp/Segment/KAZ/ParameterKontoumsaetzeV1.php
+++ b/lib/Fhp/Segment/KAZ/ParameterKontoumsaetzeV1.php
@@ -19,7 +19,7 @@ class ParameterKontoumsaetzeV1 extends BaseDeg implements ParameterKontoumsaetze
     public $eingabeAnzahlEintraegeErlaubt;
 
     /** @return bool */
-    public function getAlleKontenErlaubt()
+    public function getAlleKontenErlaubt(): bool
     {
         return false;
     }

--- a/lib/Fhp/Segment/KAZ/ParameterKontoumsaetzeV2.php
+++ b/lib/Fhp/Segment/KAZ/ParameterKontoumsaetzeV2.php
@@ -16,7 +16,7 @@ class ParameterKontoumsaetzeV2 extends ParameterKontoumsaetzeV1 implements Param
     public $alleKontenErlaubt;
 
     /** @return bool */
-    public function getAlleKontenErlaubt()
+    public function getAlleKontenErlaubt(): bool
     {
         return $this->alleKontenErlaubt;
     }

--- a/lib/Fhp/Segment/NameMapping.php
+++ b/lib/Fhp/Segment/NameMapping.php
@@ -85,7 +85,6 @@ class NameMapping
     ];
 
     /**
-     * @param string $code
      * @return string
      */
     public static function codeToName(string $code)
@@ -94,7 +93,6 @@ class NameMapping
     }
 
     /**
-     * @param string $name
      * @return string
      */
     public static function nameToCode(string $name)
@@ -104,7 +102,6 @@ class NameMapping
     }
 
     /**
-     * @param string $text
      * @return string
      */
     public static function translateResponse(string $text)

--- a/lib/Fhp/Segment/NameMapping.php
+++ b/lib/Fhp/Segment/NameMapping.php
@@ -88,7 +88,7 @@ class NameMapping
      * @param string $code
      * @return string
      */
-    public static function codeToName($code)
+    public static function codeToName(string $code)
     {
         return isset(static::$mapping[$code]) ? static::$mapping[$code] : $code;
     }
@@ -97,7 +97,7 @@ class NameMapping
      * @param string $name
      * @return string
      */
-    public static function nameToCode($name)
+    public static function nameToCode(string $name)
     {
         $flipped = array_flip(static::$mapping);
         return isset($flipped[$name]) ? $flipped[$name] : $name;
@@ -107,7 +107,7 @@ class NameMapping
      * @param string $text
      * @return string
      */
-    public static function translateResponse($text)
+    public static function translateResponse(string $text)
     {
         return str_replace(array_flip(static::$mapping), static::$mapping, $text);
     }

--- a/lib/Fhp/Segment/SPA/GetUnterstuetzteSepaDatenformateTrait.php
+++ b/lib/Fhp/Segment/SPA/GetUnterstuetzteSepaDatenformateTrait.php
@@ -9,7 +9,7 @@ namespace Fhp\Segment\SPA;
 trait GetUnterstuetzteSepaDatenformateTrait
 {
     /** @return string[] */
-    public function getUnterstuetzteSepaDatenformate()
+    public function getUnterstuetzteSepaDatenformate(): array
     {
         // Something like "sepade.pain.00x.001.0y.xsd" is allowed here, which is not a valid SEPA XML URN / Namespace
         return array_map(function ($sepaUrn) {

--- a/lib/Fhp/Segment/SPA/HISPA.php
+++ b/lib/Fhp/Segment/SPA/HISPA.php
@@ -10,5 +10,5 @@ use Fhp\Segment\Common\Ktz;
 interface HISPA
 {
     /** @return Ktz[] */
-    public function getSepaKontoverbindung();
+    public function getSepaKontoverbindung(): array;
 }

--- a/lib/Fhp/Segment/SPA/HISPAS.php
+++ b/lib/Fhp/Segment/SPA/HISPAS.php
@@ -8,5 +8,5 @@ namespace Fhp\Segment\SPA;
 interface HISPAS
 {
     /** @return ParameterSepaKontoverbindungAnfordern */
-    public function getParameter();
+    public function getParameter(): ParameterSepaKontoverbindungAnfordern;
 }

--- a/lib/Fhp/Segment/SPA/HISPASv1.php
+++ b/lib/Fhp/Segment/SPA/HISPASv1.php
@@ -16,7 +16,7 @@ class HISPASv1 extends BaseGeschaeftsvorfallparameter implements HISPAS
     public $parameter;
 
     /** {@inheritdoc} */
-    public function getParameter()
+    public function getParameter(): ParameterSepaKontoverbindungAnfordern
     {
         return $this->parameter;
     }

--- a/lib/Fhp/Segment/SPA/HISPASv2.php
+++ b/lib/Fhp/Segment/SPA/HISPASv2.php
@@ -16,7 +16,7 @@ class HISPASv2 extends BaseGeschaeftsvorfallparameter implements HISPAS
     public $parameter;
 
     /** {@inheritdoc} */
-    public function getParameter()
+    public function getParameter(): ParameterSepaKontoverbindungAnfordern
     {
         return $this->parameter;
     }

--- a/lib/Fhp/Segment/SPA/HISPAv1.php
+++ b/lib/Fhp/Segment/SPA/HISPAv1.php
@@ -17,7 +17,7 @@ class HISPAv1 extends BaseSegment implements HISPA
     public $sepaKontoverbindung;
 
     /** @return \Fhp\Segment\Common\Ktz[] */
-    public function getSepaKontoverbindung()
+    public function getSepaKontoverbindung(): array
     {
         return $this->sepaKontoverbindung ?? [];
     }

--- a/lib/Fhp/Segment/SPA/ParameterSepaKontoverbindungAnfordern.php
+++ b/lib/Fhp/Segment/SPA/ParameterSepaKontoverbindungAnfordern.php
@@ -8,5 +8,5 @@ namespace Fhp\Segment\SPA;
 interface ParameterSepaKontoverbindungAnfordern
 {
     /** @return string[] */
-    public function getUnterstuetzteSepaDatenformate();
+    public function getUnterstuetzteSepaDatenformate(): array;
 }

--- a/lib/Fhp/Segment/Segment.php
+++ b/lib/Fhp/Segment/Segment.php
@@ -7,7 +7,6 @@ use Fhp\Syntax\Parser;
 class Segment extends AbstractSegment
 {
     /**
-     * @param string $string
      * @return BaseSegment|AbstractSegment
      */
     public static function createFromString(string $string)

--- a/lib/Fhp/Segment/Segment.php
+++ b/lib/Fhp/Segment/Segment.php
@@ -10,7 +10,7 @@ class Segment extends AbstractSegment
      * @param string $string
      * @return BaseSegment|AbstractSegment
      */
-    public static function createFromString($string)
+    public static function createFromString(string $string)
     {
         return Parser::detectAndParseSegment($string);
     }

--- a/lib/Fhp/Segment/SegmentDescriptor.php
+++ b/lib/Fhp/Segment/SegmentDescriptor.php
@@ -15,7 +15,7 @@ class SegmentDescriptor extends BaseDescriptor
      * @param string $class The name of a sub-class of {@link BaseSegment}.
      * @return SegmentDescriptor The descriptor for the class.
      */
-    public static function get($class)
+    public static function get(string $class): SegmentDescriptor
     {
         if (!array_key_exists($class, static::$descriptors)) {
             static::$descriptors[$class] = new SegmentDescriptor($class);
@@ -30,7 +30,7 @@ class SegmentDescriptor extends BaseDescriptor
      * Please use the factory above.
      * @param string $class The name of a sub-class of {@link BaseSegment}.
      */
-    protected function __construct($class)
+    protected function __construct(string $class)
     {
         $this->class = $class;
         try {

--- a/lib/Fhp/Segment/SegmentInterface.php
+++ b/lib/Fhp/Segment/SegmentInterface.php
@@ -6,25 +6,15 @@ interface SegmentInterface
 {
     /**
      * Returns string representation of object.
-     *
-     * @return string
      */
     public function __toString(): string;
 
     /**
      * Gets the name of the segment.
-     *
-     * @return string
      */
     public function getName(): string;
 
-    /**
-     * @return int
-     */
     public function getVersion(): int;
 
-    /**
-     * @return int
-     */
     public function getSegmentNumber(): int;
 }

--- a/lib/Fhp/Segment/SegmentInterface.php
+++ b/lib/Fhp/Segment/SegmentInterface.php
@@ -9,22 +9,22 @@ interface SegmentInterface
      *
      * @return string
      */
-    public function __toString();
+    public function __toString(): string;
 
     /**
      * Gets the name of the segment.
      *
      * @return string
      */
-    public function getName();
+    public function getName(): string;
 
     /**
      * @return int
      */
-    public function getVersion();
+    public function getVersion(): int;
 
     /**
      * @return int
      */
-    public function getSegmentNumber();
+    public function getSegmentNumber(): int;
 }

--- a/lib/Fhp/Segment/TAB/HITAB.php
+++ b/lib/Fhp/Segment/TAB/HITAB.php
@@ -10,5 +10,5 @@ use Fhp\Segment\SegmentInterface;
 interface HITAB extends SegmentInterface
 {
     /** @return TanMediumListe[]|null */
-    public function getTanMediumListe();
+    public function getTanMediumListe(): ?array;
 }

--- a/lib/Fhp/Segment/TAB/HITABv4.php
+++ b/lib/Fhp/Segment/TAB/HITABv4.php
@@ -23,7 +23,7 @@ class HITABv4 extends BaseSegment implements HITAB
     public $tanMediumListe;
 
     /** {@inheritdoc} */
-    public function getTanMediumListe()
+    public function getTanMediumListe(): array
     {
         return $this->tanMediumListe;
     }

--- a/lib/Fhp/Segment/TAB/HITABv5.php
+++ b/lib/Fhp/Segment/TAB/HITABv5.php
@@ -23,7 +23,7 @@ class HITABv5 extends BaseSegment implements HITAB
     public $tanMediumListe;
 
     /** {@inheritdoc} */
-    public function getTanMediumListe()
+    public function getTanMediumListe(): array
     {
         return $this->tanMediumListe;
     }

--- a/lib/Fhp/Segment/TAB/TanMediumListeV4.php
+++ b/lib/Fhp/Segment/TAB/TanMediumListeV4.php
@@ -59,13 +59,13 @@ class TanMediumListeV4 extends BaseDeg implements TanMediumListe
     public $freigeschaltetAm;
 
     /** {@inheritdoc} */
-    public function getName()
+    public function getName(): string
     {
         return $this->bezeichnungDesTanMediums;
     }
 
     /** {@inheritdoc} */
-    public function getPhoneNumber()
+    public function getPhoneNumber(): ?string
     {
         return $this->mobiltelefonnummer !== null ? $this->mobiltelefonnummer : $this->mobiltelefonnummerVerschleiert;
     }

--- a/lib/Fhp/Segment/TAB/TanMediumListeV5.php
+++ b/lib/Fhp/Segment/TAB/TanMediumListeV5.php
@@ -62,13 +62,13 @@ class TanMediumListeV5 extends BaseDeg implements TanMediumListe
     public $freigeschaltetAm;
 
     /** {@inheritdoc} */
-    public function getName()
+    public function getName(): string
     {
         return $this->bezeichnungDesTanMediums;
     }
 
     /** {@inheritdoc} */
-    public function getPhoneNumber()
+    public function getPhoneNumber(): ?string
     {
         return $this->mobiltelefonnummer !== null ? $this->mobiltelefonnummer : $this->mobiltelefonnummerVerschleiert;
     }

--- a/lib/Fhp/Segment/TAN/HITANv6.php
+++ b/lib/Fhp/Segment/TAN/HITANv6.php
@@ -79,49 +79,31 @@ class HITANv6 extends BaseSegment implements TanRequest
         return $this->bezeichnungDesTanMediums;
     }
 
-    /**
-     * @return int
-     */
     public function getTanProzess(): int
     {
         return $this->tanProzess;
     }
 
-    /**
-     * @return Bin|null
-     */
     public function getAuftragsHashwert(): ?Bin
     {
         return $this->auftragsHashwert;
     }
 
-    /**
-     * @return string|null
-     */
     public function getAuftragsreferenz(): ?string
     {
         return $this->auftragsreferenz;
     }
 
-    /**
-     * @return Bin|null
-     */
     public function getChallengeHhdUc(): ?Bin
     {
         return $this->challengeHhdUc;
     }
 
-    /**
-     * @return GueltigkeitsdatumUndUhrzeitFuerChallenge|null
-     */
     public function getGueltigkeitsdatumUndUhrzeitFuerChallenge(): ?GueltigkeitsdatumUndUhrzeitFuerChallenge
     {
         return $this->gueltigkeitsdatumUndUhrzeitFuerChallenge;
     }
 
-    /**
-     * @return string|null
-     */
     public function getBezeichnungDesTanMediums(): ?string
     {
         return $this->bezeichnungDesTanMediums;

--- a/lib/Fhp/Segment/TAN/HITANv6.php
+++ b/lib/Fhp/Segment/TAN/HITANv6.php
@@ -60,21 +60,21 @@ class HITANv6 extends BaseSegment implements TanRequest
     public $bezeichnungDesTanMediums;
 
     /** {@inheritdoc} */
-    public function getProcessId()
+    public function getProcessId(): string
     {
         // Note: This is non-null because tanProzess==4.
         return $this->auftragsreferenz;
     }
 
     /** {@inheritdoc} */
-    public function getChallenge()
+    public function getChallenge(): string
     {
         // Note: This is non-null because tanProzess==4.
         return $this->challenge;
     }
 
     /** {@inheritdoc} */
-    public function getTanMediumName()
+    public function getTanMediumName(): string
     {
         return $this->bezeichnungDesTanMediums;
     }

--- a/lib/Fhp/Segment/TAN/HKTANv6.php
+++ b/lib/Fhp/Segment/TAN/HKTANv6.php
@@ -117,7 +117,7 @@ class HKTANv6 extends BaseSegment
      * @param string $segmentkennung The segment that we want to authenticate with the HKTAN instance.
      * @return HKTANv6 A HKTAN instance to signal to the server that Prozessvariante 2 shall be used.
      */
-    public static function createProzessvariante2Step1($tanMode = null, $tanMedium = null, $segmentkennung = 'HKIDN')
+    public static function createProzessvariante2Step1(?TanMode $tanMode = null, ?string $tanMedium = null, string $segmentkennung = 'HKIDN'): HKTANv6
     {
         // TODO: Implement the inclusion of the account for which an action is called, in the HKTAN Segment
         // A lot of Banks announce they need the account when in fact they work fine without it.
@@ -148,7 +148,7 @@ class HKTANv6 extends BaseSegment
      * @return HKTANv6 A HKTAN instance to signal to the server that the client supports strong authentication but wants
      *     to use weak authentication in this dialog, which only consists of the special business transaction.
      */
-    public static function createWeakAuthenticationFor($segmentkennung)
+    public static function createWeakAuthenticationFor(string $segmentkennung): HKTANv6
     {
         $result = HKTANv6::createProzessvariante2Step1();
         $result->segmentkennung = $segmentkennung;
@@ -161,7 +161,7 @@ class HKTANv6 extends BaseSegment
      * @param string $auftragsreferenz The reference number received from the server in step 1 response (HITAN).
      * @return HKTANv6 A HKTAN instance to tell the server the reference of the previously submitted order.
      */
-    public static function createProzessvariante2Step2($params, $auftragsreferenz)
+    public static function createProzessvariante2Step2(TanMode $params, string $auftragsreferenz): HKTANv6
     {
         if ($params->getAntwortHhdUcErforderlich()) {
             // TODO Implement photoTAN support.

--- a/lib/Fhp/Segment/TAN/HKTANv6.php
+++ b/lib/Fhp/Segment/TAN/HKTANv6.php
@@ -113,6 +113,8 @@ class HKTANv6 extends BaseSegment
     /**
      * @param TanMode|null $tanMode Parameters retrieved from the server during dialog initialization that describe how
      *     the TAN processes need to be parameterized.
+     * @param string|null $tanMedium The TAN medium selected by the user. Mandatory if $tanMode is present and requires
+     *     a TAN medium.
      * @param string $segmentkennung The segment that we want to authenticate with the HKTAN instance.
      * @return HKTANv6 A HKTAN instance to signal to the server that Prozessvariante 2 shall be used.
      */

--- a/lib/Fhp/Segment/TAN/HKTANv6.php
+++ b/lib/Fhp/Segment/TAN/HKTANv6.php
@@ -113,7 +113,6 @@ class HKTANv6 extends BaseSegment
     /**
      * @param TanMode|null $tanMode Parameters retrieved from the server during dialog initialization that describe how
      *     the TAN processes need to be parameterized.
-     * @param string|null $tanMedium
      * @param string $segmentkennung The segment that we want to authenticate with the HKTAN instance.
      * @return HKTANv6 A HKTAN instance to signal to the server that Prozessvariante 2 shall be used.
      */

--- a/lib/Fhp/Syntax/InvalidResponseException.php
+++ b/lib/Fhp/Syntax/InvalidResponseException.php
@@ -12,7 +12,7 @@ class InvalidResponseException extends \RuntimeException
      * @param int $code
      * @param \Exception|null $previous
      */
-    public function __construct($message, $code = 0, \Exception $previous = null)
+    public function __construct(string $message, int $code = 0, \Exception $previous = null)
     {
         parent::__construct($message, $code, $previous);
     }

--- a/lib/Fhp/Syntax/InvalidResponseException.php
+++ b/lib/Fhp/Syntax/InvalidResponseException.php
@@ -7,11 +7,6 @@ namespace Fhp\Syntax;
  */
 class InvalidResponseException extends \RuntimeException
 {
-    /**
-     * @param string $message
-     * @param int $code
-     * @param \Exception|null $previous
-     */
     public function __construct(string $message, int $code = 0, \Exception $previous = null)
     {
         parent::__construct($message, $code, $previous);

--- a/lib/Fhp/Syntax/Parser.php
+++ b/lib/Fhp/Syntax/Parser.php
@@ -45,7 +45,7 @@ abstract class Parser
      *     end of each returned substring, i.e. it's considered part of each item instead of a delimiter between items.
      * @return string[] The splitted substrings. Note that escaped characters inside will still be escaped.
      */
-    public static function splitEscapedString($delimiter, $str, $trailingDelimiter = false)
+    public static function splitEscapedString(string $delimiter, string $str, bool $trailingDelimiter = false): array
     {
         if (strlen($str) === 0) {
             return [];
@@ -111,7 +111,7 @@ abstract class Parser
      * @param string $str The raw string, usually a response from the server.
      * @return string The string with the escaping removed.
      */
-    public static function unescape($str)
+    public static function unescape(string $str): string
     {
         return preg_replace('/\?([+:\'?@])/', '$1', $str);
     }
@@ -127,7 +127,7 @@ abstract class Parser
      *     {@link ElementDescriptor#isScalarType()} returns true.
      * @return mixed|null The parsed value of type $type, null if the $rawValue was empty.
      */
-    public static function parseDataElement($rawValue, $type)
+    public static function parseDataElement(string $rawValue, string $type)
     {
         if ($rawValue === '') {
             return null;
@@ -163,7 +163,7 @@ abstract class Parser
      * @param string $rawValue The raw value (wire format), e.g. "@4@abcd".
      * @return Bin|null The parsed value, or null if $rawValue was empty.
      */
-    public static function parseBinaryBlock($rawValue)
+    public static function parseBinaryBlock(string $rawValue): ?Bin
     {
         if ($rawValue === '') {
             return null;
@@ -199,7 +199,7 @@ abstract class Parser
      * @param bool $allowEmpty If true, this returns either a valid DEG, or null if *all* the fields were empty.
      * @return BaseDeg|null The parsed value, of type $type, or null if all fields were empty and $allowEmpty is true.
      */
-    public static function parseDeg($rawElements, $type, $allowEmpty = false)
+    public static function parseDeg(string $rawElements, $type, bool $allowEmpty = false): ?BaseDeg
     {
         $rawElements = static::splitEscapedString(Delimiter::GROUP, $rawElements);
         list($result, $offset) = static::parseDegElements($rawElements, $type, $allowEmpty);
@@ -223,7 +223,7 @@ abstract class Parser
      *     2. The offset at which parsing should continue. The difference between this returned offset and the $offset
      *        that was passed in is the number of elements that this function call consumed.
      */
-    private static function parseDegElements($rawElements, $type, $allowEmpty = false, $offset = 0)
+    private static function parseDegElements(array $rawElements, $type, bool $allowEmpty = false, int $offset = 0): array
     {
         /** @var BaseDeg $result */
         $result = is_string($type) ? new $type() : $type;
@@ -305,7 +305,7 @@ abstract class Parser
      *     instance to write to (the same instance will be returned from this function).
      * @return BaseSegment The parsed segment of type $type.
      */
-    public static function parseSegment($rawSegment, $type)
+    public static function parseSegment(string $rawSegment, $type): BaseSegment
     {
         /** @var BaseSegment $result */
         $result = is_string($type) ? new $type() : $type;
@@ -355,7 +355,7 @@ abstract class Parser
      *     the end).
      * @return AnonymousSegment The segment parsed as an anonymous segment.
      */
-    public static function parseAnonymousSegment($rawSegment)
+    public static function parseAnonymousSegment(string $rawSegment): AnonymousSegment
     {
         $rawElements = static::splitIntoSegmentElements($rawSegment);
         return new AnonymousSegment(
@@ -376,7 +376,7 @@ abstract class Parser
      * @param string $rawSegment The serialized wire format for a single segment incl delimiter at the end.
      * @return string[] The segment splitted into raw elements.
      */
-    private static function splitIntoSegmentElements($rawSegment)
+    private static function splitIntoSegmentElements(string $rawSegment): array
     {
         if (substr($rawSegment, -1) !== Delimiter::SEGMENT) {
             throw new \InvalidArgumentException("Raw segment does not end with delimiter: $rawSegment");
@@ -395,7 +395,7 @@ abstract class Parser
      * @param ElementDescriptor $descriptor The descriptor that describes the expected format of the element.
      * @return mixed|null The parsed value, or null if it was empty.
      */
-    private static function parseSegmentElement($rawElement, $descriptor)
+    private static function parseSegmentElement(string $rawElement, ElementDescriptor $descriptor)
     {
         if (is_string($descriptor->type)) { // Scalar value / DE
             return static::parseDataElement($rawElement, $descriptor->type);
@@ -411,7 +411,7 @@ abstract class Parser
      *     the end). This should be ISO-8859-1-encoded.
      * @return BaseSegment The parsed segment, possibly an {@link AnonymousSegment}.
      */
-    public static function detectAndParseSegment($rawSegment)
+    public static function detectAndParseSegment(string $rawSegment): BaseSegment
     {
         if (substr($rawSegment, -1) !== Delimiter::SEGMENT) {
             throw new \InvalidArgumentException("Raw segment does not end with delimiter: $rawSegment");
@@ -447,7 +447,7 @@ abstract class Parser
      * @param string $rawSegments Concatenated segments in wire format.
      * @return BaseSegment[] The parsed segments.
      */
-    public static function parseSegments($rawSegments)
+    public static function parseSegments(string $rawSegments): array
     {
         if (strlen($rawSegments) === 0) {
             return [];
@@ -461,7 +461,7 @@ abstract class Parser
      * @param string $rawSegments
      * @return string[] RawSegments
      */
-    public static function parseRawSegments($rawSegments)
+    public static function parseRawSegments(string $rawSegments): array
     {
         if (strlen($rawSegments) === 0) {
             return [];

--- a/lib/Fhp/Syntax/Parser.php
+++ b/lib/Fhp/Syntax/Parser.php
@@ -458,7 +458,6 @@ abstract class Parser
 
     /**
      * @deprecated Could be removed, if Response::$rawSegments is removed.
-     * @param string $rawSegments
      * @return string[] RawSegments
      */
     public static function parseRawSegments(string $rawSegments): array

--- a/lib/Fhp/Syntax/Serializer.php
+++ b/lib/Fhp/Syntax/Serializer.php
@@ -28,7 +28,7 @@ abstract class Serializer
      * @param string $str The unescaped string.
      * @return string The escaped string in wire format.
      */
-    public static function escape($str)
+    public static function escape(string $str): string
     {
         return preg_replace('/([+:\'?@])/', '?$1', $str);
     }
@@ -39,7 +39,7 @@ abstract class Serializer
      *     {@link ElementDescriptor#isScalarType()} returns true.
      * @return string The HBCI wire format representation of the value.
      */
-    public static function serializeDataElement($value, $type)
+    public static function serializeDataElement($value, string $type): string
     {
         if ($value === null) {
             return '';
@@ -63,7 +63,7 @@ abstract class Serializer
      * @param DegDescriptor $descriptor The descriptor for the DEG type.
      * @return string The HBCI wire format representation of the DEG.
      */
-    public static function serializeDeg($deg, $descriptor)
+    public static function serializeDeg(?BaseDeg $deg, DegDescriptor $descriptor): string
     {
         $serializedElements = Serializer::serializeElements($deg, $descriptor);
         return implode(Delimiter::GROUP, static::flattenAndTrimEnd($serializedElements));
@@ -74,7 +74,7 @@ abstract class Serializer
      * @return string The HBCI wire format representation of the segment, in ISO-8859-1 encoding, terminated by the
      *     segment delimiter.
      */
-    public static function serializeSegment($segment)
+    public static function serializeSegment(BaseSegment $segment): string
     {
         if ($segment instanceof AnonymousSegment) {
             throw new \InvalidArgumentException('Cannot serialize anonymous segments');
@@ -91,7 +91,7 @@ abstract class Serializer
      *     position, the returned array may contain emtpy strings as gaps/buffers in the middle (for subsequent elements
      *     in $obj) and/or at the end (for subsequent elements added by the caller for data following $obj).
      */
-    private static function serializeElements($obj, $descriptor)
+    private static function serializeElements($obj, BaseDescriptor $descriptor): array
     {
         $isSegment = $descriptor instanceof SegmentDescriptor;
         $serializedElements = [];
@@ -130,7 +130,7 @@ abstract class Serializer
      * @return string|array The serialized value. In case $type is a complex type and $fullySerialize is false, this
      *     returns a (possibly nested) array of strings.
      */
-    private static function serializeElement($value, $type, $fullySerialize)
+    private static function serializeElement($value, $type, bool $fullySerialize)
     {
         if (is_string($type)) {
             return static::serializeDataElement($value, $type);
@@ -149,7 +149,7 @@ abstract class Serializer
      * @return string[] A flat array with the same string values (using in-order tree traversal), but empty values
      *     removed from the end.
      */
-    private static function flattenAndTrimEnd($elements)
+    private static function flattenAndTrimEnd(array $elements): array
     {
         $result = [];
         $nonemptyLength = 0;

--- a/lib/Fhp/UnsupportedException.php
+++ b/lib/Fhp/UnsupportedException.php
@@ -7,11 +7,6 @@ namespace Fhp;
  */
 class UnsupportedException extends \RuntimeException
 {
-    /**
-     * @param string $message
-     * @param int $code
-     * @param \Exception|null $previous
-     */
     public function __construct(string $message, int $code = 0, \Exception $previous = null)
     {
         parent::__construct($message, $code, $previous);

--- a/lib/Fhp/UnsupportedException.php
+++ b/lib/Fhp/UnsupportedException.php
@@ -12,7 +12,7 @@ class UnsupportedException extends \RuntimeException
      * @param int $code
      * @param \Exception|null $previous
      */
-    public function __construct($message, $code = 0, \Exception $previous = null)
+    public function __construct(string $message, int $code = 0, \Exception $previous = null)
     {
         parent::__construct($message, $code, $previous);
     }

--- a/lib/Tests/Fhp/FinTsPeer.php
+++ b/lib/Tests/Fhp/FinTsPeer.php
@@ -16,7 +16,8 @@ class FinTsPeer extends FinTsNew
      */
     public $mockConnection;
 
-    protected function newConnection()
+    /** {@inheritdoc} */
+    protected function newConnection(): Connection
     {
         return $this->mockConnection;
     }
@@ -25,7 +26,7 @@ class FinTsPeer extends FinTsNew
      * {@inheritdoc}
      * @throws ServerException
      */
-    public function endDialog($isAnonymous = false) // parent::endDialog() is protected
+    public function endDialog(bool $isAnonymous = false) // parent::endDialog() is protected
     {
         parent::endDialog($isAnonymous);
     }

--- a/lib/Tests/Fhp/FinTsTestCase.php
+++ b/lib/Tests/Fhp/FinTsTestCase.php
@@ -116,7 +116,7 @@ abstract class FinTsTestCase extends TestCase
      * @param string $response Can be a full response (starting with HNHBK) or just the inner part of HNVSD, more
      *     precisely the slice *between* the HNSHK and HNSHA segments.
      */
-    protected function expectMessage($request, $response)
+    protected function expectMessage(string $request, string $response)
     {
         $this->expectedMessages[] = [$request, $response];
     }

--- a/lib/Tests/Fhp/Integration/DKB/GetStatementOfAccountTest.php
+++ b/lib/Tests/Fhp/Integration/DKB/GetStatementOfAccountTest.php
@@ -49,7 +49,6 @@ class GetStatementOfAccountTest extends DKBIntegrationTestBase
     }
 
     /**
-     * @return GetStatementOfAccount
      * @throws \Throwable
      */
     private function runInitialRequest(): GetStatementOfAccount
@@ -74,7 +73,6 @@ class GetStatementOfAccountTest extends DKBIntegrationTestBase
     }
 
     /**
-     * @param GetStatementOfAccount $getStatement
      * @throws \Throwable
      */
     private function completeWithTan(GetStatementOfAccount $getStatement)
@@ -135,7 +133,6 @@ class GetStatementOfAccountTest extends DKBIntegrationTestBase
     }
 
     /**
-     * @param StatementOfAccount $statement
      * @throws \Exception
      */
     private function checkResult(StatementOfAccount $statement)

--- a/lib/Tests/Fhp/Integration/DKB/GetStatementOfAccountTest.php
+++ b/lib/Tests/Fhp/Integration/DKB/GetStatementOfAccountTest.php
@@ -138,7 +138,7 @@ class GetStatementOfAccountTest extends DKBIntegrationTestBase
      * @param StatementOfAccount $statement
      * @throws \Exception
      */
-    private function checkResult($statement)
+    private function checkResult(StatementOfAccount $statement)
     {
         $this->assertCount(2, $statement->getStatements());
 

--- a/lib/Tests/Fhp/Integration/DKB/SendSEPATransferTest.php
+++ b/lib/Tests/Fhp/Integration/DKB/SendSEPATransferTest.php
@@ -91,7 +91,6 @@ class SendSEPATransferTest extends DKBIntegrationTestBase
     }
 
     /**
-     * @return SendSEPATransfer
      * @throws \Throwable
      */
     private function runInitialRequest(): SendSEPATransfer
@@ -103,7 +102,6 @@ class SendSEPATransferTest extends DKBIntegrationTestBase
     }
 
     /**
-     * @param SendSEPATransfer $sendTransfer
      * @throws \Throwable
      */
     private function completeWithTan(SendSEPATransfer $sendTransfer)

--- a/lib/Tests/Fhp/SanitizingCLILogger.php
+++ b/lib/Tests/Fhp/SanitizingCLILogger.php
@@ -34,7 +34,7 @@ class SanitizingCLILogger extends \Psr\Log\AbstractLogger
      *     some sensitive information. This array may also contain plain strings, which are themselves interpreted as
      *     sensitive.
      */
-    public function __construct($sensitiveMaterial)
+    public function __construct(array $sensitiveMaterial)
     {
         $this->needles = static::computeNeedles($sensitiveMaterial);
     }
@@ -42,7 +42,7 @@ class SanitizingCLILogger extends \Psr\Log\AbstractLogger
     /**
      * @param array $sensitiveMaterial See the constructor.
      */
-    public function addSensitiveMaterial($sensitiveMaterial)
+    public function addSensitiveMaterial(array $sensitiveMaterial)
     {
         $this->needles = array_merge($this->needles, static::computeNeedles($sensitiveMaterial));
     }
@@ -60,7 +60,7 @@ class SanitizingCLILogger extends \Psr\Log\AbstractLogger
      *     sensitive.
      * @return string[] An array of search-replacement "needles" that should be replaced in log messages.
      */
-    public static function computeNeedles($sensitiveMaterial)
+    public static function computeNeedles(array $sensitiveMaterial): array
     {
         $needles = [];
         foreach ($sensitiveMaterial as $item) {
@@ -99,7 +99,7 @@ class SanitizingCLILogger extends \Psr\Log\AbstractLogger
      * @param string[] The sensitive values to be replaced, usually from {@link #computeNeedles()}.
      * @return string The same string, but with sensitive values removed.
      */
-    public static function sanitizeForLogging($str, $needles)
+    public static function sanitizeForLogging(string $str, $needles): string
     {
         $replacements = array_map(function ($needle) {
             $len = strlen($needle) - 1;

--- a/lib/Tests/Fhp/SanitizingCLILogger.php
+++ b/lib/Tests/Fhp/SanitizingCLILogger.php
@@ -85,7 +85,7 @@ class SanitizingCLILogger extends \Psr\Log\AbstractLogger
             }
         }
         $needles = array_filter($needles); // Filter out empty entries.
-        $escapedNeedles = array_map(function ($needle) {
+        $escapedNeedles = array_map(function (string $needle) {
             // The wire format is ISO-8859-1, so thats what will be logged and thats what needs to looked for when replacing
             return utf8_decode(Serializer::escape($needle));
         }, $needles);

--- a/lib/Tests/Fhp/Syntax/SerializerTest.php
+++ b/lib/Tests/Fhp/Syntax/SerializerTest.php
@@ -22,7 +22,6 @@ class SerializerTest extends \PHPUnit\Framework\TestCase
             ['?\'', '\''],
             ['????', '??'],
             ['', ''],
-            ['', null],
         ];
     }
 


### PR DESCRIPTION
PHP CS Fixer did the bulk for the work, plus some manual clean-up. First add type hints where possible, (semi-)automatically derived from the existing @param/@return tags. Then remove those tags (and sometimes the entire phpDoc block) if they don't provide any additional information. Manually fix some cases around inheritance and a few instances of wrong typing information.

This only fixes the cases that are covered by unit tests. I have deliberately excluded entire directories (`Dialog`, `Message`, `DataElementGroups`, ...) and a few classes (`FinTs`, `FinTsInternal`, ...) from the automatically derived type hints, because adding them at the language level makes PHP enforce them, which can lead to new runtime errors. The old classes don't have good/any unit test coverage, and they can hopefully be deleted soon anyway, so it's not worth doing this refactoring for them.

Even among the classes that are here to stay for the long term, this refactoring uncovered some wrong type annotations. This PR only fixes those that are run/discovered by the unit tests. It's possible that there are more hidden problems that users uncover after merging this. Though the resulting PHP errors should be easy to debug and fix.

See #109

@ampaze fyi

This PR has merge conflicts with many others. @nemiah Please do not merge for now, this is here only for review / hearing people's opinions. Once all the others are merged, I can do a rebase.