### PR TITLE
Fix Problem with [0] as Index in Sample

### DIFF
--- a/Samples/tanModesAndMedia.php
+++ b/Samples/tanModesAndMedia.php
@@ -25,7 +25,7 @@ print_r($tanModeNames);
 
 echo "Which one do you want to use? Index:\n";
 $tanModeIndex = trim(fgets(STDIN));
-if (empty($tanModeIndex) || !array_key_exists(intval($tanModeIndex), $tanModes)) {
+if (!is_numeric($tanModeIndex) || !array_key_exists(intval($tanModeIndex), $tanModes)) {
     echo 'Invalid index!';
     return;
 }
@@ -49,7 +49,7 @@ if ($tanMode->needsTanMedium()) {
 
     echo "Which one do you want to use? Index:\n";
     $tanMediumIndex = trim(fgets(STDIN));
-    if (empty($tanMediumIndex) || !array_key_exists(intval($tanMediumIndex), $tanMedia)) {
+    if (!is_numeric($tanMediumIndex) || !array_key_exists(intval($tanMediumIndex), $tanMedia)) {
         echo 'Invalid index!';
         return;
     }


### PR DESCRIPTION
An error occurred as soon as index "0" was selected as TAN Mode or TAN Medium.

I noticed the problem when I tried to select my first of two registered devices with TAN2Go (Mode 921) of DKB.

empty() is also false if the variable in question contains 0 or "0" (as string).