### PR TITLE
Remove support for @Index annotations in field descriptors

### DIFF
--- a/lib/Fhp/Segment/BaseDescriptor.php
+++ b/lib/Fhp/Segment/BaseDescriptor.php
@@ -44,18 +44,7 @@ abstract class BaseDescriptor
                 continue; // Skip @Ignore-d propeties.
             }
 
-            $index = static::getIntAnnotation('Index', $docComment);
-            if ($index === null) {
-                if ($implicitIndex) {
-                    $index = $nextIndex;
-                } else {
-                    throw new \InvalidArgumentException("Property $property needs an explicit @Index");
-                }
-            } else {
-                // After one field was marked with an @Index, all subsequent fields need an explicit index too.
-                $implicitIndex = false;
-            }
-
+            $index = $nextIndex;
             $descriptor = new ElementDescriptor();
             $descriptor->field = $property->getName();
             $type = static::getVarAnnotation($docComment);
@@ -125,7 +114,7 @@ abstract class BaseDescriptor
 
     /**
      * Looks for the annotation with the given name and extracts the content of the parentheses behind it. For instance,
-     * when called with the name "Index" and a docComment that contains {@}Index(15), this would return "15".
+     * when called with the name "Max" and a docComment that contains {@}Max(15), this would return "15".
      * @param string $name The name of the annotation.
      * @param string $docComment The documentation string of a PHP field.
      * @return string|null The content of the annotation, or null if absent.


### PR DESCRIPTION
It was originally added for two reasons, both of which are not applicable anymore: Firstly, it seemed useful to skip some unnecessary fields in the specification and to be able to continue at a later field by specifying its absolute index. But in practice, it is much easier to just copy over all fields from the specification than to fiddle with index magic and off-by-one errors. Secondly, it seemed necessary to declare the indices of fields behind a repeated field, e.g. a repeated field of length 100 occupies indices 0 through 99 and must thus be followed by index 100. But this use case is now supported implicitly as long as the repeated field specifies the @Max annotation, which is now mandatory.