### PR TITLE
Various changes to prepare for HKTANv7 and decoupled strong authentication

### DIFF
--- a/lib/Fhp/FinTs.php
+++ b/lib/Fhp/FinTs.php
@@ -23,6 +23,7 @@ use Fhp\Segment\HKEND\HKENDv1;
 use Fhp\Segment\HKIDN\HKIDNv2;
 use Fhp\Segment\HKVVB\HKVVBv3;
 use Fhp\Segment\TAN\HITANv6;
+use Fhp\Segment\TAN\HKTAN;
 use Fhp\Segment\TAN\HKTANFactory;
 use Fhp\Segment\TAN\HKTANv6;
 use Fhp\Segment\TAN\VerfahrensparameterZweiSchrittVerfahrenV6;
@@ -311,7 +312,7 @@ class FinTs
         /** @var HITANv6 $hitan */
         $hitan = $response->findSegment(HITANv6::class);
         if ($hitan !== null && $hitan->auftragsreferenz !== HITANv6::DUMMY_REFERENCE) {
-            if ($hitan->tanProzess !== 4) {
+            if ($hitan->tanProzess !== HKTAN::TAN_PROZESS_4) {
                 throw new UnexpectedResponseException("Unsupported TAN request type $hitan->tanProzess");
             }
             if ($this->bpd === null || $this->kundensystemId === null) {
@@ -377,7 +378,7 @@ class FinTs
         if ($hitan === null) {
             throw new UnexpectedResponseException('HITAN missing after submitting TAN');
         }
-        if ($hitan->tanProzess !== 2 || $hitan->auftragsreferenz !== $tanRequest->getProcessId()) {
+        if ($hitan->tanProzess !== HKTAN::TAN_PROZESS_2 || $hitan->auftragsreferenz !== $tanRequest->getProcessId()) {
             throw new UnexpectedResponseException("Bank has not accepted TAN: $hitan");
         }
         $action->setTanRequest(null);
@@ -629,7 +630,7 @@ class FinTs
             if (!($this->selectedTanMode instanceof VerfahrensparameterZweiSchrittVerfahrenV6)) {
                 throw new UnsupportedException('Only supports VerfahrensparameterZweiSchrittVerfahrenV6');
             }
-            if ($this->selectedTanMode->tanProzess !== VerfahrensparameterZweiSchrittVerfahrenV6::PROZESSVARIANTE_2) {
+            if ($this->selectedTanMode->tanProzess !== HKTAN::TAN_PROZESS_2) {
                 throw new UnsupportedException('Only supports Prozessvariante 2');
             }
 

--- a/lib/Fhp/Model/NoPsd2TanMode.php
+++ b/lib/Fhp/Model/NoPsd2TanMode.php
@@ -2,6 +2,8 @@
 
 namespace Fhp\Model;
 
+use Fhp\Segment\TAN\HKTAN;
+
 /**
  * This is a placeholder used instead of a real {@link TanMode} in order to signal that the bank's HBCI interface
  * supports no strong authentication whatsoever and thus also no TAN modes. While it should still support the
@@ -78,5 +80,10 @@ final class NoPsd2TanMode implements TanMode
     public function getAntwortHhdUcErforderlich(): bool
     {
         return false;
+    }
+
+    public function createHKTAN(): HKTAN
+    {
+        throw new \AssertionError('HKTAN should not be needed when the bank does not support PSD2');
     }
 }

--- a/lib/Fhp/Model/NoPsd2TanMode.php
+++ b/lib/Fhp/Model/NoPsd2TanMode.php
@@ -28,6 +28,11 @@ final class NoPsd2TanMode implements TanMode
         return 'No PSD2/TANs supported';
     }
 
+    public function isProzessvariante2(): bool
+    {
+        return false;
+    }
+
     /** {@inheritdoc} */
     public function getChallengeLabel(): string
     {

--- a/lib/Fhp/Model/TanMode.php
+++ b/lib/Fhp/Model/TanMode.php
@@ -38,6 +38,13 @@ interface TanMode
     public function getName(): string;
 
     /**
+     * @return bool True if this TAN mode can be used with Prozessvariante 2. Since that's the only mode currently
+     *     implemented in this library, you likely want to filter out any TAN modes that return false here, though those
+     *     are rare in practice anyway.
+     */
+    public function isProzessvariante2(): bool;
+
+    /**
      * @return string A user-readable label for the text field that displays the challenge to the user.
      */
     public function getChallengeLabel(): string;

--- a/lib/Fhp/Model/TanMode.php
+++ b/lib/Fhp/Model/TanMode.php
@@ -2,6 +2,9 @@
 
 namespace Fhp\Model;
 
+use Fhp\Segment\BaseSegment;
+use Fhp\Segment\TAN\HKTAN;
+
 /**
  * For two-step authentication, users need to enter a TAN, which can be obtained in various ways (SMS, TAN generator
  * device, and so on). Users regularly have multiple ways to obtain a TAN even for a single bank, so they will need to
@@ -75,4 +78,10 @@ interface TanMode
 
     /** @return bool */
     public function getAntwortHhdUcErforderlich(): bool;
+
+    /**
+     * This function is for internal use by the library implementation.
+     * @return HKTAN&BaseSegment A newly created segment.
+     */
+    public function createHKTAN(): HKTAN;
 }

--- a/lib/Fhp/Model/TanRequest.php
+++ b/lib/Fhp/Model/TanRequest.php
@@ -17,18 +17,19 @@ interface TanRequest
     public function getProcessId(): string;
 
     /**
-     * @return string A challenge to be displayed to the user.
+     * @return ?string A challenge to be displayed to the user.
      */
-    public function getChallenge(): string;
+    public function getChallenge(): ?string;
 
     /**
-     * @return string|null Possibly the name of the {@link TanMedium} to be used. If present, this should be displayed
+     * @return ?string Possibly the name of the {@link TanMedium} to be used. If present, this should be displayed
      *     to the user, so that they know what to do.
      */
     public function getTanMediumName(): ?string;
 
     /**
-     * @return Bin|null An additional binary challenge payload. Used to receive the PhotoTan/ChipTan image. Use TanRequestChallengeImage to parse the binary.
+     * @return ?Bin An additional binary challenge payload. Used to receive the PhotoTan/ChipTan image. Use
+     *     {@link TanRequestChallengeImage} to parse the payload.
      */
     public function getChallengeHhdUc(): ?Bin;
 }

--- a/lib/Fhp/Protocol/BPD.php
+++ b/lib/Fhp/Protocol/BPD.php
@@ -8,7 +8,7 @@ use Fhp\Segment\BaseSegment;
 use Fhp\Segment\HIBPA\HIBPAv3;
 use Fhp\Segment\HIPINS\HIPINSv1;
 use Fhp\Segment\SegmentInterface;
-use Fhp\Segment\TAN\HITANSv6;
+use Fhp\Segment\TAN\HITANS;
 
 /**
  * Segmentfolge: Bankparameterdaten (Version 3)
@@ -174,11 +174,11 @@ class BPD
 
         // Extract all TanModes from HIPINS.
         if ($bpd->supportsPsd2()) {
-            /** @var HITANSv6 $hitans */
+            /** @var HITANS $hitans */
             $hitans = $bpd->requireLatestSupportedParameters('HITANS');
-            $tanParams = $hitans->parameterZweiSchrittTanEinreichung;
-            $bpd->singleStepTanModeAllowed = $tanParams->einschrittVerfahrenErlaubt;
-            foreach ($tanParams->verfahrensparameterZweiSchrittVerfahren as $verfahren) {
+            $tanParams = $hitans->getParameterZweiSchrittTanEinreichung();
+            $bpd->singleStepTanModeAllowed = $tanParams->isEinschrittVerfahrenErlaubt();
+            foreach ($tanParams->getVerfahrensparameterZweiSchrittVerfahren() as $verfahren) {
                 $bpd->allTanModes[$verfahren->getId()] = $verfahren;
             }
         }

--- a/lib/Fhp/Protocol/DialogInitialization.php
+++ b/lib/Fhp/Protocol/DialogInitialization.php
@@ -11,7 +11,7 @@ use Fhp\Segment\HISYN\HISYNv4;
 use Fhp\Segment\HKIDN\HKIDNv2;
 use Fhp\Segment\HKSYN\HKSYNv3;
 use Fhp\Segment\HKVVB\HKVVBv3;
-use Fhp\Segment\TAN\HKTANv6;
+use Fhp\Segment\TAN\HKTANFactory;
 
 /**
  * Initializes a FinTs dialog. The dialog initialization message is usually the first message that should be sent over
@@ -148,7 +148,8 @@ class DialogInitialization extends BaseAction
             HKVVBv3::create($this->options, $bpd, $upd),
         ];
         if ($this->tanMode !== null) {
-            $request[] = HKTANv6::createProzessvariante2Step1($this->tanMode, $this->tanMedium, $this->hktanRef ?? 'HKIDN');
+            $request[] = HKTANFactory::createProzessvariante2Step1(
+                $this->tanMode, $this->tanMedium, $this->hktanRef ?? 'HKIDN');
         }
 
         if ($this->kundensystemId === null) {

--- a/lib/Fhp/Protocol/TanRequiredException.php
+++ b/lib/Fhp/Protocol/TanRequiredException.php
@@ -9,7 +9,7 @@ use Fhp\Model\TanRequest;
  */
 class TanRequiredException extends \RuntimeException
 {
-    /** @var TanRequest $hitan */
+    /** @var TanRequest */
     private $tanRequest;
 
     public function __construct(TanRequest $tanRequest)

--- a/lib/Fhp/Segment/CAZ/HKCAZv1.php
+++ b/lib/Fhp/Segment/CAZ/HKCAZv1.php
@@ -19,13 +19,13 @@ class HKCAZv1 extends BaseSegment implements Paginateable
     /** @var UnterstuetzteCamtMessages */
     public $unterstuetzteCamtMessages;
 
-    /** @var bool Only allowed if HIKAZS $alleKontenErlaubt says so. */
+    /** @var bool Only allowed if {@link ParameterKontoumsaetzeCamt::$alleKontenErlaubt} says so. */
     public $alleKonten;
     /** @var string|null JJJJMMTT gemäß ISO 8601 */
     public $vonDatum;
     /** @var string|null JJJJMMTT gemäß ISO 8601 */
     public $bisDatum;
-    /** @var int|null Only allowed if HIKAZS $eingabeAnzahlEintraegeErlaubt says so. */
+    /** @var int|null Only allowed if {@link ParameterKontoumsaetzeCamt::$eingabeAnzahlEintraegeErlaubt} says so. */
     public $maximaleAnzahlEintraege;
     /** @var string|null Max length: 35 */
     public $aufsetzpunkt;

--- a/lib/Fhp/Segment/CAZ/ParameterKontoumsaetzeCamt.php
+++ b/lib/Fhp/Segment/CAZ/ParameterKontoumsaetzeCamt.php
@@ -12,7 +12,7 @@ use Fhp\Segment\KAZ\ParameterKontoumsaetzeV2;
  */
 class ParameterKontoumsaetzeCamt extends ParameterKontoumsaetzeV2
 {
-    /** @var UnterstuetzteCamtMessages $unterstuetzteCamtMessages */
+    /** @var UnterstuetzteCamtMessages */
     public $unterstuetzteCamtMessages;
 
     public function getUnterstuetzteCamtMessages(): UnterstuetzteCamtMessages

--- a/lib/Fhp/Segment/HNVSK/SicherheitsidentifikationDetailsV2.php
+++ b/lib/Fhp/Segment/HNVSK/SicherheitsidentifikationDetailsV2.php
@@ -20,7 +20,7 @@ class SicherheitsidentifikationDetailsV2 extends BaseDeg
     public $bezeichnerFuerSicherheitspartei = 1; // Unless we receive another value that overwrites this one, we're sending.
     /** @var string|null Only allowed and mandatory for Chip-card, so this library does not support it. */
     public $cid = null;
-    /** @var string|null Must be set to the $kundensystemId, or '0' during synchronization. */
+    /** @var string|null Must be set to the {@link FinTs::$kundensystemId}, or '0' during synchronization. */
     public $identifizierungDerPartei;
 
     /**

--- a/lib/Fhp/Segment/KAZ/HKKAZv4.php
+++ b/lib/Fhp/Segment/KAZ/HKKAZv4.php
@@ -22,7 +22,7 @@ class HKKAZv4 extends BaseSegment implements Paginateable
     public $vonDatum;
     /** @var string|null JJJJMMTT gemäß ISO 8601 */
     public $bisDatum;
-    /** @var int|null Only allowed if HIKAZS $eingabeAnzahlEintraegeErlaubt says so. */
+    /** @var int|null Only allowed if {@link ParameterKontoumsaetzeV1::$eingabeAnzahlEintraegeErlaubt} says so. */
     public $maximaleAnzahlEintraege;
     /** @var string|null Max length: 35 */
     public $aufsetzpunkt;

--- a/lib/Fhp/Segment/KAZ/HKKAZv5.php
+++ b/lib/Fhp/Segment/KAZ/HKKAZv5.php
@@ -16,13 +16,13 @@ class HKKAZv5 extends BaseSegment implements Paginateable
 {
     /** @var \Fhp\Segment\Common\KtvV3 */
     public $kontoverbindungAuftraggeber;
-    /** @var bool Only allowed if HIKAZS $alleKontenErlaubt says so. */
+    /** @var bool Only allowed if {@link ParameterKontoumsaetzeV2::$alleKontenErlaubt} says so. */
     public $alleKonten;
     /** @var string|null JJJJMMTT gemäß ISO 8601 */
     public $vonDatum;
     /** @var string|null JJJJMMTT gemäß ISO 8601 */
     public $bisDatum;
-    /** @var int|null Only allowed if HIKAZS $eingabeAnzahlEintraegeErlaubt says so. */
+    /** @var int|null Only allowed if {@link ParameterKontoumsaetzeV2::$eingabeAnzahlEintraegeErlaubt} says so. */
     public $maximaleAnzahlEintraege;
     /** @var string|null Max length: 35 */
     public $aufsetzpunkt;

--- a/lib/Fhp/Segment/KAZ/HKKAZv6.php
+++ b/lib/Fhp/Segment/KAZ/HKKAZv6.php
@@ -15,13 +15,13 @@ class HKKAZv6 extends BaseSegment implements Paginateable
 {
     /** @var \Fhp\Segment\Common\KtvV3 */
     public $kontoverbindungAuftraggeber;
-    /** @var bool Only allowed if HIKAZS $alleKontenErlaubt says so. */
+    /** @var bool Only allowed if {@link ParameterKontoumsaetzeV2::$alleKontenErlaubt} says so. */
     public $alleKonten;
     /** @var string|null JJJJMMTT gemäß ISO 8601 */
     public $vonDatum;
     /** @var string|null JJJJMMTT gemäß ISO 8601 */
     public $bisDatum;
-    /** @var int|null Only allowed if HIKAZS $eingabeAnzahlEintraegeErlaubt says so. */
+    /** @var int|null Only allowed if {@link ParameterKontoumsaetzeV2::$eingabeAnzahlEintraegeErlaubt} says so. */
     public $maximaleAnzahlEintraege;
     /** @var string|null Max length: 35 */
     public $aufsetzpunkt;

--- a/lib/Fhp/Segment/KAZ/HKKAZv7.php
+++ b/lib/Fhp/Segment/KAZ/HKKAZv7.php
@@ -15,13 +15,13 @@ class HKKAZv7 extends BaseSegment implements Paginateable
 {
     /** @var \Fhp\Segment\Common\Kti */
     public $kontoverbindungInternational;
-    /** @var bool Only allowed if HIKAZS $alleKontenErlaubt says so. */
+    /** @var bool Only allowed if {@link ParameterKontoumsaetzeV2::$alleKontenErlaubt} says so. */
     public $alleKonten;
     /** @var string|null JJJJMMTT gemäß ISO 8601 */
     public $vonDatum;
     /** @var string|null JJJJMMTT gemäß ISO 8601 */
     public $bisDatum;
-    /** @var int|null Only allowed if HIKAZS $eingabeAnzahlEintraegeErlaubt says so. */
+    /** @var int|null Only allowed if {@link ParameterKontoumsaetzeV2::$eingabeAnzahlEintraegeErlaubt} says so. */
     public $maximaleAnzahlEintraege;
     /** @var string|null Max length: 35 */
     public $aufsetzpunkt;

--- a/lib/Fhp/Segment/SAL/HISALv6.php
+++ b/lib/Fhp/Segment/SAL/HISALv6.php
@@ -31,7 +31,7 @@ class HISALv6 extends BaseSegment implements HISAL
     public $verfuegbarerBetrag;
     /** @var \Fhp\Segment\Common\Btg|null */
     public $bereitsVerfuegterBetrag;
-    /** @var \Fhp\Segment\Common\Btg|null This field can only be filled if $verfuegbarerBetrag is zero. */
+    /** @var \Fhp\Segment\Common\Btg|null This field can only be filled if {@link HISALv6::$verfuegbarerBetrag} is zero. */
     public $ueberziehung;
     /** @var \Fhp\Segment\Common\Tsp|null */
     public $buchungszeitpunkt;

--- a/lib/Fhp/Segment/SAL/HISALv7.php
+++ b/lib/Fhp/Segment/SAL/HISALv7.php
@@ -31,7 +31,7 @@ class HISALv7 extends BaseSegment implements HISAL
     public $verfuegbarerBetrag;
     /** @var \Fhp\Segment\Common\Btg|null */
     public $bereitsVerfuegterBetrag;
-    /** @var \Fhp\Segment\Common\Btg|null This field can only be filled if $verfuegbarerBetrag is zero. */
+    /** @var \Fhp\Segment\Common\Btg|null This field can only be filled if {@link HISALv7::$verfuegbarerBetrag} is zero. */
     public $ueberziehung;
     /** @var \Fhp\Segment\Common\Tsp|null */
     public $buchungszeitpunkt;

--- a/lib/Fhp/Segment/SAL/HKSALv4.php
+++ b/lib/Fhp/Segment/SAL/HKSALv4.php
@@ -20,7 +20,7 @@ class HKSALv4 extends BaseSegment implements Paginateable
     public $alleKonten;
     /** @var string|null */
     public $kontowaehrung;
-    /** @var int|null Only allowed if HISALS $eingabeAnzahlEintraegeErlaubt says so. */
+    /** @var int|null */
     public $maximaleAnzahlEintraege;
     /** @var string|null Max length: 35 */
     public $aufsetzpunkt;

--- a/lib/Fhp/Segment/SPA/HKSPAv2.php
+++ b/lib/Fhp/Segment/SPA/HKSPAv2.php
@@ -18,7 +18,7 @@ class HKSPAv2 extends BaseSegment implements Paginateable
      * @var \Fhp\Segment\Common\KtvV3[]|null @Max(999)
      */
     public $kontoverbindung;
-    /** @var int|null Only allowed if HISPAS $eingabeAnzahlEintraegeErlaubt allows it. */
+    /** @var int|null Only allowed if {@link ParameterSepaKontoverbindungAnfordernV2::$eingabeAnzahlEintraegeErlaubt} says so. */
     public $maximaleAnzahlEintraege;
     /** @var string|null For pagination. */
     public $aufsetzpunkt;

--- a/lib/Fhp/Segment/TAB/TanMediumListeV4.php
+++ b/lib/Fhp/Segment/TAB/TanMediumListeV4.php
@@ -29,27 +29,27 @@ class TanMediumListeV4 extends BaseDeg implements TanMediumListe
      * @var int
      */
     public $status;
-    /** @var string|null Only for $tanMediumKlasse=='G' */
+    /** @var string|null Only for tanMediumKlasse=='G' */
     public $kartennummer;
-    /** @var string|null Only for $tanMediumKlasse=='G' */
+    /** @var string|null Only for tanMediumKlasse=='G' */
     public $kartenfolgenummer;
-    /** @var int|null Only and optional for $tanMediumKlasse=='G' and if BPD allows it */
+    /** @var int|null Only and optional for tanMediumKlasse=='G' and if BPD allows it */
     public $kartenart;
-    /** @var \Fhp\Segment\Common\KtvV3|null Only and optional for $tanMediumKlasse=='G' */
+    /** @var \Fhp\Segment\Common\KtvV3|null Only and optional for tanMediumKlasse=='G' */
     public $kontoverbindungAuftraggeber;
-    /** @var string|null JJJJMMTT gemäß ISO 8601 Only and optional for $tanMediumKlasse=='G' */
+    /** @var string|null JJJJMMTT gemäß ISO 8601 Only and optional for tanMediumKlasse=='G' */
     public $gueltigAb;
-    /** @var string|null JJJJMMTT gemäß ISO 8601 Only and optional for $tanMediumKlasse=='G' */
+    /** @var string|null JJJJMMTT gemäß ISO 8601 Only and optional for tanMediumKlasse=='G' */
     public $gueltigBis;
-    /** @var string|null Only for $tanMediumKlasse=='L' */
+    /** @var string|null Only for tanMediumKlasse=='L' */
     public $tanListennumer;
-    /** @var string|null Must for $tanMediumKlasse=='M', optional otherwise. Max length: 32 */
+    /** @var string|null Must for tanMediumKlasse=='M', optional otherwise. Max length: 32 */
     public $bezeichnungDesTanMediums;
-    /** @var string|null Only and optional for $tanMediumKlasse=='M' */
+    /** @var string|null Only and optional for tanMediumKlasse=='M' */
     public $mobiltelefonnummerVerschleiert;
-    /** @var string|null Only and optional for $tanMediumKlasse=='M' */
+    /** @var string|null Only and optional for tanMediumKlasse=='M' */
     public $mobiltelefonnummer;
-    /** @var \Fhp\Segment\Common\Kti|null Only and optional for $tanMediumKlasse=='M' */
+    /** @var \Fhp\Segment\Common\Kti|null Only and optional for tanMediumKlasse=='M' */
     public $smsAbbuchungskonto;
     /** @var int|null */
     public $anzahlFreieTans;

--- a/lib/Fhp/Segment/TAB/TanMediumListeV5.php
+++ b/lib/Fhp/Segment/TAB/TanMediumListeV5.php
@@ -30,29 +30,29 @@ class TanMediumListeV5 extends BaseDeg implements TanMediumListe
      * @var int
      */
     public $status;
-    /** @var int|null Only for $tanMediumKlasse=='B' */
+    /** @var int|null Only for tanMediumKlasse=='B' */
     public $sicherheitsfunktion;
-    /** @var string|null Only for $tanMediumKlasse=='G' */
+    /** @var string|null Only for tanMediumKlasse=='G' */
     public $kartennummer;
-    /** @var string|null Only for $tanMediumKlasse=='G' */
+    /** @var string|null Only for tanMediumKlasse=='G' */
     public $kartenfolgenummer;
-    /** @var int|null Only and optional for $tanMediumKlasse=='G' and if BPD allows it */
+    /** @var int|null Only and optional for tanMediumKlasse=='G' and if BPD allows it */
     public $kartenart;
-    /** @var \Fhp\Segment\Common\KtvV3|null Only and optional for $tanMediumKlasse=='G' */
+    /** @var \Fhp\Segment\Common\KtvV3|null Only and optional for tanMediumKlasse=='G' */
     public $kontoverbindungAuftraggeber;
-    /** @var string|null JJJJMMTT gemäß ISO 8601 Only and optional for $tanMediumKlasse=='G' */
+    /** @var string|null JJJJMMTT gemäß ISO 8601 Only and optional for tanMediumKlasse=='G' */
     public $gueltigAb;
-    /** @var string|null JJJJMMTT gemäß ISO 8601 Only and optional for $tanMediumKlasse=='G' */
+    /** @var string|null JJJJMMTT gemäß ISO 8601 Only and optional for tanMediumKlasse=='G' */
     public $gueltigBis;
-    /** @var string|null Only for $tanMediumKlasse=='L' */
+    /** @var string|null Only for tanMediumKlasse=='L' */
     public $tanListennumer;
-    /** @var string|null Must for $tanMediumKlasse=='M', optional otherwise */
+    /** @var string|null Must for tanMediumKlasse=='M', optional otherwise */
     public $bezeichnungDesTanMediums;
-    /** @var string|null Only and optional for $tanMediumKlasse=='M' */
+    /** @var string|null Only and optional for tanMediumKlasse=='M' */
     public $mobiltelefonnummerVerschleiert;
-    /** @var string|null Only and optional for $tanMediumKlasse=='M' */
+    /** @var string|null Only and optional for tanMediumKlasse=='M' */
     public $mobiltelefonnummer;
-    /** @var \Fhp\Segment\Common\Kti|null Only and optional for $tanMediumKlasse=='M' */
+    /** @var \Fhp\Segment\Common\Kti|null Only and optional for tanMediumKlasse=='M' */
     public $smsAbbuchungskonto;
     /** @var int|null */
     public $anzahlFreieTans;

--- a/lib/Fhp/Segment/TAN/HITAN.php
+++ b/lib/Fhp/Segment/TAN/HITAN.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Fhp\Segment\TAN;
+
+use Fhp\Model\TanRequest;
+
+interface HITAN extends TanRequest
+{
+    const DUMMY_REFERENCE = 'noref';
+    const DUMMY_CHALLENGE = 'nochallenge';
+
+    public function getTanProzess(): string;
+
+    public function getAuftragsreferenz(): ?string;
+}

--- a/lib/Fhp/Segment/TAN/HITANS.php
+++ b/lib/Fhp/Segment/TAN/HITANS.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Fhp\Segment\TAN;
+
+interface HITANS
+{
+    public function getParameterZweiSchrittTanEinreichung(): ParameterZweiSchrittTanEinreichung;
+}

--- a/lib/Fhp/Segment/TAN/HITANSv6.php
+++ b/lib/Fhp/Segment/TAN/HITANSv6.php
@@ -13,8 +13,13 @@ use Fhp\Segment\BaseGeschaeftsvorfallparameter;
  * @link: https://www.hbci-zka.de/dokumente/spezifikation_deutsch/fintsv3/FinTS_3.0_Security_Sicherheitsverfahren_PINTAN_2018-02-23_final_version.pdf
  * Section: B.5.1 c)
  */
-class HITANSv6 extends BaseGeschaeftsvorfallparameter
+class HITANSv6 extends BaseGeschaeftsvorfallparameter implements HITANS
 {
     /** @var ParameterZweiSchrittTanEinreichungV6 */
     public $parameterZweiSchrittTanEinreichung;
+
+    public function getParameterZweiSchrittTanEinreichung(): ParameterZweiSchrittTanEinreichung
+    {
+        return $this->parameterZweiSchrittTanEinreichung;
+    }
 }

--- a/lib/Fhp/Segment/TAN/HITANv6.php
+++ b/lib/Fhp/Segment/TAN/HITANv6.php
@@ -18,7 +18,7 @@ class HITANv6 extends BaseSegment implements TanRequest
     const DUMMY_CHALLENGE = 'nochallenge';
 
     /**
-     * @var int Allowed values: 1 (for Prozessvariante 1), 2, 3, 4. See {@link HKTANv6::$$tanProzess} for details.
+     * @var string Allowed values: 1 (for Prozessvariante 1), 2, 3, 4. See {@link HKTANv6::$$tanProzess} for details.
      */
     public $tanProzess;
     /**
@@ -80,7 +80,7 @@ class HITANv6 extends BaseSegment implements TanRequest
         return $this->bezeichnungDesTanMediums;
     }
 
-    public function getTanProzess(): int
+    public function getTanProzess(): string
     {
         return $this->tanProzess;
     }

--- a/lib/Fhp/Segment/TAN/HITANv6.php
+++ b/lib/Fhp/Segment/TAN/HITANv6.php
@@ -15,6 +15,7 @@ use Fhp\Syntax\Bin;
 class HITANv6 extends BaseSegment implements TanRequest
 {
     const DUMMY_REFERENCE = 'noref';
+    const DUMMY_CHALLENGE = 'nochallenge';
 
     /**
      * @var int Allowed values: 1 (for Prozessvariante 1), 2, 3, 4. See {@link HKTANv6::$$tanProzess} for details.
@@ -67,10 +68,10 @@ class HITANv6 extends BaseSegment implements TanRequest
     }
 
     /** {@inheritdoc} */
-    public function getChallenge(): string
+    public function getChallenge(): ?string
     {
         // Note: This is non-null because tanProzess==4.
-        return $this->challenge;
+        return $this->challenge === static::DUMMY_CHALLENGE ? null : $this->challenge;
     }
 
     /** {@inheritdoc} */

--- a/lib/Fhp/Segment/TAN/HITANv6.php
+++ b/lib/Fhp/Segment/TAN/HITANv6.php
@@ -2,7 +2,6 @@
 
 namespace Fhp\Segment\TAN;
 
-use Fhp\Model\TanRequest;
 use Fhp\Segment\BaseSegment;
 use Fhp\Syntax\Bin;
 
@@ -12,11 +11,8 @@ use Fhp\Syntax\Bin;
  * @link: https://www.hbci-zka.de/dokumente/spezifikation_deutsch/fintsv3/FinTS_3.0_Security_Sicherheitsverfahren_PINTAN_2018-02-23_final_version.pdf
  * Section: B.5.1 b)
  */
-class HITANv6 extends BaseSegment implements TanRequest
+class HITANv6 extends BaseSegment implements HITAN
 {
-    const DUMMY_REFERENCE = 'noref';
-    const DUMMY_CHALLENGE = 'nochallenge';
-
     /**
      * @var string Allowed values: 1 (for Prozessvariante 1), 2, 3, 4. See {@link HKTANv6::$$tanProzess} for details.
      */

--- a/lib/Fhp/Segment/TAN/HKTAN.php
+++ b/lib/Fhp/Segment/TAN/HKTAN.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Fhp\Segment\TAN;
+
+interface HKTAN
+{
+    public function setTanProzess(int $tanProzess): void;
+
+    public function setSegmentkennung(?string $segmentkennung): void;
+
+    public function setBezeichnungDesTanMediums(?string $bezeichnungDesTanMediums): void;
+
+    public function setAuftragsreferenz(?string $auftragsreferenz): void;
+
+    public function setWeitereTanFolgt(?bool $weitereTanFolgt): void;
+}

--- a/lib/Fhp/Segment/TAN/HKTAN.php
+++ b/lib/Fhp/Segment/TAN/HKTAN.php
@@ -4,7 +4,11 @@ namespace Fhp\Segment\TAN;
 
 interface HKTAN
 {
-    public function setTanProzess(int $tanProzess): void;
+    // Note: TAN Prozess 1 is for Prozessvariante 1, which is not implemented at all in this library.
+    const TAN_PROZESS_2 = '2'; // Prozessvariante 2 step 2
+    const TAN_PROZESS_4 = '4'; // Prozessvariante 2 step 1 (yes, four is one!)
+
+    public function setTanProzess(string $tanProzess): void;
 
     public function setSegmentkennung(?string $segmentkennung): void;
 

--- a/lib/Fhp/Segment/TAN/HKTANFactory.php
+++ b/lib/Fhp/Segment/TAN/HKTANFactory.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Fhp\Segment\TAN;
+
+use Fhp\Model\TanMode;
+use Fhp\Segment\BaseSegment;
+
+/**
+ * Creates HKTAN segments matching the segment version used by the server.
+ */
+class HKTANFactory
+{
+    /**
+     * @param TanMode $tanMode Parameters retrieved from the server during dialog initialization that describe how the
+     *     TAN processes need to be parameterized.
+     * @param ?string $tanMedium The TAN medium selected by the user. Mandatory if $tanMode is present and requires a
+     *     TAN medium.
+     * @param string $segmentkennung The segment that we want to authenticate with the HKTAN instance.
+     * @return BaseSegment A HKTAN instance to signal to the server that Prozessvariante 2 shall be used.
+     */
+    public static function createProzessvariante2Step1(TanMode $tanMode, ?string $tanMedium = null, string $segmentkennung = 'HKIDN'): BaseSegment
+    {
+        if ($tanMode !== null && $tanMode->getSmsAbbuchungskontoErforderlich()) {
+            throw new \InvalidArgumentException('SMS-Abbuchungskonto not supported');
+        }
+
+        $result = $tanMode->createHKTAN();
+        $result->setTanProzess(4);
+        $result->setSegmentkennung($segmentkennung);
+        if ($tanMode !== null && $tanMode->needsTanMedium()) {
+            if ($tanMedium === null) {
+                throw new \InvalidArgumentException('Missing tanMedium');
+            }
+            $result->setBezeichnungDesTanMediums($tanMedium);
+        }
+        return $result;
+    }
+
+    /**
+     * @param TanMode $tanMode Parameters retrieved from the server during dialog initialization that describe how the
+     *     TAN processes need to be parameterized.
+     * @param string $auftragsreferenz The reference number received from the server in step 1 response (HITAN).
+     * @return BaseSegment A HKTAN instance to tell the server the reference of the previously submitted order.
+     */
+    public static function createProzessvariante2Step2(TanMode $tanMode, string $auftragsreferenz): BaseSegment
+    {
+        $result = $tanMode->createHKTAN();
+        $result->setTanProzess(2);
+        $result->setAuftragsreferenz($auftragsreferenz);
+        $result->setWeitereTanFolgt(false); // No Mehrfach-TAN support, so we'll never send true here.
+        return $result;
+    }
+}

--- a/lib/Fhp/Segment/TAN/HKTANFactory.php
+++ b/lib/Fhp/Segment/TAN/HKTANFactory.php
@@ -25,7 +25,7 @@ class HKTANFactory
         }
 
         $result = $tanMode->createHKTAN();
-        $result->setTanProzess(4);
+        $result->setTanProzess(HKTAN::TAN_PROZESS_4);
         $result->setSegmentkennung($segmentkennung);
         if ($tanMode !== null && $tanMode->needsTanMedium()) {
             if ($tanMedium === null) {
@@ -45,7 +45,7 @@ class HKTANFactory
     public static function createProzessvariante2Step2(TanMode $tanMode, string $auftragsreferenz): BaseSegment
     {
         $result = $tanMode->createHKTAN();
-        $result->setTanProzess(2);
+        $result->setTanProzess(HKTAN::TAN_PROZESS_2);
         $result->setAuftragsreferenz($auftragsreferenz);
         $result->setWeitereTanFolgt(false); // No Mehrfach-TAN support, so we'll never send true here.
         return $result;

--- a/lib/Fhp/Segment/TAN/HKTANFactory.php
+++ b/lib/Fhp/Segment/TAN/HKTANFactory.php
@@ -7,10 +7,17 @@ use Fhp\Segment\BaseSegment;
 
 /**
  * Creates HKTAN segments matching the segment version used by the server.
+ *
+ * @link https://www.hbci-zka.de/dokumente/spezifikation_deutsch/fintsv3/FinTS_3.0_Security_Sicherheitsverfahren_PINTAN_2020-07-10_final_version.pdf
+ * Section D (look for "TAN-Prozess" version 1)
  */
 class HKTANFactory
 {
     /**
+     * This is TAN-Prozess=4, which is the first step of Prozessvariante 2. In this step, the client application sends
+     * a main action segment together with a HKTAN segment, in order to indicate that it is prepared to authenticate the
+     * action with a TAN if the server asks for it (which would trigger step 2 below).
+     *
      * @param TanMode $tanMode Parameters retrieved from the server during dialog initialization that describe how the
      *     TAN processes need to be parameterized.
      * @param ?string $tanMedium The TAN medium selected by the user. Mandatory if $tanMode is present and requires a
@@ -37,6 +44,10 @@ class HKTANFactory
     }
 
     /**
+     * This is TAN-Prozess=2, which is the second step of Prozessvariante 2. If the bank server asked for a TAN in step
+     * 1 above, then the client application sends that TAN in a HKTAN segment to the server in order to authenticate the
+     * previously transmitted action.
+     *
      * @param TanMode $tanMode Parameters retrieved from the server during dialog initialization that describe how the
      *     TAN processes need to be parameterized.
      * @param string $auftragsreferenz The reference number received from the server in step 1 response (HITAN).

--- a/lib/Fhp/Segment/TAN/HKTANv6.php
+++ b/lib/Fhp/Segment/TAN/HKTANv6.php
@@ -32,7 +32,7 @@ class HKTANv6 extends BaseSegment implements HKTAN
      * configured in the BPD ({@link VerfahrensparameterZweiSchrittVerfahren} field $tanProzess). In practice,
      * Prozessvariante 2 is much more common.
      *
-     * @var int Allowed values: 1 (for Prozessvariante 1), 2, 3, 4
+     * @var string Allowed values: 1 (for Prozessvariante 1), 2, 3, 4
      */
     public $tanProzess;
     /**
@@ -115,12 +115,12 @@ class HKTANv6 extends BaseSegment implements HKTAN
     public static function createDummy(): HKTANv6
     {
         $result = HKTANv6::createEmpty();
-        $result->tanProzess = 4;
+        $result->tanProzess = HKTAN::TAN_PROZESS_4;
         $result->segmentkennung = 'HKIDN';
         return $result;
     }
 
-    public function setTanProzess(int $tanProzess): void
+    public function setTanProzess(string $tanProzess): void
     {
         $this->tanProzess = $tanProzess;
     }

--- a/lib/Fhp/Segment/TAN/ParameterZweiSchrittTanEinreichung.php
+++ b/lib/Fhp/Segment/TAN/ParameterZweiSchrittTanEinreichung.php
@@ -1,0 +1,13 @@
+<?php /** @noinspection PhpUnused */
+
+namespace Fhp\Segment\TAN;
+
+use Fhp\Model\TanMode;
+
+interface ParameterZweiSchrittTanEinreichung
+{
+    public function isEinschrittVerfahrenErlaubt(): bool;
+
+    /** @return TanMode[] */
+    public function getVerfahrensparameterZweiSchrittVerfahren(): array;
+}

--- a/lib/Fhp/Segment/TAN/ParameterZweiSchrittTanEinreichungV6.php
+++ b/lib/Fhp/Segment/TAN/ParameterZweiSchrittTanEinreichungV6.php
@@ -4,7 +4,7 @@ namespace Fhp\Segment\TAN;
 
 use Fhp\Segment\BaseDeg;
 
-class ParameterZweiSchrittTanEinreichungV6 extends BaseDeg
+class ParameterZweiSchrittTanEinreichungV6 extends BaseDeg implements ParameterZweiSchrittTanEinreichung
 {
     /** @var bool */
     public $einschrittVerfahrenErlaubt;
@@ -19,4 +19,14 @@ class ParameterZweiSchrittTanEinreichungV6 extends BaseDeg
     public $auftragsHashwertverfahren;
     /** @var VerfahrensparameterZweiSchrittVerfahrenV6[] @Max(98) */
     public $verfahrensparameterZweiSchrittVerfahren;
+
+    public function isEinschrittVerfahrenErlaubt(): bool
+    {
+        return $this->einschrittVerfahrenErlaubt;
+    }
+
+    public function getVerfahrensparameterZweiSchrittVerfahren(): array
+    {
+        return $this->verfahrensparameterZweiSchrittVerfahren;
+    }
 }

--- a/lib/Fhp/Segment/TAN/VerfahrensparameterZweiSchrittVerfahrenV6.php
+++ b/lib/Fhp/Segment/TAN/VerfahrensparameterZweiSchrittVerfahrenV6.php
@@ -125,4 +125,10 @@ class VerfahrensparameterZweiSchrittVerfahrenV6 extends BaseDeg implements TanMo
     {
         return $this->bezeichnungDesTanMediumsErforderlich === 2 && $this->anzahlUnterstuetzterAktiverTanMedien > 0;
     }
+
+    /** {@inheritdoc} */
+    public function createHKTAN(): HKTAN
+    {
+        return HKTANv6::createEmpty();
+    }
 }

--- a/lib/Fhp/Segment/TAN/VerfahrensparameterZweiSchrittVerfahrenV6.php
+++ b/lib/Fhp/Segment/TAN/VerfahrensparameterZweiSchrittVerfahrenV6.php
@@ -71,6 +71,12 @@ class VerfahrensparameterZweiSchrittVerfahrenV6 extends BaseDeg implements TanMo
     }
 
     /** {@inheritdoc} */
+    public function isProzessvariante2(): bool
+    {
+        return $this->tanProzess === HKTAN::TAN_PROZESS_2;
+    }
+
+    /** {@inheritdoc} */
     public function getSmsAbbuchungskontoErforderlich(): bool
     {
         return $this->smsAbbuchungskontoErforderlich === 2;

--- a/lib/Fhp/Segment/TAN/VerfahrensparameterZweiSchrittVerfahrenV6.php
+++ b/lib/Fhp/Segment/TAN/VerfahrensparameterZweiSchrittVerfahrenV6.php
@@ -7,11 +7,9 @@ use Fhp\Segment\BaseDeg;
 
 class VerfahrensparameterZweiSchrittVerfahrenV6 extends BaseDeg implements TanMode
 {
-    const PROZESSVARIANTE_2 = 2;
-
     /** @var int Allowed values: 900 through 997 */
     public $sicherheitsfunktion;
-    /** @var int Allowed values: 1, 2; See specification or {@link HKTANv6::$$tanProzess} for details. */
+    /** @var string Allowed values: 1, 2; See specification or {@link HKTANv6::$$tanProzess} for details. */
     public $tanProzess;
     /** @var string */
     public $technischeIdentifikationTanVerfahren;


### PR DESCRIPTION
See #309 for background and the individual commit messages for details.

This PR prepares the code base for adding HKTANv7 and support for decoupled strong authentication in a subsequent PR.

Breaking changes:
* Make `TanRequest::getChallenge()` nullable. Instead of returning `"nochallenge"`, return null. With HKTANv7, the field is nullable for decoupled modes anyway.