### PR TITLE
Populate HKTAN.segmentkennung with the business transaction's segment name

### DIFF
--- a/lib/Fhp/FinTsNew.php
+++ b/lib/Fhp/FinTsNew.php
@@ -283,8 +283,10 @@ class FinTsNew
 
         // Construct the full request message.
         $message = MessageBuilder::create()->add($requestSegments); // This fills in the segment numbers.
-        if ($this->bpd->tanRequiredForRequest($requestSegments)) {
-            $message->add(HKTANv6::createProzessvariante2Step1($this->requireTanMode(), $this->selectedTanMedium));
+        $needTanForSegment = $this->bpd->tanRequiredForRequest($requestSegments);
+        if ($needTanForSegment !== null) {
+            $message->add(HKTANv6::createProzessvariante2Step1(
+                $this->requireTanMode(), $this->selectedTanMedium, $needTanForSegment));
         }
         $request = $this->buildMessage($message, $this->getSelectedTanMode());
         $action->setRequestSegmentNumbers(array_map(function ($segment) {

--- a/lib/Fhp/FinTsNew.php
+++ b/lib/Fhp/FinTsNew.php
@@ -198,9 +198,6 @@ class FinTsNew
             ) = $data;
     }
 
-    /**
-     * @return SanitizingLogger
-     */
     public function getLogger(): SanitizingLogger
     {
         return $this->logger;

--- a/lib/Fhp/Protocol/BPD.php
+++ b/lib/Fhp/Protocol/BPD.php
@@ -125,16 +125,17 @@ class BPD
 
     /**
      * @param SegmentInterface[] $requestSegments The segments that shall be sent to the bank.
-     * @return bool True if any of the given segments requires a TAN according to HIPINS.
+     * @return string|null Identifier of the (first) segment that requires a TAN according to HIPINS, or null if none of
+     *     the segments require a TAN.
      */
-    public function tanRequiredForRequest(array $requestSegments): bool
+    public function tanRequiredForRequest(array $requestSegments): ?string
     {
         foreach ($requestSegments as $segment) {
             if ($this->tanRequired[$segment->getName()] ?? false) {
-                return true;
+                return $segment->getName();
             }
         }
-        return false;
+        return null;
     }
 
     /**

--- a/lib/Tests/Fhp/Integration/Consors/GetStatementOfAccountTest.php
+++ b/lib/Tests/Fhp/Integration/Consors/GetStatementOfAccountTest.php
@@ -7,7 +7,7 @@ use Fhp\Model\StatementOfAccount\Statement;
 class GetStatementOfAccountTest extends ConsorsIntegrationTestBase
 {
     // Statement request (HKKAZ).
-    const GET_STATEMENT_REQUEST = "HKKAZ:3:7+DExxABCDEFGH1234567890:CSDBDE71XXX:1234567890::280:50220500+N+20190601+20190922'HKTAN:4:6+4+HKIDN'";
+    const GET_STATEMENT_REQUEST = "HKKAZ:3:7+DExxABCDEFGH1234567890:CSDBDE71XXX:1234567890::280:50220500+N+20190601+20190922'HKTAN:4:6+4+HKKAZ'";
 
     // Note: Consorsbank weirdly returns November statements even when only up to September was requested.
     const GET_STATEMENT_RESPONSE = "HIRMG:2:2:+3060::Teilweise liegen Warnungen/Hinweise vor.'HIRMS:3:2:3+0020::Der Auftrag wurde ausgefuhrt.+3076::Keine starke Authentifizierung erforderlich.+3997::Der Auftrag wurde nur teilweise ausgefuhrt.'"

--- a/lib/Tests/Fhp/Integration/DKB/SendSEPATransferTest.php
+++ b/lib/Tests/Fhp/Integration/DKB/SendSEPATransferTest.php
@@ -86,7 +86,7 @@ class SendSEPATransferTest extends DKBIntegrationTestBase
         // may be changed by linters and other tools, and because it contains line breaks, which are different depending
         // the platform where this test runs.
         return 'HKCCS:3:1+DExxABCDEFGH1234567890:BYLADEM1001:1234567890::280:12030000+urn?:iso?:std?:iso?:20022?:tech?:xsd?:pain.001.003.03+@'
-            . strlen(self::PAIN_MESSAGE) . '@' . self::PAIN_MESSAGE . "'HKTAN:4:6+4+HKIDN+++++++++SomePhone1'";
+            . strlen(self::PAIN_MESSAGE) . '@' . self::PAIN_MESSAGE . "'HKTAN:4:6+4+HKCCS+++++++++SomePhone1'";
     }
 
     /**


### PR DESCRIPTION
The field is supposed to contain the segment identifier of the segment for which the authentication is needed. The specification requires setting it upon login for special PIN/TAN use cases, requires setting it to HKIDN for regular logins, but does not specify anything for regular requests.

Now Consorsbank starts requiring it to be set to HKKAZ for such requests, and possibly similarly for others. This commit changes the behavior accordingly. HKKAZ also still works for DKB.