### PR TITLE
Fix csfixer check

### DIFF
--- a/csfixer-check.sh
+++ b/csfixer-check.sh
@@ -8,4 +8,4 @@ IFS='
 '
 CHANGED_FILES=$(git diff --name-only --diff-filter=ACMRTUXB "${COMMIT_RANGE}")
 if ! echo "${CHANGED_FILES}" | grep -qE "^(\\.php_cs(\\.dist)?|composer\\.lock)$"; then EXTRA_ARGS=$(printf -- '--path-mode=intersection\n--\n%s' "${CHANGED_FILES}"); else EXTRA_ARGS=''; fi
-vendor/bin/php-cs-fixer fix --config=.php_cs -v --dry-run --stop-on-violation --using-cache=no ${EXTRA_ARGS}
+vendor/bin/php-cs-fixer fix --config=.php_cs -v --dry-run --stop-on-violation --using-cache=no ${EXTRA_ARGS} || (echo "php-cs-fixer failed" && exit 1)

--- a/csfixer-check.sh
+++ b/csfixer-check.sh
@@ -15,5 +15,17 @@ fi
 IFS='
 '
 CHANGED_FILES=$(git diff --name-only --diff-filter=ACMRTUXB "$TRAVIS_COMMIT_RANGE")
+if [ "$?" -ne "0" ]
+then
+  echo "Error: git diff response code > 0, aborting"
+  exit 1
+fi
+
+if [ -z ${CHANGED_FILES} ]
+then
+  echo "0 changed files found, exiting"
+  exit 0
+fi
+
 if ! echo "${CHANGED_FILES}" | grep -qE "^(\\.php_cs(\\.dist)?|composer\\.lock)$"; then EXTRA_ARGS=$(printf -- '--path-mode=intersection\n--\n%s' "${CHANGED_FILES}"); else EXTRA_ARGS=''; fi
 vendor/bin/php-cs-fixer fix --config=.php_cs -v --dry-run --stop-on-violation --using-cache=no ${EXTRA_ARGS} || (echo "php-cs-fixer failed" && exit 1)

--- a/csfixer-check.sh
+++ b/csfixer-check.sh
@@ -4,8 +4,16 @@
 # PHP CS Fixer warnings.
 # From: https://github.com/FriendsOfPHP/PHP-CS-Fixer#using-php-cs-fixer-on-ci
 
+if [ -z "$TRAVIS_COMMIT_RANGE" ]
+then
+# TRAVIS_COMMIT_RANGE "is empty for builds triggered by the initial commit of a new branch"
+# From: https://docs.travis-ci.com/user/environment-variables/
+  echo "Variable TRAVIS_COMMIT_RANGE not set, falling back to full git diff"
+  TRAVIS_COMMIT_RANGE=.
+fi
+
 IFS='
 '
-CHANGED_FILES=$(git diff --name-only --diff-filter=ACMRTUXB "${COMMIT_RANGE}")
+CHANGED_FILES=$(git diff --name-only --diff-filter=ACMRTUXB "$TRAVIS_COMMIT_RANGE")
 if ! echo "${CHANGED_FILES}" | grep -qE "^(\\.php_cs(\\.dist)?|composer\\.lock)$"; then EXTRA_ARGS=$(printf -- '--path-mode=intersection\n--\n%s' "${CHANGED_FILES}"); else EXTRA_ARGS=''; fi
 vendor/bin/php-cs-fixer fix --config=.php_cs -v --dry-run --stop-on-violation --using-cache=no ${EXTRA_ARGS} || (echo "php-cs-fixer failed" && exit 1)

--- a/csfixer-check.sh
+++ b/csfixer-check.sh
@@ -21,7 +21,7 @@ then
   exit 1
 fi
 
-if [ -z ${CHANGED_FILES} ]
+if [ -z "${CHANGED_FILES}" ]
 then
   echo "0 changed files found, exiting"
   exit 0


### PR DESCRIPTION
#227 has shown, that Travis does not fully execute the script "csfixer-check.sh"
In a consequence the coding styles are not validated.

Travis job protocol to #227:
https://travis-ci.com/nemiah/phpFinTS/jobs/280889151

Error message:
````
fatal: ambiguous argument '': unknown revision or path not in the working tree.
````

Cause:
Travis does not set $COMMIT_RANGE and "" is not accepted by git diff, but an empty string without double quote is.

Problem:
The script does not return an error code > 0 in this case, so the Travis result keeps untouched (valid).

This PR includes several improvements:
- Check result of "vendor/bin/php-cs-fixer", output an error message and exit with error code 1, if an error occurs
- Use of Travis environment variable "$TRAVIS_COMMIT_RANGE" including workaround, if this variable is not set
- Several validations of "git diff" result

