### PR TITLE
Fix {@link} references in phpDoc

### DIFF
--- a/lib/Fhp/Action/GetBalance.php
+++ b/lib/Fhp/Action/GetBalance.php
@@ -36,7 +36,7 @@ class GetBalance extends BaseAction
 
     /**
      * @param SEPAAccount $account The account to get the balance for. This can be constructed based on information
-     *     that the user entered, or it can be {@link SEPAAccount} instance retrieved from {@link #getAccounts()}.
+     *     that the user entered, or it can be {@link SEPAAccount} instance retrieved from {@link getAccounts()}.
      * @param bool $allAccounts If set to true, will return balances for all accounts of the user. You still need to
      *     pass one of the accounts into $account, though.
      */
@@ -67,7 +67,7 @@ class GetBalance extends BaseAction
 
     /**
      * @return HISAL[]
-     * @throws \Exception See {@link #ensureSuccess()}.
+     * @throws \Exception See {@link ensureSuccess()}.
      */
     public function getBalances()
     {

--- a/lib/Fhp/Action/GetSEPAAccounts.php
+++ b/lib/Fhp/Action/GetSEPAAccounts.php
@@ -39,7 +39,7 @@ class GetSEPAAccounts extends BaseAction
 
     /**
      * @return SEPAAccount[]
-     * @throws \Exception See {@link #ensureSuccess()}.
+     * @throws \Exception See {@link ensureSuccess()}.
      */
     public function getAccounts()
     {

--- a/lib/Fhp/Action/GetStatementOfAccount.php
+++ b/lib/Fhp/Action/GetStatementOfAccount.php
@@ -57,7 +57,7 @@ class GetStatementOfAccount extends BaseAction
 
     /**
      * @param SEPAAccount $account The account to get the statement for. This can be constructed based on information
-     *     that the user entered, or it can be {@link SEPAAccount} instance retrieved from {@link #getAccounts()}.
+     *     that the user entered, or it can be {@link SEPAAccount} instance retrieved from {@link getAccounts()}.
      * @param \DateTime|null $from If set, only transactions after this date (inclusive) are returned.
      * @param \DateTime|null $to If set, only transactions before this date (inclusive) are returned.
      * @param bool $allAccounts If set to true, will return statements for all accounts of the user. You still need to
@@ -99,7 +99,7 @@ class GetStatementOfAccount extends BaseAction
 
     /**
      * @return string The raw MT940 data received from the server.
-     * @throws \Exception See {@link #ensureSuccess()}.
+     * @throws \Exception See {@link ensureSuccess()}.
      * @noinspection PhpUnused
      */
     public function getRawMT940(): string
@@ -110,7 +110,7 @@ class GetStatementOfAccount extends BaseAction
 
     /**
      * @return array The parsed MT940 data.
-     * @throws \Exception See {@link #ensureSuccess()}.
+     * @throws \Exception See {@link ensureSuccess()}.
      */
     public function getParsedMT940(): array
     {
@@ -120,7 +120,7 @@ class GetStatementOfAccount extends BaseAction
 
     /**
      * @return StatementOfAccount
-     * @throws \Exception See {@link #ensureSuccess()}.
+     * @throws \Exception See {@link ensureSuccess()}.
      */
     public function getStatement()
     {

--- a/lib/Fhp/Action/GetStatementOfAccountXML.php
+++ b/lib/Fhp/Action/GetStatementOfAccountXML.php
@@ -42,7 +42,7 @@ class GetStatementOfAccountXML extends BaseAction
 
     /**
      * @param SEPAAccount $account The account to get the statement for. This can be constructed based on information
-     *     that the user entered, or it can be {@link SEPAAccount} instance retrieved from {@link #getAccounts()}.
+     *     that the user entered, or it can be {@link SEPAAccount} instance retrieved from {@link getAccounts()}.
      * @param \DateTime|null $from If set, only transactions after this date (inclusive) are returned.
      * @param \DateTime|null $to If set, only transactions before this date (inclusive) are returned.
      * @param string|null $camtURN The URN/descriptor of the CAMT XML format you want the bank to return.
@@ -86,7 +86,7 @@ class GetStatementOfAccountXML extends BaseAction
 
     /**
      * @return string[] The XML-Document(s) received from the bank, or empty array if the statement is unavailable/empty.
-     * @throws \Exception See {@link #ensureSuccess()}.
+     * @throws \Exception See {@link ensureSuccess()}.
      */
     public function getBookedXML(): array
     {

--- a/lib/Fhp/BaseAction.php
+++ b/lib/Fhp/BaseAction.php
@@ -37,7 +37,7 @@ use Fhp\Segment\HIRMS\Rueckmeldungscode;
  */
 abstract class BaseAction implements \Serializable
 {
-    /** @var int[] Stores segment numbers that were assigned to the segments returned from {@link #createRequest()}. */
+    /** @var int[] Stores segment numbers that were assigned to the segments returned from {@link createRequest()}. */
     private $requestSegmentNumbers;
 
     /**
@@ -89,7 +89,7 @@ abstract class BaseAction implements \Serializable
 
     /**
      * @return bool Whether the underlying operation has completed (whether successfully or not) and the result or error
-     *     message in this future is available. Note: If this returns false, check {@link #needsTan()}.
+     *     message in this future is available. Note: If this returns false, check {@link needsTan()}.
      */
     public function isAvailable(): bool
     {
@@ -106,7 +106,7 @@ abstract class BaseAction implements \Serializable
     }
 
     /**
-     * @return bool Whether the underlying operation has completed unsuccessfully and the {@link #getError()} is
+     * @return bool Whether the underlying operation has completed unsuccessfully and the {@link getError()} is
      *     available.
      */
     public function isError(): bool
@@ -116,7 +116,7 @@ abstract class BaseAction implements \Serializable
 
     /**
      * @return bool If this returns true, the underlying operation has not completed because it is awaiting a TAN. You
-     *     should ask the user for this TAN and pass it to {@link #submitTan()}.
+     *     should ask the user for this TAN and pass it to {@link submitTan()}.
      */
     public function needsTan(): bool
     {
@@ -139,7 +139,7 @@ abstract class BaseAction implements \Serializable
 
     /**
      * @return string|null Possibly a pagination token to be sent to the server. For actions that support pagination,
-     *     this should be read in {@link #createRequest()}.
+     *     this should be read in {@link createRequest()}.
      */
     public function getPaginationToken(): ?string
     {
@@ -181,7 +181,7 @@ abstract class BaseAction implements \Serializable
 
     /**
      * Called when this action is about to be executed, in order to construct the request. This function can be called
-     * multiple times in case the response is paginated. On all but the first call, {@link #getPaginationToken()} will
+     * multiple times in case the response is paginated. On all but the first call, {@link getPaginationToken()} will
      * return a non-null token that should be included in the returned request.
      * @param BPD $bpd See {@link BPD}.
      * @param UPD|null $upd See {@link UPD}. This is usually present (non-null), except for a few special login and TAN
@@ -189,19 +189,19 @@ abstract class BaseAction implements \Serializable
      * @return BaseSegment|BaseSegment[] A segment or a series of segments that should be sent to the bank server.
      *     Note that an action can return an empty array to indicate that it does not need to make a request to the
      *     server, but can instead compute the result just from the BPD/UPD, in which case it should set
-     *     `$this->isAvailable = true;` already in {@link #createRequest()} and {@link #processResponse()} will never
+     *     `$this->isAvailable = true;` already in {@link createRequest()} and {@link processResponse()} will never
      *     be executed.
      * @throws \InvalidArgumentException When the request cannot be built because the input data or BPD/UPD is invalid.
      */
     abstract public function createRequest(BPD $bpd, ?UPD $upd);
 
     /**
-     * Called when this action was executed on the server (never if {@link #createRequest()} returned an empty request),
+     * Called when this action was executed on the server (never if {@link createRequest()} returned an empty request),
      * to process the response. This function can be called multiple times in case the response is paginated.
      * In case the response indicates that this action failed, this function may throw an appropriate exception. Sub-classes should override this function
      * and call the parent/super function.
      * @param Message $response A fake message that contains the subset of segments received from the server that
-     *     were in response to the request segments that were created by {@link #createRequest()}.
+     *     were in response to the request segments that were created by {@link createRequest()}.
      * @throws UnexpectedResponseException When the response indicates failure.
      */
     public function processResponse(Message $response)

--- a/lib/Fhp/FinTs.php
+++ b/lib/Fhp/FinTs.php
@@ -47,7 +47,7 @@ class FinTs
     // The TAN mode and medium to be used for business transactions that require a TAN.
     /** @var VerfahrensparameterZweiSchrittVerfahrenV6|int|null Note that this is a sub-type of {@link TanMode} */
     private $selectedTanMode;
-    /** @var string|null This is a {@link TanMedium#getName()}, but we don't have the {@link TanMedium} instance. */
+    /** @var string|null This is a {@link TanMedium::getName()}, but we don't have the {@link TanMedium} instance. */
     private $selectedTanMedium;
 
     // State that persists across physical connections, dialogs and even PHP executions.
@@ -73,7 +73,7 @@ class FinTs
      * @param FinTsOptions $options Configuration options for the connection to the bank.
      * @param Credentials $credentials Authentication information for the user. Note: This library does not support
      *     anonymous connections, so the credentials are mandatory.
-     * @param string|null $persistedInstance The return value of {@link #persist()} of a previous FinTs instance,
+     * @param string|null $persistedInstance The return value of {@link persist()} of a previous FinTs instance,
      *     usually from an earlier PHP execution. Passing this in here saves 1-2 dialogs that are normally made with the
      *     bank to obtain the BPD and Kundensystem-ID.
      */
@@ -118,7 +118,7 @@ class FinTs
     }
 
     /**
-     * Destructing the object only disconnects. Please use {@link #close()} if you want to properly "log out", i.e. end
+     * Destructing the object only disconnects. Please use {@link close()} if you want to properly "log out", i.e. end
      * the FinTs dialog. On the other hand, do *not* close in case you have serialized the FinTs instance and intend
      * to resume it later due to a TAN request.
      */
@@ -132,10 +132,10 @@ class FinTs
      * serializes parts and cannot simply be restored with `unserialize()` because the `FinTsOptions` and the
      * `Credentials` need to be passed to FinTs::new() in addition to the string returned here.
      *
-     * Alternatively you can use {@link #loadPersistedInstance) to separate constructing the instance and resuming it.
+     * Alternatively you can use {@link loadPersistedInstance) to separate constructing the instance and resuming it.
      *
      * NOTE: Unless you're persisting this object to complete a TAN request later on, you probably want to log the user
-     * out first by calling {@link #close()}.
+     * out first by calling {@link close()}.
      *
      * @param bool $minimal If true, the return value only contains only those values that are necessary to complete an
      *     outstanding TAN request, but not the relatively large BPD/UPD, which can always be retrieved again later with
@@ -178,7 +178,7 @@ class FinTs
      * Use this to continue a previous FinTs Instance, for example after a TAN was needed and PHP execution was ended to
      * obtain it from the user.
      *
-     * @param string $persistedInstance The return value of {@link #persist()} of a previous FinTs instance, usually
+     * @param string $persistedInstance The return value of {@link persist()} of a previous FinTs instance, usually
      *     from an earlier PHP execution.
      *
      * @throws \InvalidArgumentException
@@ -244,9 +244,9 @@ class FinTs
     /**
      * Executes a strongly authenticated login action and returns it. With some banks, this requires a TAN.
      * @return DialogInitialization A {@link BaseAction} for the outcome of the login. You should check this for errors
-     *     using {@link BaseAction#isError()} or {@link BaseAction#maybeThrowError()}. You should also check whether a
-     *     TAN is needed using {@link BaseAction#needsTan()} and, if so, finish the login by passing {@link BaseAction}
-     *     returned here to {@link #submitTan()}.
+     *     using {@link BaseAction::isError()} or {@link BaseAction::maybeThrowError()}. You should also check whether a
+     *     TAN is needed using {@link BaseAction::needsTan()} and, if so, finish the login by passing {@link BaseAction}
+     *     returned here to {@link submitTan()}.
      * @throws CurlException When the connection fails in a layer below the FinTS protocol.
      * @throws UnexpectedResponseException When the server responds with a valid but unexpected message.
      * @throws ServerException When the server responds with a (FinTS-encoded) error message. Note that some errors are
@@ -264,9 +264,9 @@ class FinTs
     }
 
     /**
-     * Executes an action. Be sure to {@link #login()} first. See the `\Fhp\Action` package for actions that can be
+     * Executes an action. Be sure to {@link login()} first. See the `\Fhp\Action` package for actions that can be
      * executed with this function. Note that, after this function returns, the result of the action is stored inside
-     * the action itself, so you need to check its {@link BaseAction#isSuccess()}, {@link BaseAction#needsTan()} and
+     * the action itself, so you need to check its {@link BaseAction::isSuccess()}, {@link BaseAction::needsTan()} and
      * other getters in order to obtain its status and result.
      * @param BaseAction $action The action to be executed. Its status will be updated when this function returns.
      * @throws CurlException When the connection fails in a layer below the FinTS protocol.
@@ -370,9 +370,9 @@ class FinTs
     }
 
     /**
-     * For an action where {@link BaseAction#needsTan()} returns `true`, this function sends the given $tan to the
+     * For an action where {@link BaseAction::needsTan()} returns `true`, this function sends the given $tan to the
      * server in order to complete the action. This can be done asynchronously, i.e. not in the same PHP process as
-     * the original {@link #execute()} call.
+     * the original {@link execute()} call.
      * @param BaseAction $action The action to be completed.
      * @param string $tan The TAN entered by the user.
      * @throws CurlException When the connection fails in a layer below the FinTS protocol.
@@ -468,13 +468,13 @@ class FinTs
     }
 
     /**
-     * For TAN modes where {@link TanMode#needsTanMedium()} returns true, the user additionally needs to pick a TAN
+     * For TAN modes where {@link TanMode::needsTanMedium()} returns true, the user additionally needs to pick a TAN
      * medium. This function returns a list of possible TAN media. Note that, depending on the bank, this list may
      * contain all the user's TAN media, or just the ones that are compatible with the given $tanMode.
-     * @param TanMode|int $tanMode Either a {@link TanMode} instance obtained from {@link #getTanModes()} or its ID.
+     * @param TanMode|int $tanMode Either a {@link TanMode} instance obtained from {@link getTanModes()} or its ID.
      * @return TanMedium[] A list of possible TAN media.
      * @throws UnexpectedResponseException Among other situations, this is thrown if the bank does not support
-     *     enumerating TAN media. In that case, hopefully {@link TanMode#needsTanMedium()} didn't return true.
+     *     enumerating TAN media. In that case, hopefully {@link TanMode::needsTanMedium()} didn't return true.
      * @throws CurlException When the connection fails in a layer below the FinTS protocol.
      * @throws ServerException When the server responds with an error.
      */
@@ -508,10 +508,10 @@ class FinTs
     }
 
     /**
-     * @param TanMode|int $tanMode Either a {@link TanMode} instance obtained from {@link #getTanModes()} or its ID.
-     * @param TanMedium|string|null $tanMedium If the $tanMode has {@link TanMode#needsTanMedium()} set to true, this
-     *     must be the value returned from {@link TanMedium#getName()} for one of the TAN media supported with that TAN
-     *     mode. Use {@link #getTanMedia()} to obtain a list of possible TAN media options.
+     * @param TanMode|int $tanMode Either a {@link TanMode} instance obtained from {@link getTanModes()} or its ID.
+     * @param TanMedium|string|null $tanMedium If the $tanMode has {@link TanMode::needsTanMedium()} set to true, this
+     *     must be the value returned from {@link TanMedium::getName()} for one of the TAN media supported with that TAN
+     *     mode. Use {@link getTanMedia()} to obtain a list of possible TAN media options.
      */
     public function selectTanMode($tanMode, $tanMedium = null)
     {
@@ -544,7 +544,7 @@ class FinTs
     /**
      * Ensures that the latest BPD data is present by executing an anonymous dialog (including initialization and
      * termination of the dialog) if necessary. Executing this does not require (strong or any) authentication, and it
-     * makes the {@link #$bpd} available.
+     * makes the {@link $bpd} available.
      *
      * @link https://www.hbci-zka.de/dokumente/spezifikation_deutsch/fintsv3/FinTS_3.0_Formals_2017-10-06_final_version.pdf
      * Section: C.5.1 (and also C.3.1.1)
@@ -590,7 +590,7 @@ class FinTs
     }
 
     /**
-     * Ensures that the {@link #$allowedTanModes} are available by executing a personalized, TAN-less dialog
+     * Ensures that the {@link $allowedTanModes} are available by executing a personalized, TAN-less dialog
      * initialization (and closing the dialog again), if necessary. Executing this only requires the {@link Credentials}
      * but no strong authentication.
      * @throws CurlException When the connection fails in a layer below the FinTS protocol.
@@ -608,7 +608,7 @@ class FinTs
     }
 
     /**
-     * Ensures that we have a {@link #$kundensystemId} by executing a synchronization dialog (and closing it again) if
+     * Ensures that we have a {@link $kundensystemId} by executing a synchronization dialog (and closing it again) if
      * if necessary. Executing this does not require strong authentication.
      * @throws CurlException When the connection fails in a layer below the FinTS protocol.
      * @throws ServerException When the server resopnds with an error.
@@ -679,7 +679,7 @@ class FinTs
     }
 
     /**
-     * Like {@link #getSelectedTanMode()}, but throws an exception if none was selected.
+     * Like {@link getSelectedTanMode()}, but throws an exception if none was selected.
      * @return TanMode The current TAN mode.
      * @throws \RuntimeException If no TAN mode has been selected.
      * @throws CurlException When the connection fails in a layer below the FinTS protocol.
@@ -695,7 +695,7 @@ class FinTs
     }
 
     /**
-     * Creates a new connection based on the {@link #$options}. This can be overridden for unit testing purposes.
+     * Creates a new connection based on the {@link $options}. This can be overridden for unit testing purposes.
      * @return Connection A newly instantiated connection.
      */
     protected function newConnection(): Connection

--- a/lib/Fhp/Options/SanitizingLogger.php
+++ b/lib/Fhp/Options/SanitizingLogger.php
@@ -11,8 +11,8 @@ use Psr\Log\LoggerInterface;
  * A logger that forwards to another PSR logger, but attempts to remove confidential information
  * like usernames, passwords/PINs and so on.
  *
- * Note: This is internally used by {@link FinTs#setLogger()}, so application could usually does not need to instantiate
- * this class manually.
+ * Note: This is internally used by {@link FinTs::setLogger()}, so application could usually does not need to
+ * instantiate this class manually.
  */
 class SanitizingLogger extends \Psr\Log\AbstractLogger
 {
@@ -88,7 +88,7 @@ class SanitizingLogger extends \Psr\Log\AbstractLogger
      * Removes sensitive values from the given string, while preserving its overall length, so that wrappers like FinTS
      * messages or Bin containers, which declare the length of their contents, remain parsable.
      * @param string $str Some string.
-     * @param string[] The sensitive values to be replaced, usually from {@link #computeNeedles()}.
+     * @param string[] The sensitive values to be replaced, usually from {@link computeNeedles()}.
      * @return string The same string, but with sensitive values removed.
      */
     public static function sanitizeForLogging(string $str, $needles): string

--- a/lib/Fhp/Protocol/DialogInitialization.php
+++ b/lib/Fhp/Protocol/DialogInitialization.php
@@ -25,7 +25,7 @@ use Fhp\Segment\TAN\HKTANv6;
  * which it runs.
  * This action automatically executes synchroniziation if `$kundensystemId=null` was passed to the constructor. In this
  * case, the opened dialog must not be used for any other (financial/business) actions, so the caller must call
- * {@link FinTs#endDialog()} immediately after executing a {@link DialogInitialization} without pre-existing
+ * {@link FinTs::endDialog()} immediately after executing a {@link DialogInitialization} without pre-existing
  * Kundensystem-ID.
  * @link https://www.hbci-zka.de/dokumente/spezifikation_deutsch/fintsv3/FinTS_3.0_Formals_2017-10-06_final_version.pdf
  * Section: C.8
@@ -41,7 +41,7 @@ use Fhp\Segment\TAN\HKTANv6;
  * Rough overview of the initialization procedure with no prior information on the client side:
  * 1. Open connection.
  * 2. Initialize and close anonymously to retrieve BPD (HITANS, HIPINS, ...). This is implemented in
- *    {@link FinTs#ensureBpdAvailable()}.
+ *    {@link FinTs::ensureBpdAvailable()}.
  * 3. Initialize a dialog with $kundensystemId=null ("synchronization") and $hktanRef=null, and close it again. At this
  *    point, the allowed TAN modes are available, so the user can select a $tanMode.
  * 4. Optional: If the user needs to select a TAN medium, initialize another dialog with $hktanRef=HKTAB to execute

--- a/lib/Fhp/Protocol/GetTanMedia.php
+++ b/lib/Fhp/Protocol/GetTanMedia.php
@@ -43,7 +43,7 @@ class GetTanMedia extends BaseAction
 
     /**
      * @return TanMediumListe[]|null
-     * @throws \Exception See {@link #ensureSuccess()}.
+     * @throws \Exception See {@link ensureSuccess()}.
      */
     public function getTanMedia(): ?array
     {

--- a/lib/Fhp/Protocol/Message.php
+++ b/lib/Fhp/Protocol/Message.php
@@ -230,11 +230,11 @@ class Message
     }
 
     /**
-     * Wraps the given segments in an "encryption" envelope (see class documentation). Inverse of {@link #parse()}.
+     * Wraps the given segments in an "encryption" envelope (see class documentation). Inverse of {@link parse()}.
      * @param BaseSegment[]|MessageBuilder $plainSegments The plain segments to be wrapped. Segment numbers do not need
      *     to be set yet (or they will be overwritten).
      * @param FinTsOptions $options See {@link FinTsOptions}.
-     * @param string $kundensystemId See {@link #$kundensystemId}.
+     * @param string $kundensystemId See {@link $kundensystemId}.
      * @param Credentials $credentials The credentials used to authenticate the message.
      * @param TanMode|null $tanMode Optionally specifies which two-step TAN mode to use, defaults to 999 (single step).
      * @param string|null The TAN to be sent to the server (in HNSHA). If this is present, $tanMode must be present.
@@ -269,7 +269,7 @@ class Message
 
     /**
      * Builds a plain message by adding header and footer to the given segments, but no "encryption" envelope.
-     * Inverse of {@link #parse()}.
+     * Inverse of {@link parse()}.
      * @param BaseSegment[]|MessageBuilder $segments
      * @return Message The built message, ready to be sent to the server through {@link FinTs::sendMessage()}.
      */
@@ -287,8 +287,8 @@ class Message
 
     /**
      * Parses the given wire format and unwraps the "encryption" envelope (see class documentation) if it exists
-     * (in which case this function acts as the inverse of {@link #createWrappedMessage()}), or leaves as is otherwise
-     * (and acts as inverse of {@link #createPlainMessage()}).
+     * (in which case this function acts as the inverse of {@link createWrappedMessage()}), or leaves as is otherwise
+     * (and acts as inverse of {@link createPlainMessage()}).
      *
      * @param string $rawMessage The received message in HBCI/FinTS wire format. This should be ISO-8859-1-encoded.
      * @return Message The parsed message.

--- a/lib/Fhp/Protocol/UPD.php
+++ b/lib/Fhp/Protocol/UPD.php
@@ -25,7 +25,7 @@ class UPD
 
     /**
      * @param Message $response A dialog initialization response from the server.
-     * @return bool True if the UPD data is contained in the response and {@link #extractFromResponse()} would
+     * @return bool True if the UPD data is contained in the response and {@link extractFromResponse()} would
      *     succeed.
      */
     public static function containedInResponse(Message $response): bool

--- a/lib/Fhp/Segment/BaseDeg.php
+++ b/lib/Fhp/Segment/BaseDeg.php
@@ -44,7 +44,7 @@ abstract class BaseDeg implements \Serializable
     }
 
     /**
-     * Short-hand for {@link Serializer#serializeDeg()}.
+     * Short-hand for {@link Serializer::serializeDeg()}.
      * @return string The HBCI wire format representation of this DEG.
      */
     public function serialize(): string
@@ -62,7 +62,7 @@ abstract class BaseDeg implements \Serializable
     }
 
     /**
-     * Convenience function for {@link Parser#parseGroup()}. This function should not be called on BaseDeg itself, but
+     * Convenience function for {@link Parser::parseGroup()}. This function should not be called on BaseDeg itself, but
      * only on one of its sub-classes.
      * @param string $rawElements The serialized wire format for a data element group.
      * @return static The parsed value.

--- a/lib/Fhp/Segment/BaseSegment.php
+++ b/lib/Fhp/Segment/BaseSegment.php
@@ -69,7 +69,7 @@ abstract class BaseSegment implements SegmentInterface, \Serializable
     }
 
     /**
-     * Short-hand for {@link Serializer#serializeSegment()}.
+     * Short-hand for {@link Serializer::serializeSegment()}.
      * @return string The HBCI wire format representation of this segment, in ISO-8859-1 encoding, terminated by the
      *     segment delimiter.
      */
@@ -96,7 +96,7 @@ abstract class BaseSegment implements SegmentInterface, \Serializable
     }
 
     /**
-     * Convenience function for {@link Parser#parseSegment()}.
+     * Convenience function for {@link Parser::parseSegment()}.
      * @param string $rawSegment The serialized wire format for a single segment (segment delimiter must be present at
      *     the end). This should be ISO-8859-1-encoded.
      * @return static The parsed segment.

--- a/lib/Fhp/Segment/HNHBK/BezugsnachrichtV1.php
+++ b/lib/Fhp/Segment/HNHBK/BezugsnachrichtV1.php
@@ -12,8 +12,8 @@ use Fhp\Segment\BaseDeg;
  */
 class BezugsnachrichtV1 extends BaseDeg
 {
-    /** @var string References a previously sent {@link HNHBKv3#dialogId} */
+    /** @var string References a previously sent {@link HNHBKv3::$dialogId} */
     public $dialogId;
-    /** @var int References a previously sent {@link HNHBKv3#nachrichtennummer} */
+    /** @var int References a previously sent {@link HNHBKv3::$nachrichtennummer} */
     public $nachrichtennummer;
 }

--- a/lib/Fhp/Segment/HNHBS/HNHBSv1.php
+++ b/lib/Fhp/Segment/HNHBS/HNHBSv1.php
@@ -9,6 +9,6 @@ use Fhp\Segment\BaseSegment;
  */
 class HNHBSv1 extends BaseSegment
 {
-    /** @var int Must match the {@link HNHBKv2#nachrichtennummer} in the same message. */
+    /** @var int Must match the {@link HNHBKv2::$nachrichtennummer} in the same message. */
     public $nachrichtennummer;
 }

--- a/lib/Fhp/Segment/HNSHK/HNSHKv4.php
+++ b/lib/Fhp/Segment/HNSHK/HNSHKv4.php
@@ -25,7 +25,7 @@ class HNSHKv4 extends BaseSegment
      * For the PIN/TAN profile (see section B.9.4), this must be:
      *   - 998 for Ein-Schritt-Verfahren, or
      *   - the value in the 900--997 range as received in
-     *     {@link \Fhp\Segment\TAN\VerfahrensparameterZweiSchrittVerfahrenv6#sicherheitsfunktion}
+     *     {@link \Fhp\Segment\TAN\VerfahrensparameterZweiSchrittVerfahrenv6::$sicherheitsfunktion}
      * @var int
      */
     public $sicherheitsfunktion;
@@ -65,7 +65,7 @@ class HNSHKv4 extends BaseSegment
      * @param FinTsOptions $options See {@link FinTsOptions}.
      * @param Credentials $credentials See {@link Credentials}.
      * @param TanMode|null $tanMode Optionally specifies which two-step TAN mode to use, defaults to 999 (single step).
-     * @param string $kundensystemId See {@link SicherheitsidentifikationDetailsV2#identifizierungDerPartei}.
+     * @param string $kundensystemId See {@link SicherheitsidentifikationDetailsV2::$identifizierungDerPartei}.
      */
     public static function create(string $sicherheitskontrollreferenz, FinTsOptions $options, Credentials $credentials, ?TanMode $tanMode, string $kundensystemId): HNSHKv4
     {

--- a/lib/Fhp/Segment/HNVSK/HNVSKv3.php
+++ b/lib/Fhp/Segment/HNVSK/HNVSKv3.php
@@ -70,7 +70,7 @@ class HNVSKv3 extends BaseSegment
     /**
      * @param FinTsOptions $options See {@link FinTsOptions}.
      * @param Credentials $credentials See {@link Credentials}.
-     * @param string $kundensystemId See {@link SicherheitsidentifikationDetailsV2#identifizierungDerPartei}.
+     * @param string $kundensystemId See {@link SicherheitsidentifikationDetailsV2::$identifizierungDerPartei}.
      * @param TanMode|null $tanMode Optionally specifies which two-step TAN mode to use, defaults to 999 (single step).
      */
     public static function create(FinTsOptions $options, Credentials $credentials, string $kundensystemId, ?TanMode $tanMode): HNVSKv3

--- a/lib/Fhp/Segment/Segmentkopf.php
+++ b/lib/Fhp/Segment/Segmentkopf.php
@@ -5,7 +5,7 @@ namespace Fhp\Segment;
 class Segmentkopf extends BaseDeg
 {
     /**
-     * The name/type of the segment, e.g. "HITANS", corresponding to {@link SegmentDescriptor#kennung}.
+     * The name/type of the segment, e.g. "HITANS", corresponding to {@link SegmentDescriptor::$kennung}.
      * Max length: 6
      * @var string
      */
@@ -19,14 +19,14 @@ class Segmentkopf extends BaseDeg
     public $segmentnummer;
 
     /**
-     * Version of the segment, corresponding to {@link SegmentDescriptor#version}.
+     * Version of the segment, corresponding to {@link SegmentDescriptor::$version}.
      * @var int
      */
     public $segmentversion;
 
     /**
      * Not allowed in requests, optionally present in responses.
-     * In a response message, this refers to the {@link #segmentnummer} of a segment in the request message.
+     * In a response message, this refers to the {@link $segmentnummer} of a segment in the request message.
      * @var int|null
      */
     public $bezugselement;

--- a/lib/Fhp/Segment/TAN/HITANv6.php
+++ b/lib/Fhp/Segment/TAN/HITANv6.php
@@ -17,7 +17,7 @@ class HITANv6 extends BaseSegment implements TanRequest
     const DUMMY_REFERENCE = 'noref';
 
     /**
-     * @var int Allowed values: 1 (for Prozessvariante 1), 2, 3, 4. See {@link HKTANv6#$tanProzess} for details.
+     * @var int Allowed values: 1 (for Prozessvariante 1), 2, 3, 4. See {@link HKTANv6::$$tanProzess} for details.
      */
     public $tanProzess;
     /**

--- a/lib/Fhp/Segment/TAN/VerfahrensparameterZweiSchrittVerfahrenV6.php
+++ b/lib/Fhp/Segment/TAN/VerfahrensparameterZweiSchrittVerfahrenV6.php
@@ -11,7 +11,7 @@ class VerfahrensparameterZweiSchrittVerfahrenV6 extends BaseDeg implements TanMo
 
     /** @var int Allowed values: 900 through 997 */
     public $sicherheitsfunktion;
-    /** @var int Allowed values: 1, 2; See specification or {@link HKTANv6#$tanProzess} for details. */
+    /** @var int Allowed values: 1, 2; See specification or {@link HKTANv6::$$tanProzess} for details. */
     public $tanProzess;
     /** @var string */
     public $technischeIdentifikationTanVerfahren;
@@ -32,7 +32,7 @@ class VerfahrensparameterZweiSchrittVerfahrenV6 extends BaseDeg implements TanMo
     /** @var bool */
     public $mehrfachTanErlaubt;
     /**
-     * In case of multi-TAN (see {@link #$mehrfachTanErlaubt}), this specifies whether all TANs must be entered in the
+     * In case of multi-TAN (see {@link $mehrfachTanErlaubt}), this specifies whether all TANs must be entered in the
      * same dialog and at the same time, or not.
      * 1 TAN nicht zeitversetzt / dialogübergreifend erlaubt
      * 2 TAN zeitversetzt / dialogübergreifend erlaubt

--- a/lib/Fhp/Syntax/Parser.php
+++ b/lib/Fhp/Syntax/Parser.php
@@ -123,7 +123,7 @@ abstract class Parser
      *
      * @param string $rawValue The raw value (wire format).
      * @param string $type The PHP type that we need. This should support exactly the values for which
-     *     {@link ElementDescriptor#isScalarType()} returns true.
+     *     {@link ElementDescriptor::isScalarType()} returns true.
      * @return mixed|null The parsed value of type $type, null if the $rawValue was empty.
      */
     public static function parseDataElement(string $rawValue, string $type)

--- a/lib/Fhp/Syntax/Serializer.php
+++ b/lib/Fhp/Syntax/Serializer.php
@@ -35,7 +35,7 @@ abstract class Serializer
     /**
      * @param mixed|null $value A scalar (DE) value.
      * @param string $type The PHP type of this value. This should support exactly the values for which
-     *     {@link ElementDescriptor#isScalarType()} returns true.
+     *     {@link ElementDescriptor::isScalarType()} returns true.
      * @return string The HBCI wire format representation of the value.
      */
     public static function serializeDataElement($value, string $type): string


### PR DESCRIPTION
phpDoc doesn't use `#` to mark member names, but rather `::` as the delimiter between class and member name, and no marker for members of the same class.