### PR TITLE
Fix PHP7.3 compatibility of return type hints

### DIFF
--- a/lib/Fhp/Segment/DME/HIDMESv1.php
+++ b/lib/Fhp/Segment/DME/HIDMESv1.php
@@ -15,7 +15,7 @@ class HIDMESv1 extends BaseGeschaeftsvorfallparameter implements HIDXES
     /** @var ParameterTerminierteSEPASammellastschriftEinreichenV1 */
     public $parameter;
 
-    public function getParameter(): ParameterTerminierteSEPASammellastschriftEinreichenV1
+    public function getParameter(): SEPADirectDebitMinimalLeadTimeProvider
     {
         return $this->parameter;
     }

--- a/lib/Fhp/Segment/DME/HIDMESv2.php
+++ b/lib/Fhp/Segment/DME/HIDMESv2.php
@@ -15,7 +15,7 @@ class HIDMESv2 extends BaseGeschaeftsvorfallparameter implements HIDXES
     /** @var ParameterTerminierteSEPASammellastschriftEinreichenV2 */
     public $parameter;
 
-    public function getParameter(): ParameterTerminierteSEPASammellastschriftEinreichenV2
+    public function getParameter(): SEPADirectDebitMinimalLeadTimeProvider
     {
         return $this->parameter;
     }

--- a/lib/Fhp/Segment/DSE/HIDSESv1.php
+++ b/lib/Fhp/Segment/DSE/HIDSESv1.php
@@ -4,6 +4,7 @@ namespace Fhp\Segment\DSE;
 
 use Fhp\Segment\BaseGeschaeftsvorfallparameter;
 use Fhp\Segment\DME\HIDXES;
+use Fhp\Segment\DME\SEPADirectDebitMinimalLeadTimeProvider;
 
 /**
  * Segment: Terminierte SEPA-Einzellastschrift einreichen Parameter
@@ -16,7 +17,7 @@ class HIDSESv1 extends BaseGeschaeftsvorfallparameter implements HIDXES
     /** @var ParameterTerminierteSEPAEinzellastschriftEinreichenV1 */
     public $parameter;
 
-    public function getParameter(): ParameterTerminierteSEPAEinzellastschriftEinreichenV1
+    public function getParameter(): SEPADirectDebitMinimalLeadTimeProvider
     {
         return $this->parameter;
     }

--- a/lib/Fhp/Segment/DSE/HIDSESv2.php
+++ b/lib/Fhp/Segment/DSE/HIDSESv2.php
@@ -4,6 +4,7 @@ namespace Fhp\Segment\DSE;
 
 use Fhp\Segment\BaseGeschaeftsvorfallparameter;
 use Fhp\Segment\DME\HIDXES;
+use Fhp\Segment\DME\SEPADirectDebitMinimalLeadTimeProvider;
 
 /**
  * Segment: Terminierte SEPA-Einzellastschrift einreichen Parameter
@@ -16,7 +17,7 @@ class HIDSESv2 extends BaseGeschaeftsvorfallparameter implements HIDXES
     /** @var ParameterTerminierteSEPAEinzellastschriftEinreichenV2 */
     public $parameter;
 
-    public function getParameter(): ParameterTerminierteSEPAEinzellastschriftEinreichenV2
+    public function getParameter(): SEPADirectDebitMinimalLeadTimeProvider
     {
         return $this->parameter;
     }


### PR DESCRIPTION
This should fix current Travis failures on `master`.