### PR TITLE
Überweisungen können auch ohne TAN direkt ausgeführt werden

### DIFF
--- a/lib/Fhp/Action/SendSEPATransfer.php
+++ b/lib/Fhp/Action/SendSEPATransfer.php
@@ -71,7 +71,7 @@ class SendSEPATransfer extends BaseAction
     public function processResponse(Message $response)
     {
         parent::processResponse($response);
-        if ($response->findRueckmeldung(Rueckmeldungscode::ENTGEGENGENOMMEN) === null) {
+        if ($response->findRueckmeldung(Rueckmeldungscode::ENTGEGENGENOMMEN) === null && $response->findRueckmeldung(Rueckmeldungscode::AUSGEFUEHRT) === null) {
             throw new UnexpectedResponseException('Bank did not confirm SEPATransfer execution');
         }
     }

--- a/lib/Fhp/Segment/HIRMS/Rueckmeldungscode.php
+++ b/lib/Fhp/Segment/HIRMS/Rueckmeldungscode.php
@@ -47,6 +47,11 @@ abstract class Rueckmeldungscode
     const ENTGEGENGENOMMEN = 10;
 
     /**
+     * Der Auftrag wurde ausgeführt.
+     */
+    const AUSGEFUEHRT = 20;
+
+    /**
      * Bestätigung der Dialogbeendigung des Benutzers oder des Kreditinstituts.
      */
     const BEENDET = 100;


### PR DESCRIPTION
@Philipp91 Warum gibt es bei SendSEPATransfer diese extra Prüfung überhaupt? Es würde doch bei einem Fehler eh eine ServerException geben. Und bei keinem Fehler eben nicht.