### PR TITLE
Remove per-action error handling

### DIFF
--- a/Samples/login.php
+++ b/Samples/login.php
@@ -2,6 +2,10 @@
 
 /** @noinspection PhpUnhandledExceptionInspection */
 
+use Fhp\CurlException;
+use Fhp\Protocol\ServerException;
+use Fhp\Protocol\UnexpectedResponseException;
+
 /**
  * SAMPLE - Creates a new FinTs instance (init.php) and makes sure its logged in.
  */
@@ -25,7 +29,7 @@ $fints = require_once 'init.php';
  * but it is also possible to interrupt the PHP execution entirely while asking for the TAN.
  *
  * @param \Fhp\BaseAction $action Some action that requires a TAN.
- * @throws \Exception See {@link FinTs::execute()} for details on the exception types.
+ * @throws CurlException|UnexpectedResponseException|ServerException See {@link FinTs::execute()} for details.
  */
 function handleTan(\Fhp\BaseAction $action)
 {

--- a/lib/Fhp/Action/GetBalance.php
+++ b/lib/Fhp/Action/GetBalance.php
@@ -67,11 +67,10 @@ class GetBalance extends BaseAction
 
     /**
      * @return HISAL[]
-     * @throws \Exception See {@link ensureSuccess()}.
      */
     public function getBalances()
     {
-        $this->ensureSuccess();
+        $this->ensureDone();
         return $this->response;
     }
 

--- a/lib/Fhp/Action/GetSEPAAccounts.php
+++ b/lib/Fhp/Action/GetSEPAAccounts.php
@@ -39,11 +39,10 @@ class GetSEPAAccounts extends BaseAction
 
     /**
      * @return SEPAAccount[]
-     * @throws \Exception See {@link ensureSuccess()}.
      */
     public function getAccounts()
     {
-        $this->ensureSuccess();
+        $this->ensureDone();
         return $this->accounts;
     }
 

--- a/lib/Fhp/Action/GetSEPADirectDebitParameters.php
+++ b/lib/Fhp/Action/GetSEPADirectDebitParameters.php
@@ -63,7 +63,7 @@ class GetSEPADirectDebitParameters extends BaseAction
      */
     public function getMinimalLeadTime(): ?MinimaleVorlaufzeitSEPALastschrift
     {
-        //$this->ensureSuccess();
+        //$this->ensureDone();
         return $this->minimalLeadTime;
     }
 }

--- a/lib/Fhp/Action/GetStatementOfAccount.php
+++ b/lib/Fhp/Action/GetStatementOfAccount.php
@@ -99,32 +99,29 @@ class GetStatementOfAccount extends BaseAction
 
     /**
      * @return string The raw MT940 data received from the server.
-     * @throws \Exception See {@link ensureSuccess()}.
      * @noinspection PhpUnused
      */
     public function getRawMT940(): string
     {
-        $this->ensureSuccess();
+        $this->ensureDone();
         return $this->rawMT940;
     }
 
     /**
      * @return array The parsed MT940 data.
-     * @throws \Exception See {@link ensureSuccess()}.
      */
     public function getParsedMT940(): array
     {
-        $this->ensureSuccess();
+        $this->ensureDone();
         return $this->parsedMT940;
     }
 
     /**
      * @return StatementOfAccount
-     * @throws \Exception See {@link ensureSuccess()}.
      */
     public function getStatement()
     {
-        $this->ensureSuccess();
+        $this->ensureDone();
         return $this->statement;
     }
 

--- a/lib/Fhp/Action/GetStatementOfAccountXML.php
+++ b/lib/Fhp/Action/GetStatementOfAccountXML.php
@@ -86,11 +86,10 @@ class GetStatementOfAccountXML extends BaseAction
 
     /**
      * @return string[] The XML-Document(s) received from the bank, or empty array if the statement is unavailable/empty.
-     * @throws \Exception See {@link ensureSuccess()}.
      */
     public function getBookedXML(): array
     {
-        $this->ensureSuccess();
+        $this->ensureDone();
         return $this->xml;
     }
 

--- a/lib/Fhp/Protocol/GetTanMedia.php
+++ b/lib/Fhp/Protocol/GetTanMedia.php
@@ -43,11 +43,10 @@ class GetTanMedia extends BaseAction
 
     /**
      * @return TanMediumListe[]|null
-     * @throws \Exception See {@link ensureSuccess()}.
      */
     public function getTanMedia(): ?array
     {
-        $this->ensureSuccess();
+        $this->ensureDone();
         return $this->tanMedia;
     }
 }

--- a/lib/Fhp/Protocol/ServerException.php
+++ b/lib/Fhp/Protocol/ServerException.php
@@ -46,32 +46,6 @@ class ServerException extends \Exception
     }
 
     /**
-     * Takes all errors and warnings that pertain to any of the given $referenceSegments, puts them in a new
-     * ServerException instance (if any) and removes them from this instance.
-     * @param int[] $referenceNumbers The numbers of thte reference segments.
-     * @return ServerException|null The part of the exception that pertains to the given reference segments, or null if
-     *     none of the errors refer to them.
-     */
-    public function extractErrorsForReference(array $referenceNumbers): ?ServerException
-    {
-        if (count($referenceNumbers) === 0) {
-            return null;
-        }
-        $errors = array_filter($this->errors, function ($error) use ($referenceNumbers) {
-            return in_array($error->referenceSegment, $referenceNumbers);
-        });
-        if (count($errors) === 0) {
-            return null;
-        }
-        $warnings = array_filter($this->warnings, function ($error) use ($referenceNumbers) {
-            return in_array($error->referenceSegment, $referenceNumbers);
-        });
-        $this->errors = array_diff($this->errors, $errors);
-        $this->warnings = array_diff($this->warnings, $warnings);
-        return new ServerException($errors, $warnings, $this->requestSegments, $this->request, $this->response);
-    }
-
-    /**
      * @return Rueckmeldung[]
      */
     public function getErrors()
@@ -121,21 +95,6 @@ class ServerException extends \Exception
             }
         }
         return false;
-    }
-
-    /**
-     * @param int $code A Rueckmeldungscode to look for.
-     * @return Rueckmeldung|null The first matching Rueckmeldung, which will have been removed from this instance, or
-     *     null if no match was found.
-     */
-    public function extractError($code)
-    {
-        foreach ($this->errors as $index => $error) {
-            if ($error->rueckmeldungscode === $code) {
-                return array_splice($this->errors, $index, 1)[0];
-            }
-        }
-        return null;
     }
 
     /**

--- a/lib/Tests/Fhp/Integration/DKB/DKBIntegrationTestBase.php
+++ b/lib/Tests/Fhp/Integration/DKB/DKBIntegrationTestBase.php
@@ -49,7 +49,7 @@ class DKBIntegrationTestBase extends FinTsTestCase
 
         $this->fints->selectTanMode(intval(static::TEST_TAN_MODE), 'SomePhone1');
         $login = $this->fints->login();
-        $login->ensureSuccess(); // No TAN required upon login.
+        $login->ensureDone(); // No TAN required upon login.
         $this->assertAllMessagesSeen();
     }
 

--- a/lib/Tests/Fhp/Integration/DKB/GetStatementOfAccountTest.php
+++ b/lib/Tests/Fhp/Integration/DKB/GetStatementOfAccountTest.php
@@ -132,7 +132,7 @@ class GetStatementOfAccountTest extends DKBIntegrationTestBase
     }
 
     /**
-     * @throws \Exception
+     * @throws \Throwable
      */
     private function checkResult(StatementOfAccount $statement)
     {

--- a/lib/Tests/Fhp/Integration/DKB/SendSEPATransferTest.php
+++ b/lib/Tests/Fhp/Integration/DKB/SendSEPATransferTest.php
@@ -108,7 +108,7 @@ class SendSEPATransferTest extends DKBIntegrationTestBase
         $this->expectMessage(static::SEND_TAN_REQUEST, static::SEND_TAN_RESPONSE);
         $this->fints->submitTan($sendTransfer, '666555');
         $this->assertFalse($sendTransfer->needsTan());
-        $this->assertTrue($sendTransfer->isSuccess());
+        $this->assertTrue($sendTransfer->isDone());
     }
 
     /**

--- a/lib/Tests/Fhp/Integration/IngDiba/IngDibaIntegrationTestBase.php
+++ b/lib/Tests/Fhp/Integration/IngDiba/IngDibaIntegrationTestBase.php
@@ -43,7 +43,7 @@ class IngDibaIntegrationTestBase extends FinTsTestCase
 
         $this->fints->selectTanMode(new NoPsd2TanMode());
         $login = $this->fints->login();
-        $login->ensureSuccess(); // No TAN required upon login.
+        $login->ensureDone(); // No TAN required upon login.
         $this->assertAllMessagesSeen();
     }
 

--- a/lib/Tests/Fhp/Integration/KSK/KSKIntegrationTestBase.php
+++ b/lib/Tests/Fhp/Integration/KSK/KSKIntegrationTestBase.php
@@ -45,7 +45,7 @@ class KSKIntegrationTestBase extends FinTsTestCase
 
         $this->fints->selectTanMode(intval(self::TEST_TAN_MODE));
         $login = $this->fints->login();
-        $login->ensureSuccess(); // No TAN required upon login.
+        $login->ensureDone(); // No TAN required upon login.
         $this->assertAllMessagesSeen();
     }
 

--- a/lib/Tests/Fhp/Integration/Postbank/PostbankIntegrationTestBase.php
+++ b/lib/Tests/Fhp/Integration/Postbank/PostbankIntegrationTestBase.php
@@ -51,7 +51,7 @@ class PostbankIntegrationTestBase extends FinTsTestCase
 
         $this->fints->selectTanMode(intval(self::TEST_TAN_MODE), 'mT:PRIVATE__');
         $login = $this->fints->login();
-        $login->ensureSuccess(); // No TAN required upon login.
+        $login->ensureDone(); // No TAN required upon login.
         $this->assertAllMessagesSeen();
     }
 


### PR DESCRIPTION
Summary: This is a breaking API change for the new library implementation (which hasn't been released yet). isSuccess() is now isDone() and ensureSuccess() is now ensureDone(). Other status indicators on BaseAction are removed, as they are now unnecessary (an action is either done or not, execute() throws all the errors). See #282 for discussion.

In practice, most library users will only want to execute() one action at a time, the library currently only supports one action anyway, and many banks might only support this too. This makes the distinction between per-action errors (where one action could fail and another could succeed within the same request) and request-level errors (where there was an issue with the overall request and none of the actions were even attempted) less important. Previously (see #289), the execute() and submitTan() functions were changed to immediately throw all action-level errors too. This now makes it unnecessary to store errors in the BaseAction, which simplifies a lot of code in the library. It also makes the library easier to use because no generic \Exception isn't thrown anywhere anymore.

- Remove BaseAction:$error. Remove the distinction between "available" and "success", just call it "done".
- Remove @throws \Exception from ensureDone() and from all action getters, as the only possible exceptions that these can still throw are \RuntimeExceptions.
- Remove the FinTs::sendRequestForAction() and ServerException::extractErrorsForReference() helper functions that were needed to split the exceptions apart and assign them to the action. This also simplifies some catch blocks elsewhere in the FinTs class.