### PR TITLE
Fix parsing of segments with required but empty DEGs where all subfields are optional

### DIFF
--- a/lib/Fhp/Segment/Common/Sdo.php
+++ b/lib/Fhp/Segment/Common/Sdo.php
@@ -54,4 +54,17 @@ class Sdo extends BaseDeg
     {
         return \DateTime::createFromFormat('Ymd His', $this->datum . ' ' . ($this->uhrzeit ?? '000000'));
     }
+
+    public static function create(float $amount, string $currency, \DateTime $timestamp)
+    {
+        $result = new Sdo();
+        $result->sollHabenKennzeichen = $amount < 0 ? self::DEBIT : self::CREDIT;
+        $result->betrag = Btg::create($amount, $currency);
+        $result->datum = $timestamp->format('Ymd');
+        $result->uhrzeit = $timestamp->format('His');
+        if ($result->uhrzeit == '000000') {
+            $result->uhrzeit = null;
+        }
+        return $result;
+    }
 }

--- a/lib/Fhp/Segment/DegDescriptor.php
+++ b/lib/Fhp/Segment/DegDescriptor.php
@@ -3,7 +3,7 @@
 namespace Fhp\Segment;
 
 /**
- * Contains meta information about a data elemnt group, i.e. anything that can be statically known about a sub-class of
+ * Contains meta information about a data element group, i.e. anything that can be statically known about a sub-class of
  * {@link BaseDeg} through reflection.
  */
 class DegDescriptor extends BaseDescriptor

--- a/lib/Tests/Fhp/Segment/HISALTest.php
+++ b/lib/Tests/Fhp/Segment/HISALTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Tests\Fhp\Segment;
+
+use Fhp\Segment\Common\Kti;
+use Fhp\Segment\Common\Sdo;
+use Fhp\Segment\SAL\HISALv7;
+
+class HISALTest extends \PHPUnit\Framework\TestCase
+{
+    const REAL_DKB_RESPONSE = "HITAB:1:4:3+0+A:1:::::::::::pushtan::::::::+A:1:::::::::::SomePhone1::::::::'";
+
+    public function test_empty_kti()
+    {
+        $hisal = HISALv7::createEmpty();
+        $hisal->segmentkopf->segmentnummer = 11;
+        $hisal->kontoverbindungInternational = new Kti();  // Note that none of its fields are filled.
+        $hisal->kontoproduktbezeichnung = 'Test';
+        $hisal->kontowaehrung = 'EUR';
+        $hisal->gebuchterSaldo = Sdo::create(42, 'EUR', \DateTime::createFromFormat('Ymd His', '20200102 030405'));
+
+        $serialized = $hisal->serialize();
+        $this->assertEquals("HISAL:11:7++Test+EUR+C:42,:EUR:20200102:030405'", $serialized);
+        $parsed = HISALv7::parse($serialized);
+        $this->assertEquals($parsed, $hisal);
+    }
+}


### PR DESCRIPTION
Fixes #304

Not sure if a similar fix is necessary for the DEG parsing function, though probably not because DEG field delimiters need to be present even for empty subfields for the indices of subsequent fields to match. So probably the existing $allowEmpy logic in the DEG parsing function handles the same case there, and thus this fix is only necessary on the segment level.