### PR TITLE
Textschlüsselergänzung hinzufügen

### DIFF
--- a/lib/Fhp/Model/StatementOfAccount/StatementOfAccount.php
+++ b/lib/Fhp/Model/StatementOfAccount/StatementOfAccount.php
@@ -108,6 +108,7 @@ class StatementOfAccount
                     $transaction->setName($trx['description']['name']);
                     $transaction->setBooked($trx['booked']);
                     $transaction->setPN($trx['description']['primanoten_nr']);
+                    $transaction->setTextKeyAddition($trx['description']['text_key_addition']);
                     $statementModel->addTransaction($transaction);
                 }
             }

--- a/lib/Fhp/Model/StatementOfAccount/Transaction.php
+++ b/lib/Fhp/Model/StatementOfAccount/Transaction.php
@@ -79,6 +79,11 @@ class Transaction
     protected $pn;
 
     /**
+     * @var int
+     */
+    protected $textKeyAddition;
+
+    /**
      * Get booking date.
      *
      * @deprecated Use getBookingDate() instead
@@ -394,6 +399,26 @@ class Transaction
     public function setPN($nr)
     {
         $this->pn = intval($nr);
+        return $this;
+    }
+
+    /**
+     * Get text key addition
+     */
+    public function getTextKeyAddition(): int
+    {
+        return $this->textKeyAddition;
+    }
+
+    /**
+     * Set text key addition
+     *
+     * @param int|mixed $textKeyAddition Will be parsed to an int.
+     * @return $this
+     */
+    public function setTextKeyAddition($textKeyAddition)
+    {
+        $this->textKeyAddition = intval($textKeyAddition);
         return $this;
     }
 }


### PR DESCRIPTION
Für eine RLS enthält die Textschlüsselergänzung den Rückgabegrund, für die weitere Auswertung kann es sinnvoll sein darauf zugreifen zu können.