### PR TITLE
#198 Serialize action parameters in GetStatementOfAccount

### DIFF
--- a/lib/Fhp/Action/GetStatementOfAccount.php
+++ b/lib/Fhp/Action/GetStatementOfAccount.php
@@ -80,12 +80,20 @@ class GetStatementOfAccount extends BaseAction
 
     public function serialize(): string
     {
-        return serialize([parent::serialize(), $this->bankName]);
+        return serialize([
+            parent::serialize(),
+            $this->account, $this->from, $this->to, $this->allAccounts,
+            $this->bankName,
+        ]);
     }
 
     public function unserialize($serialized)
     {
-        list($parentSerialized, $this->bankName) = unserialize($serialized);
+        list(
+            $parentSerialized,
+            $this->account, $this->from, $this->to, $this->allAccounts,
+            $this->bankName
+            ) = unserialize($serialized);
         parent::unserialize($parentSerialized);
     }
 

--- a/lib/Fhp/Action/GetStatementOfAccountXML.php
+++ b/lib/Fhp/Action/GetStatementOfAccountXML.php
@@ -67,6 +67,23 @@ class GetStatementOfAccountXML extends BaseAction
         return $result;
     }
 
+    public function serialize(): string
+    {
+        return serialize([
+            parent::serialize(),
+            $this->account, $this->camtURN, $this->from, $this->to, $this->allAccounts,
+        ]);
+    }
+
+    public function unserialize($serialized)
+    {
+        list(
+            $parentSerialized,
+            $this->account, $this->camtURN, $this->from, $this->to, $this->allAccounts
+            ) = unserialize($serialized);
+        parent::unserialize($parentSerialized);
+    }
+
     /**
      * @return string[] The XML-Document(s) received from the bank, or empty array if the statement is unavailable/empty.
      * @throws \Exception See {@link #ensureSuccess()}.


### PR DESCRIPTION
Fixes #198 

They are needed for subsequent requests in case of paginated responses.