### PR TITLE
Replace "PHP session" with "PHP execution or "PHP process"

### DIFF
--- a/Samples/login.php
+++ b/Samples/login.php
@@ -52,7 +52,7 @@ function handleTan(\Fhp\BaseAction $action)
 
     // Optional: Instead of printing the above to the console, you can relay the information (challenge and TAN medium)
     // to the user in any other way (through your REST API, a push notification, ...). If waiting for the TAN requires
-    // you to interrupt this PHP session and the TAN will arrive in a fresh (HTTP/REST/...) request, you can do so:
+    // you to interrupt this PHP execution and the TAN will arrive in a fresh (HTTP/REST/...) request, you can do so:
     if ($optionallyPersistEverything = false) {
         $persistedAction = serialize($action);
         $persistedFints = $fints->persist();
@@ -67,15 +67,15 @@ function handleTan(\Fhp\BaseAction $action)
     // Ask the user for the TAN. ----------------------------------------------------------------------------------------
     // IMPORTANT: In your real application, you cannot use fgets(STDIN) of course (unless you're running PHP only as a
     // command line application). So you instead want to send a response to the user. This means that, after executing
-    // the first half of handleTan() above, your real application will terminate the PHP session. The second half of
+    // the first half of handleTan() above, your real application will terminate the PHP process. The second half of
     // handleTan() will likely live elsewhere in your application code (i.e. you will have two functions for the TAN
     // handling, not just one like in this simplified example). You *only* need to carry over the $persistedInstance
     // and the $persistedAction (which are simple strings) by storing them in some database or file where you can load
-    // them again in a new PHP session when the user sends the TAN.
+    // them again in a new PHP process when the user sends the TAN.
     echo "Please enter the TAN:\n";
     $tan = trim(fgets(STDIN));
 
-    // Optional: If the state was persisted above, we can restore it now (imagine this is a new PHP session).
+    // Optional: If the state was persisted above, we can restore it now (imagine this is a new PHP execution).
     if ($optionallyPersistEverything) {
         $restoredState = file_get_contents('state.txt');
         list($persistedInstance, $persistedAction) = unserialize($restoredState);

--- a/lib/Fhp/BaseAction.php
+++ b/lib/Fhp/BaseAction.php
@@ -25,8 +25,8 @@ use Fhp\Segment\HIRMS\Rueckmeldungscode;
  * requested information or the execution confirmation of the transaction) becomes available in the future, possibly
  * much later than when the request was sent, in case the user needs to enter a TAN.
  * All action instances are serializable, so that the execution can be interrupted to ask the user for a TAN. Once the
- * TAN is available, the execution can resume either a couple seconds later in the same PHP session using the same
- * physical connection to the bank, or on the order of minutes later in a new PHP session with a newly established
+ * TAN is available, the execution can resume either a couple seconds later in the same PHP process using the same
+ * physical connection to the bank, or on the order of minutes later in a new PHP process with a newly established
  * connection to the bank. Note that the serialization only applies to selected relevant request parameters, and not to
  * the response. Thus it is only possible to serialize an action when its execution has been attempted but resulted in a
  * TAN request.

--- a/lib/Fhp/FinTs.php
+++ b/lib/Fhp/FinTs.php
@@ -50,7 +50,7 @@ class FinTs
     /** @var string|null This is a {@link TanMedium#getName()}, but we don't have the {@link TanMedium} instance. */
     private $selectedTanMedium;
 
-    // State that persists across physical connections, dialogs and even PHP sessions.
+    // State that persists across physical connections, dialogs and even PHP executions.
     /** @var BPD|null */
     private $bpd;
     /** @var int[]|null The IDs of the {@link TanMode}s from the BPD which the user is allowed to use. */
@@ -74,7 +74,7 @@ class FinTs
      * @param Credentials $credentials Authentication information for the user. Note: This library does not support
      *     anonymous connections, so the credentials are mandatory.
      * @param string|null $persistedInstance The return value of {@link #persist()} of a previous FinTs instance,
-     *     usually from an earlier PHP session. Passing this in here saves 1-2 dialogs that are normally made with the
+     *     usually from an earlier PHP execution. Passing this in here saves 1-2 dialogs that are normally made with the
      *     bank to obtain the BPD and Kundensystem-ID.
      */
     public static function new(FinTsOptions $options, Credentials $credentials, ?string $persistedInstance = null): FinTs
@@ -178,8 +178,8 @@ class FinTs
      * Use this to continue a previous FinTs Instance, for example after a TAN was needed and PHP execution was ended to
      * obtain it from the user.
      *
-     * @param string $persistedInstance The return value of {@link #persist()} of a previous FinTs instance, usually from an earlier
-     *     PHP session.
+     * @param string $persistedInstance The return value of {@link #persist()} of a previous FinTs instance, usually
+     *     from an earlier PHP execution.
      *
      * @throws \InvalidArgumentException
      */
@@ -371,8 +371,8 @@ class FinTs
 
     /**
      * For an action where {@link BaseAction#needsTan()} returns `true`, this function sends the given $tan to the
-     * server in order to complete the action. This can be done asynchronously, i.e. not in the same PHP session as the
-     * original {@link #execute()} call.
+     * server in order to complete the action. This can be done asynchronously, i.e. not in the same PHP process as
+     * the original {@link #execute()} call.
      * @param BaseAction $action The action to be completed.
      * @param string $tan The TAN entered by the user.
      * @throws CurlException When the connection fails in a layer below the FinTS protocol.

--- a/lib/Tests/Fhp/Integration/Consors/ConsorsIntegrationTestBase.php
+++ b/lib/Tests/Fhp/Integration/Consors/ConsorsIntegrationTestBase.php
@@ -65,7 +65,7 @@ class ConsorsIntegrationTestBase extends FinTsTestCase
         $this->assertEquals('000003QS34CK6EMOUGT3JJOI834L7Kvb', $tanRequest->getProcessId());
         $this->assertEquals('Bitte TAN eingeben.', $tanRequest->getChallenge());
 
-        // Pretend that we close everything and open everything from scratch, as if it were a new PHP session.
+        // Pretend that we close everything and open everything from scratch, as if it were a new PHP process.
         $persistedInstance = $this->fints->persist();
         $persistedLogin = serialize($login);
         $this->connection->expects($this->once())->method('disconnect');

--- a/lib/Tests/Fhp/Integration/DKB/GetStatementOfAccountTest.php
+++ b/lib/Tests/Fhp/Integration/DKB/GetStatementOfAccountTest.php
@@ -107,7 +107,7 @@ class GetStatementOfAccountTest extends DKBIntegrationTestBase
         $getStatement = $this->runInitialRequest();
         $this->assertTrue($getStatement->needsTan());
 
-        // Pretend that we close everything and open everything from scratch, as if it were a new PHP session.
+        // Pretend that we close everything and open everything from scratch, as if it were a new PHP process.
         $persistedInstance = $this->fints->persist();
         $persistedGetStatement = serialize($getStatement);
         $this->connection->expects($this->once())->method('disconnect');

--- a/lib/Tests/Fhp/Integration/DKB/SendSEPATransferTest.php
+++ b/lib/Tests/Fhp/Integration/DKB/SendSEPATransferTest.php
@@ -136,7 +136,7 @@ class SendSEPATransferTest extends DKBIntegrationTestBase
         $sendTransfer = $this->runInitialRequest();
         $this->assertTrue($sendTransfer->needsTan());
 
-        // Pretend that we close everything and open everything from scratch, as if it were a new PHP session.
+        // Pretend that we close everything and open everything from scratch, as if it were a new PHP process.
         $persistedInstance = $this->fints->persist();
         $persistedAction = serialize($sendTransfer);
         $this->connection->expects($this->once())->method('disconnect');


### PR DESCRIPTION
The term "session" can easily be confused with PHP's session management mechanism ($_SESSION etc.). Use the term "execution" or "process" instead, whichever fits best in the respective context.

See #271 @ampaze fyi