### PR TITLE
(urgent) Fix TAN mechanism array vs. integer (this fixes TAN based statement fetch)

### DIFF
--- a/lib/Fhp/FinTs.php
+++ b/lib/Fhp/FinTs.php
@@ -267,7 +267,7 @@ class FinTs extends FinTsInternal
         $dialog = $this->getDialog();
 
         $message = $this->createStateOfAccountMessage($dialog, $account, $from, $to, null);
-        $response = $dialog->sendMessage($message, $this->getUsedPinTanMechanism($dialog), $tanCallback, $interval);
+        $response = $dialog->sendMessage($message, $this->getUsedPinTanMechanisms($dialog)[0], $tanCallback, $interval);
         //echo get_class($response);
         if ($response->isTANRequest()) {
             return $response;
@@ -284,7 +284,7 @@ class FinTs extends FinTsInternal
         $this->dialog = $dialog;
 
         if ($tan) {
-            $response = $dialog->submitTAN($response, $this->getUsedPinTanMechanism($dialog), $tan);
+            $response = $dialog->submitTAN($response, $this->getUsedPinTanMechanisms($dialog)[0], $tan);
         }
 
         $message = $this->createStateOfAccountMessage($dialog, $account, $from, $to, null);

--- a/lib/Fhp/FinTsInternal.php
+++ b/lib/Fhp/FinTsInternal.php
@@ -165,7 +165,7 @@ abstract class FinTsInternal
         return str_replace("\n", '', trim($dom->saveXml()));
     }
 
-    protected function getUsedPinTanMechanism($dialog)
+    protected function getUsedPinTanMechanisms($dialog)
     {
         $mechs = array_keys($dialog->getSupportedPinTanMechanisms());
         if ($this->tanMechanism !== null && in_array($this->tanMechanism, $mechs)) {


### PR DESCRIPTION
This patch fixes the broken TAN based statement fetch for transactions that are older than 4 weeks.

The library function "getUsedPinTanMechanism" returns an array but result is handled as integer; I renamed it to "getUsedPinTanMechanisms" and let users of this function extract the first element.