### PR TITLE
Bei SEPA Überweisungen auch von der Bank gemeldete XML Formate der Form sepade.pain.00x.001.0y.xsd unterstützen

### DIFF
--- a/lib/Fhp/Segment/SPA/GetUnterstuetzteSepaDatenformateTrait.php
+++ b/lib/Fhp/Segment/SPA/GetUnterstuetzteSepaDatenformateTrait.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Fhp\Segment\SPA;
+
+/**
+ * @link https://www.hbci-zka.de/dokumente/spezifikation_deutsch/fintsv3/FinTS_3.0_Messages_Geschaeftsvorfaelle_2015-08-07_final_version.pdf
+ * Section: D ("Unterstützte SEPA-Datenformate")
+ */
+trait GetUnterstuetzteSepaDatenformateTrait
+{
+    /** @return string[] */
+    public function getUnterstuetzteSepaDatenformate()
+    {
+        // Something like "sepade.pain.00x.001.0y.xsd" is allowed here, which is not a valid SEPA XML URN / Namespace
+        return array_map(function ($sepaUrn) {
+            return strtr($sepaUrn, [
+                'sepade:' => 'urn:iso:std:iso:20022:tech:',
+                '.xsd' => '',
+            ]);
+        }, $this->unterstuetzteSepaDatenformate);
+    }
+}

--- a/lib/Fhp/Segment/SPA/ParameterSepaKontoverbindungAnfordernV1.php
+++ b/lib/Fhp/Segment/SPA/ParameterSepaKontoverbindungAnfordernV1.php
@@ -12,6 +12,8 @@ use Fhp\Segment\BaseDeg;
  */
 class ParameterSepaKontoverbindungAnfordernV1 extends BaseDeg implements ParameterSepaKontoverbindungAnfordern
 {
+    use GetUnterstuetzteSepaDatenformateTrait;
+
     /** @var bool */
     public $einzelkontenabrufErlaubt;
     /** @var bool */
@@ -20,10 +22,4 @@ class ParameterSepaKontoverbindungAnfordernV1 extends BaseDeg implements Paramet
     public $strukturierterVerwendungszweckErlaubt;
     /** @var string[] @Max(99) Max length each: 256 */
     public $unterstuetzteSepaDatenformate;
-
-    /** {@inheritdoc} */
-    public function getUnterstuetzteSepaDatenformate()
-    {
-        return $this->unterstuetzteSepaDatenformate;
-    }
 }

--- a/lib/Fhp/Segment/SPA/ParameterSepaKontoverbindungAnfordernV2.php
+++ b/lib/Fhp/Segment/SPA/ParameterSepaKontoverbindungAnfordernV2.php
@@ -12,6 +12,8 @@ use Fhp\Segment\BaseDeg;
  */
 class ParameterSepaKontoverbindungAnfordernV2 extends BaseDeg implements ParameterSepaKontoverbindungAnfordern
 {
+    use GetUnterstuetzteSepaDatenformateTrait;
+
     /** @var bool */
     public $einzelkontenabrufErlaubt;
     /** @var bool */
@@ -22,10 +24,4 @@ class ParameterSepaKontoverbindungAnfordernV2 extends BaseDeg implements Paramet
     public $eingabeAnzahlEintraegeErlaubt;
     /** @var string[] @Max(99) Max length each: 256 */
     public $unterstuetzteSepaDatenformate;
-
-    /** {@inheritdoc} */
-    public function getUnterstuetzteSepaDatenformate()
-    {
-        return $this->unterstuetzteSepaDatenformate;
-    }
 }


### PR DESCRIPTION
refs #175 