### PR TITLE
Split SanitizingCLILogger, enforce its use and remove from FinTsOptions

### DIFF
--- a/DEVELOPER-GUIDE.md
+++ b/DEVELOPER-GUIDE.md
@@ -184,12 +184,12 @@ To minify the impact on these accounts (undesired transactions, account locks du
 integration testing (against fake backends) has proven very useful (in addition to the usual regression-catching
 benefits of those tests).
 
-The `SanitizingCLILogger` class can be used to record requests/responses during a (manually scripted) dialog with the
-bank.
+The `CLILogger` class can be used to record requests/responses during a (manually scripted) dialog with the bank.
 The recorded messages can then be filled into a `PhpUnit` test.
-While the logger already replaces the most important sensitive values (username, PIN, ...), the recorded segments
-regularly still contain personal information (e.g. IBANs and names of other parties involved in transactions,
-descriptions of transactions, etc.).
+When used through `FinTsNew::setLogger()`, the logger already replaces the most important sensitive values
+(username, PIN, ...) with placeholders.
+But the recorded segments regularly still contain personal information (e.g. IBANs and names of other parties involved
+in transactions, descriptions of transactions, etc.).
 In order to remove this information, it is advisable not to change the overall length (i.e. using the `Ins` mode in the
 code editor to overwrite it with some dummy data), because the wire format hard-codes the length of subsequent data in
 various places and simply removing it would result in parsing failures.

--- a/SamplesNew/login.php
+++ b/SamplesNew/login.php
@@ -18,7 +18,7 @@ $options->productName = ''; // The number you receive after registration / FinTS
 $options->productVersion = '1.0'; // Your own Software product version
 $credentials = \Fhp\Credentials::create('username', 'pin'); // This is NOT the PIN of your bank card!
 $fints = new \Fhp\FinTsNew($options, $credentials);
-$fints->setLogger(new \Tests\Fhp\SanitizingCLILogger([$options, $credentials]));
+$fints->setLogger(new \Tests\Fhp\CLILogger());
 
 /**
  * This function is key to how FinTS works in times of PSD2 regulations. Most actions like wire transfers, getting
@@ -61,7 +61,7 @@ function handleTan(\Fhp\BaseAction $action)
         // This example code stores them in a text file, but you might write them to your database (use a BLOB, not a
         // CHAR/TEXT field to allow for arbitrary encoding) or in some other storage (possibly base64-encoded to make it
         // ASCII).
-        file_put_contents(__DIR__ . 'state.txt', serialize([$fints->persist(), serialize($action)]));
+        file_put_contents(__DIR__ . 'state.txt', serialize([$persistedFints, $persistedAction]));
     }
 
     echo "Please enter the TAN:\n";

--- a/SamplesNew/login.php
+++ b/SamplesNew/login.php
@@ -17,8 +17,8 @@ $options->bankCode = ''; // Your bank code / Bankleitzahl
 $options->productName = ''; // The number you receive after registration / FinTS-Registrierungsnummer
 $options->productVersion = '1.0'; // Your own Software product version
 $credentials = \Fhp\Credentials::create('username', 'pin'); // This is NOT the PIN of your bank card!
-$options->logger = new \Tests\Fhp\SanitizingCLILogger([$options, $credentials]);
 $fints = new \Fhp\FinTsNew($options, $credentials);
+$fints->setLogger(new \Tests\Fhp\SanitizingCLILogger([$options, $credentials]));
 
 /**
  * This function is key to how FinTS works in times of PSD2 regulations. Most actions like wire transfers, getting

--- a/lib/Fhp/FinTsNew.php
+++ b/lib/Fhp/FinTsNew.php
@@ -4,6 +4,7 @@ namespace Fhp;
 
 use Fhp\Model\TanMedium;
 use Fhp\Model\TanMode;
+use Fhp\Options\SanitizingLogger;
 use Fhp\Protocol\BPD;
 use Fhp\Protocol\DialogInitialization;
 use Fhp\Protocol\GetTanMedia;
@@ -37,7 +38,7 @@ class FinTsNew
     private $options;
     /** @var Credentials */
     private $credentials;
-    /** @var LoggerInterface */
+    /** @var SanitizingLogger */
     private $logger;
 
     // The TAN mode and medium to be used for business transactions that require a TAN.
@@ -170,11 +171,24 @@ class FinTsNew
     }
 
     /**
-     * @param LoggerInterface $logger
+     * @return SanitizingLogger
+     */
+    public function getLogger(): SanitizingLogger
+    {
+        return $this->logger;
+    }
+
+    /**
+     * @param LoggerInterface $logger The logger to use going forward. Note that it will be wrapped in a
+     *     {@link SanitizingLogger} to protect sensitive information like usernames and PINs.
      */
     public function setLogger(LoggerInterface $logger): void
     {
-        $this->logger = $logger;
+        if ($logger instanceof SanitizingLogger) {
+            $this->logger = $logger;
+        } else {
+            $this->logger = new SanitizingLogger($logger, [$this->options, $this->credentials]);
+        }
     }
 
     /**

--- a/lib/Fhp/FinTsNew.php
+++ b/lib/Fhp/FinTsNew.php
@@ -24,6 +24,7 @@ use Fhp\Segment\TAN\VerfahrensparameterZweiSchrittVerfahrenV6;
 use Fhp\Syntax\InvalidResponseException;
 use Fhp\Syntax\Serializer;
 use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 
 /**
  * This is the main class of this library. Please see the Samples directory for how to use it.
@@ -73,8 +74,8 @@ class FinTsNew
      */
     public function __construct(FinTsOptions $options, Credentials $credentials, ?string $persistedInstance = null)
     {
+        $this->logger = new NullLogger();
         $options->validate();
-        $this->logger = $options->logger;
         $this->options = $options;
         $this->credentials = $credentials;
 
@@ -166,6 +167,14 @@ class FinTsNew
             $this->dialogId,
             $this->messageNumber
             ) = $data;
+    }
+
+    /**
+     * @param LoggerInterface $logger
+     */
+    public function setLogger(LoggerInterface $logger): void
+    {
+        $this->logger = $logger;
     }
 
     /**

--- a/lib/Fhp/FinTsOptions.php
+++ b/lib/Fhp/FinTsOptions.php
@@ -2,9 +2,6 @@
 
 namespace Fhp;
 
-use Psr\Log\LoggerInterface;
-use Psr\Log\NullLogger;
-
 /**
  * Holds options for FinTS connections and operations. These options are independent of the user and depend only on the
  * bank system and the client system that uses this library.
@@ -46,9 +43,6 @@ class FinTsOptions
     /** @var int */
     public $timeoutResponse = 30;
 
-    /** @var LoggerInterface */
-    public $logger;
-
     /**
      * @throws \InvalidArgumentException If the options are invalid.
      */
@@ -69,9 +63,6 @@ class FinTsOptions
         }
         if (strlen($this->url) === 0) {
             throw new \InvalidArgumentException('Server URL required!');
-        }
-        if ($this->logger === null) {
-            $this->logger = new NullLogger();
         }
     }
 }

--- a/lib/Tests/Fhp/CLILogger.php
+++ b/lib/Tests/Fhp/CLILogger.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Tests\Fhp;
+
+/**
+ * A logger that prints log messages to the console (just PHP `echo`). This class is designed to be used only for
+ * testing purposes.
+ */
+class CLILogger extends \Psr\Log\AbstractLogger
+{
+    public function log($level, $message, array $context = []): void
+    {
+        $message .= count($context) === 0 ? '' : ' ' . implode(', ', $context);
+        echo "$level: $message\n";
+    }
+}

--- a/lib/Tests/Fhp/Options/SanitizingLoggerTest.php
+++ b/lib/Tests/Fhp/Options/SanitizingLoggerTest.php
@@ -1,20 +1,21 @@
 <?php
 
-namespace Tests\Fhp;
+namespace Tests\Fhp\Options;
 
 use Fhp\Credentials;
 use Fhp\FinTsOptions;
+use Fhp\Options\SanitizingLogger;
 
-class SanitizingCLILoggerTest extends \PHPUnit\Framework\TestCase
+class SanitizingLoggerTest extends \PHPUnit\Framework\TestCase
 {
     public function test_sanitize()
     {
         $credentials = Credentials::create('USER123', 'pw+?123');
         $options = new FinTsOptions();
         $options->productName = 'ABCDEFGHIJKLMNOPQRS';
-        $needles = SanitizingCLILogger::computeNeedles([$credentials, $options, 'RAWNEEDLE']);
+        $needles = SanitizingLogger::computeNeedles([$credentials, $options, 'RAWNEEDLE']);
         $sanitize = function ($str) use ($needles) {
-            $result = SanitizingCLILogger::sanitizeForLogging($str, $needles);
+            $result = SanitizingLogger::sanitizeForLogging($str, $needles);
             $this->assertEquals(strlen($str), strlen($result));
             return $result;
         };

--- a/lib/Tests/Fhp/SanitizingCLILogger.php
+++ b/lib/Tests/Fhp/SanitizingCLILogger.php
@@ -18,11 +18,11 @@ use Fhp\Syntax\Serializer;
  * $options = new \Fhp\FinTsOptions();
  * $options->productName = 'YourProductRegistrationID';
  * $options->productVersion = '1.0';
- * $options->logger = new \Fhp\SanitizingCLILogger([$options, $credentials]);
+ * $logger = new \Fhp\SanitizingCLILogger([$options, $credentials]);
  * ...
  * $sepaAccount = new SEPAAccount();
  * $sepaAccount->setIban('DE45SENSITIVEIBAN');
- * $options->logger->addSensitiveMaterial([$sepaAccount])
+ * $logger->addSensitiveMaterial([$sepaAccount])
  */
 class SanitizingCLILogger extends \Psr\Log\AbstractLogger
 {

--- a/lib/Tests/Fhp/SanitizingCLILogger.php
+++ b/lib/Tests/Fhp/SanitizingCLILogger.php
@@ -70,7 +70,6 @@ class SanitizingCLILogger extends \Psr\Log\AbstractLogger
                 $needles[] = $item->benutzerkennung;
                 $needles[] = $item->pin;
             } elseif ($item instanceof FinTsOptions) {
-                $needles[] = $item->bankCode;
                 $needles[] = $item->productName;
             } elseif ($item instanceof Account) {
                 $needles[] = $item->getIban();


### PR DESCRIPTION
See the commit messages for more details. `FinTsNew::setLogger()` is the new way to set the logger.

This is a duplicate of #221, which appears to have gone lost in the "unfork" operation by GitHub.