### PR TITLE
remove check for empty string

### DIFF
--- a/lib/Fhp/MT940/MT940.php
+++ b/lib/Fhp/MT940/MT940.php
@@ -165,9 +165,7 @@ class MT940
                 } else {
                     $description2 .= $m[2];
                 }
-                if (!empty($m[2])) {
-                    $descriptionLines[] = $m[2];
-                }
+                $descriptionLines[] = $m[2];
             }
             $prepared[$index] = $m[2];
         }


### PR DESCRIPTION
Der Test auf einen leeren String ergibt an dieser Stelle nicht wirklich Sinn.
Nach der Definition des Regex oben enthält die zweite Matching-Group bereits einen nicht leeren String (ein oder mehr Zeichen).
Der einzige Fall bei dem dieser Test fälschlicherweise fehlschlägt ist bei dem String "0" (`empty("0")` ist `true`)
Das in einigen Fällen dazu, dass z.B. bei einer EREF die mit 0 Endet die 0 abgeschnitten wird.