### PR TITLE
Move StatementOfAccount creation function to the class itself

### DIFF
--- a/lib/Fhp/Action/GetStatementOfAccount.php
+++ b/lib/Fhp/Action/GetStatementOfAccount.php
@@ -124,9 +124,7 @@ class GetStatementOfAccount extends BaseAction
      */
     public function getStatement()
     {
-        if (is_null($this->statement)) {
-            $this->statement = StatementOfAccount::fromMT940Array($this->getParsedMT940());
-        }
+        $this->ensureSuccess();
         return $this->statement;
     }
 

--- a/lib/Fhp/Action/GetStatementOfAccount.php
+++ b/lib/Fhp/Action/GetStatementOfAccount.php
@@ -100,6 +100,7 @@ class GetStatementOfAccount extends BaseAction
     /**
      * @return string The raw MT940 data received from the server.
      * @throws \Exception See {@link #ensureSuccess()}.
+     * @noinspection PhpUnused
      */
     public function getRawMT940(): string
     {
@@ -124,7 +125,7 @@ class GetStatementOfAccount extends BaseAction
     public function getStatement()
     {
         if (is_null($this->statement)) {
-            $this->statement = \Fhp\Response\GetStatementOfAccount::createModelFromArray($this->getParsedMT940());
+            $this->statement = StatementOfAccount::fromMT940Array($this->getParsedMT940());
         }
         return $this->statement;
     }
@@ -194,7 +195,7 @@ class GetStatementOfAccount extends BaseAction
             $rawMT940 = mb_detect_encoding($this->rawMT940, 'UTF-8', true) === false
                 ? utf8_encode($this->rawMT940) : $this->rawMT940;
             $this->parsedMT940 = $parser->parse($rawMT940);
-            $this->statement = \Fhp\Response\GetStatementOfAccount::createModelFromArray($this->parsedMT940);
+            $this->statement = StatementOfAccount::fromMT940Array($this->parsedMT940);
         } catch (MT940Exception $e) {
             throw new \InvalidArgumentException('Invalid MT940 data', 0, $e);
         }

--- a/lib/Fhp/FinTs.php
+++ b/lib/Fhp/FinTs.php
@@ -13,6 +13,7 @@ use Fhp\Message\Message;
 use Fhp\Model\Account;
 use Fhp\Model\SEPAAccount;
 use Fhp\Model\SEPAStandingOrder;
+use Fhp\Model\StatementOfAccount\StatementOfAccount;
 use Fhp\MT940\Dialect\PostbankMT940;
 use Fhp\MT940\Dialect\SpardaMT940;
 use Fhp\MT940\MT940;
@@ -334,7 +335,7 @@ class FinTs extends FinTsInternal
                 break;
         }
 
-        return GetStatementOfAccount::createModelFromArray($parser->parse($rawMt940));
+        return StatementOfAccount::fromMT940Array($parser->parse($rawMt940));
     }
 
     /**

--- a/lib/Fhp/Model/Account.php
+++ b/lib/Fhp/Model/Account.php
@@ -1,4 +1,4 @@
-<?php
+<?php /** @noinspection PhpUnused */
 
 namespace Fhp\Model;
 

--- a/lib/Fhp/Model/StatementOfAccount/Statement.php
+++ b/lib/Fhp/Model/StatementOfAccount/Statement.php
@@ -37,20 +37,6 @@ class Statement
         return $this->transactions;
     }
 
-    /**
-     * Set transactions
-     *
-     * @param array $transactions
-     *
-     * @return $this
-     */
-    public function setTransactions(array $transactions = null)
-    {
-        $this->transactions = $transactions;
-
-        return $this;
-    }
-
     public function addTransaction(Transaction $transaction)
     {
         $this->transactions[] = $transaction;

--- a/lib/Fhp/Model/StatementOfAccount/StatementOfAccount.php
+++ b/lib/Fhp/Model/StatementOfAccount/StatementOfAccount.php
@@ -19,25 +19,6 @@ class StatementOfAccount
         return $this->statements;
     }
 
-    /**
-     * Set statements
-     *
-     * @param array $statements
-     *
-     * @return $this
-     */
-    public function setStatements(array $statements = null)
-    {
-        $this->statements = null == $statements ? [] : $statements;
-
-        return $this;
-    }
-
-    public function isTANRequest()
-    {
-        return false;
-    }
-
     public function addStatement(Statement $statement)
     {
         $this->statements[] = $statement;
@@ -51,7 +32,11 @@ class StatementOfAccount
     public function getStatementForDate($date): ?Statement
     {
         if (is_string($date)) {
-            $date = new \DateTime($date);
+            try {
+                $date = new \DateTime($date);
+            } catch (\Exception $e) {
+                throw new \InvalidArgumentException("Invalid date: $date", 0, $e);
+            }
         }
 
         foreach ($this->statements as $stmt) {
@@ -70,10 +55,6 @@ class StatementOfAccount
      */
     public function hasStatementForDate($date): bool
     {
-        if (is_string($date)) {
-            $date = new \DateTime($date);
-        }
-
         return null !== $this->getStatementForDate($date);
     }
 }

--- a/lib/Fhp/Model/StatementOfAccount/StatementOfAccount.php
+++ b/lib/Fhp/Model/StatementOfAccount/StatementOfAccount.php
@@ -2,6 +2,8 @@
 
 namespace Fhp\Model\StatementOfAccount;
 
+use Fhp\MT940\MT940;
+
 class StatementOfAccount
 {
     /**
@@ -19,11 +21,6 @@ class StatementOfAccount
         return $this->statements;
     }
 
-    public function addStatement(Statement $statement)
-    {
-        $this->statements[] = $statement;
-    }
-
     /**
      * Gets statement for given date.
      *
@@ -32,11 +29,7 @@ class StatementOfAccount
     public function getStatementForDate($date): ?Statement
     {
         if (is_string($date)) {
-            try {
-                $date = new \DateTime($date);
-            } catch (\Exception $e) {
-                throw new \InvalidArgumentException("Invalid date: $date", 0, $e);
-            }
+            $date = static::parseDate($date);
         }
 
         foreach ($this->statements as $stmt) {
@@ -56,5 +49,69 @@ class StatementOfAccount
     public function hasStatementForDate($date): bool
     {
         return null !== $this->getStatementForDate($date);
+    }
+
+    private static function parseDate(string $date): \DateTime
+    {
+        try {
+            return new \DateTime($date);
+        } catch (\Exception $e) {
+            throw new \InvalidArgumentException("Invalid date: $date", 0, $e);
+        }
+    }
+
+    /**
+     * @param array $array A parsed MT940 dataset, as returned from {@link MT940::parse()}.
+     * @return StatementOfAccount A new instance that contains the given data.
+     */
+    public static function fromMT940Array(array $array): StatementOfAccount
+    {
+        $result = new StatementOfAccount();
+        foreach ($array as $date => $statement) {
+            if ($result->hasStatementForDate($date)) {
+                $statementModel = $result->getStatementForDate($date);
+            } else {
+                $statementModel = new Statement();
+                $statementModel->setDate(static::parseDate($date));
+                $statementModel->setStartBalance((float) $statement['start_balance']['amount']);
+                $statementModel->setCreditDebit($statement['start_balance']['credit_debit']);
+                $result->statements[] = $statementModel;
+            }
+
+            if (isset($statement['transactions'])) {
+                foreach ($statement['transactions'] as $trx) {
+                    $replaceIn = [
+                        'booking_text',
+                        'description_1',
+                        'description_2',
+                        'description',
+                        'name',
+                    ];
+                    foreach ($replaceIn as $k) {
+                        if (isset($trx['description'][$k])) {
+                            $trx['description'][$k] = str_replace('@@', '', $trx['description'][$k]);
+                        }
+                    }
+
+                    $transaction = new Transaction();
+                    $transaction->setBookingDate(static::parseDate($trx['booking_date']));
+                    $transaction->setValutaDate(static::parseDate($trx['valuta_date']));
+                    $transaction->setCreditDebit($trx['credit_debit']);
+                    $transaction->setAmount($trx['amount']);
+                    $transaction->setBookingCode($trx['description']['booking_code']);
+                    $transaction->setBookingText($trx['description']['booking_text']);
+                    $transaction->setDescription1($trx['description']['description_1']);
+                    $transaction->setDescription2($trx['description']['description_2']);
+                    $transaction->setStructuredDescription($trx['description']['description']);
+                    $transaction->setBankCode($trx['description']['bank_code']);
+                    $transaction->setAccountNumber($trx['description']['account_number']);
+                    $transaction->setName($trx['description']['name']);
+                    $transaction->setBooked($trx['booked']);
+                    $transaction->setPN($trx['description']['primanoten_nr']);
+                    $statementModel->addTransaction($transaction);
+                }
+            }
+        }
+        return $result;
     }
 }

--- a/lib/Fhp/Model/StatementOfAccount/Transaction.php
+++ b/lib/Fhp/Model/StatementOfAccount/Transaction.php
@@ -1,4 +1,4 @@
-<?php
+<?php /** @noinspection PhpUnused */
 
 namespace Fhp\Model\StatementOfAccount;
 

--- a/lib/Fhp/Response/GetStatementOfAccount.php
+++ b/lib/Fhp/Response/GetStatementOfAccount.php
@@ -2,10 +2,6 @@
 
 namespace Fhp\Response;
 
-use Fhp\Model\StatementOfAccount\Statement;
-use Fhp\Model\StatementOfAccount\StatementOfAccount;
-use Fhp\Model\StatementOfAccount\Transaction;
-
 class GetStatementOfAccount extends Response
 {
     const SEG_ACCOUNT_INFORMATION = 'HIKAZ';
@@ -25,73 +21,5 @@ class GetStatementOfAccount extends Response
         }
 
         return '';
-    }
-
-    /**
-     * Adds statements to an existing StatementOfAccount object.
-     *
-     * @return StatementOfAccount
-     */
-    public static function addFromArray(array $array, StatementOfAccount $statementOfAccount)
-    {
-        foreach ($array as $date => $statement) {
-            if ($statementOfAccount->hasStatementForDate($date)) {
-                $statementModel = $statementOfAccount->getStatementForDate($date);
-            } else {
-                $statementModel = new Statement();
-                $statementModel->setDate(new \DateTime($date));
-                $statementModel->setStartBalance((float) $statement['start_balance']['amount']);
-                $statementModel->setCreditDebit($statement['start_balance']['credit_debit']);
-                $statementOfAccount->addStatement($statementModel);
-            }
-
-            if (isset($statement['transactions'])) {
-                foreach ($statement['transactions'] as $trx) {
-                    $replaceIn = [
-                        'booking_text',
-                        'description_1',
-                        'description_2',
-                        'description',
-                        'name',
-                    ];
-                    foreach ($replaceIn as $k) {
-                        if (isset($trx['description'][$k])) {
-                            $trx['description'][$k] = str_replace('@@', '', $trx['description'][$k]);
-                        }
-                    }
-
-                    $transaction = new Transaction();
-                    $transaction->setBookingDate(new \DateTime($trx['booking_date']));
-                    $transaction->setValutaDate(new \DateTime($trx['valuta_date']));
-                    $transaction->setCreditDebit($trx['credit_debit']);
-                    $transaction->setAmount($trx['amount']);
-                    $transaction->setBookingCode($trx['description']['booking_code']);
-                    $transaction->setBookingText($trx['description']['booking_text']);
-                    $transaction->setDescription1($trx['description']['description_1']);
-                    $transaction->setDescription2($trx['description']['description_2']);
-                    $transaction->setStructuredDescription($trx['description']['description']);
-                    $transaction->setBankCode($trx['description']['bank_code']);
-                    $transaction->setAccountNumber($trx['description']['account_number']);
-                    $transaction->setName($trx['description']['name']);
-                    $transaction->setBooked($trx['booked']);
-                    $transaction->setPN($trx['description']['primanoten_nr']);
-                    $statementModel->addTransaction($transaction);
-                }
-            }
-        }
-
-        return $statementOfAccount;
-    }
-
-    /**
-     * Creates a StatementOfAccount model from array.
-     *
-     * @return StatementOfAccount
-     */
-    public static function createModelFromArray(array $array)
-    {
-        $soa = static::addFromArray($array, new StatementOfAccount());
-
-        return $soa;
     }
 }


### PR DESCRIPTION
This decouples it from the old library's `Model` code and allows to remove its mutating accessors.