### PR TITLE
Call maybeThrowError() from execute() and submitTan()

### DIFF
--- a/Samples/directDebit_Sephpa.php
+++ b/Samples/directDebit_Sephpa.php
@@ -49,5 +49,3 @@ $fints->execute($sendSEPADirectDebit);
 if ($sendSEPADirectDebit->needsTan()) {
     handleTan($sendSEPADirectDebit); // See login.php for the implementation.
 }
-
-$sendSEPADirectDebit->ensureSuccess();

--- a/Samples/directDebit_phpSepaXml.php
+++ b/Samples/directDebit_phpSepaXml.php
@@ -65,5 +65,3 @@ $fints->execute($sendSEPADirectDebit);
 if ($sendSEPADirectDebit->needsTan()) {
     handleTan($sendSEPADirectDebit); // See login.php for the implementation.
 }
-
-$sendSEPADirectDebit->ensureSuccess();

--- a/Samples/login.php
+++ b/Samples/login.php
@@ -25,8 +25,7 @@ $fints = require_once 'init.php';
  * but it is also possible to interrupt the PHP execution entirely while asking for the TAN.
  *
  * @param \Fhp\BaseAction $action Some action that requires a TAN.
- * @throws \Fhp\CurlException
- * @throws \Fhp\Protocol\ServerException
+ * @throws \Exception See {@link FinTs::execute()} for details on the exception types.
  */
 function handleTan(\Fhp\BaseAction $action)
 {

--- a/Samples/transfer.php
+++ b/Samples/transfer.php
@@ -52,5 +52,3 @@ $fints->execute($sendSEPATransfer);
 if ($sendSEPATransfer->needsTan()) {
     handleTan($sendSEPATransfer); // See login.php for the implementation.
 }
-
-$sendSEPATransfer->ensureSuccess();

--- a/lib/Fhp/BaseAction.php
+++ b/lib/Fhp/BaseAction.php
@@ -165,9 +165,20 @@ abstract class BaseAction implements \Serializable
     }
 
     /**
+     * Throws an error unless this action has been successfully executed, i.e. in the following cases:
+     *  - the action has not been {@link FinTs::execute()}-d at all,
+     *  - the action is awaiting a TAN that first needs to be supplied with {@link FinTs::submitTan()},
+     *  - the action was executed but the bank reported a failure.
+     *
+     * After executing an action, you can use this function to make sure that it succeeded. This is especially useful
+     * for actions that don't have any results (as each result getter would call {@link ensureSuccess()} internally).
+     * On the other hand, you do not need to call this function if you make sure that (1) you called
+     * {@link FinTs::execute()} and (2) you checked {@link needsTan()} and, if it returned true, supplied a TAN by
+     * calling {@ink FinTs::submitTan()}.
      * @throws ActionIncompleteException If the action hasn't even been executed.
      * @throws TanRequiredException If the action needs a TAN.
-     * @throws \Exception If the action failed.
+     * @throws \Exception If the action failed. Note that this is the same exception that you would also have received
+     *     from {@link FinTs::execute()} or {@ink FinTs::submitTan()} before.
      */
     public function ensureSuccess()
     {

--- a/lib/Tests/Fhp/Integration/Consors/ConsorsIntegrationTestBase.php
+++ b/lib/Tests/Fhp/Integration/Consors/ConsorsIntegrationTestBase.php
@@ -56,7 +56,6 @@ class ConsorsIntegrationTestBase extends FinTsTestCase
 
         $this->fints->selectTanMode(intval(static::TEST_TAN_MODE));
         $login = $this->fints->login();
-        $login->maybeThrowError();
         $this->assertAllMessagesSeen();
 
         $this->assertTrue($login->needsTan(), 'Expected a TAN request, but got none.');

--- a/lib/Tests/Fhp/Integration/DKB/DKBIntegrationTestBase.php
+++ b/lib/Tests/Fhp/Integration/DKB/DKBIntegrationTestBase.php
@@ -49,7 +49,7 @@ class DKBIntegrationTestBase extends FinTsTestCase
 
         $this->fints->selectTanMode(intval(static::TEST_TAN_MODE), 'SomePhone1');
         $login = $this->fints->login();
-        $login->ensureSuccess();
+        $login->ensureSuccess(); // No TAN required upon login.
         $this->assertAllMessagesSeen();
     }
 

--- a/lib/Tests/Fhp/Integration/DKB/GetStatementOfAccountTest.php
+++ b/lib/Tests/Fhp/Integration/DKB/GetStatementOfAccountTest.php
@@ -56,7 +56,6 @@ class GetStatementOfAccountTest extends DKBIntegrationTestBase
         $getStatement = GetStatementOfAccount::create($this->getTestAccount(),
             new \DateTime('2019-09-01'), new \DateTime('2019-09-22'), false);
         $this->fints->execute($getStatement);
-        $getStatement->maybeThrowError();
         return $getStatement;
     }
 

--- a/lib/Tests/Fhp/Integration/DKB/SendSEPATransferTest.php
+++ b/lib/Tests/Fhp/Integration/DKB/SendSEPATransferTest.php
@@ -97,7 +97,6 @@ class SendSEPATransferTest extends DKBIntegrationTestBase
     {
         $sendTransfer = SendSEPATransfer::create($this->getTestAccount(), static::PAIN_MESSAGE);
         $this->fints->execute($sendTransfer);
-        $sendTransfer->maybeThrowError();
         return $sendTransfer;
     }
 

--- a/lib/Tests/Fhp/Integration/IngDiba/GetStatementOfAccountTest.php
+++ b/lib/Tests/Fhp/Integration/IngDiba/GetStatementOfAccountTest.php
@@ -21,7 +21,6 @@ class GetStatementOfAccountTest extends IngDibaIntegrationTestBase
         $getStatement = GetStatementOfAccount::create($this->getTestAccount(),
             new \DateTime('2020-03-01'), new \DateTime('2020-03-25'), false);
         $this->fints->execute($getStatement);
-        $getStatement->maybeThrowError();
         $this->assertFalse($getStatement->needsTan());
         $this->assertEmpty($getStatement->getStatement()->getStatements());
     }

--- a/lib/Tests/Fhp/Integration/IngDiba/IngDibaIntegrationTestBase.php
+++ b/lib/Tests/Fhp/Integration/IngDiba/IngDibaIntegrationTestBase.php
@@ -43,7 +43,7 @@ class IngDibaIntegrationTestBase extends FinTsTestCase
 
         $this->fints->selectTanMode(new NoPsd2TanMode());
         $login = $this->fints->login();
-        $login->ensureSuccess();
+        $login->ensureSuccess(); // No TAN required upon login.
         $this->assertAllMessagesSeen();
     }
 

--- a/lib/Tests/Fhp/Integration/KSK/KSKIntegrationTestBase.php
+++ b/lib/Tests/Fhp/Integration/KSK/KSKIntegrationTestBase.php
@@ -45,7 +45,7 @@ class KSKIntegrationTestBase extends FinTsTestCase
 
         $this->fints->selectTanMode(intval(self::TEST_TAN_MODE));
         $login = $this->fints->login();
-        $login->ensureSuccess();
+        $login->ensureSuccess(); // No TAN required upon login.
         $this->assertAllMessagesSeen();
     }
 

--- a/lib/Tests/Fhp/Integration/Postbank/PostbankIntegrationTestBase.php
+++ b/lib/Tests/Fhp/Integration/Postbank/PostbankIntegrationTestBase.php
@@ -51,7 +51,7 @@ class PostbankIntegrationTestBase extends FinTsTestCase
 
         $this->fints->selectTanMode(intval(self::TEST_TAN_MODE), 'mT:PRIVATE__');
         $login = $this->fints->login();
-        $login->ensureSuccess();
+        $login->ensureSuccess(); // No TAN required upon login.
         $this->assertAllMessagesSeen();
     }
 


### PR DESCRIPTION
Fixes #282.

This also affects the behavior of login(). It takes the burden off the caller to remember and call ensureSuccess() separately. Though they still need to check for needsTan(), as per the new example code and documentation.

Also, stop wrapping ServerExceptions inside UnexpectedResponseExceptions within executeWeakDialogInitialization(), as this was just making it harder to access the ServerException's helpers like indicatesBadLoginData().