### PR TITLE
Add support for HKTANv7 and decoupled authentication

### DIFF
--- a/Samples/accounts.php
+++ b/Samples/accounts.php
@@ -15,6 +15,6 @@ $fints = require_once 'login.php';
 $getSepaAccounts = \Fhp\Action\GetSEPAAccounts::create();
 $fints->execute($getSepaAccounts);
 if ($getSepaAccounts->needsTan()) {
-    handleTan($getSepaAccounts); // See login.php for the implementation.
+    handleStrongAuthentication($getSepaAccounts); // See login.php for the implementation.
 }
 print_r($getSepaAccounts->getAccounts());

--- a/Samples/balance.php
+++ b/Samples/balance.php
@@ -12,14 +12,14 @@ $fints = require_once 'login.php';
 $getSepaAccounts = \Fhp\Action\GetSEPAAccounts::create();
 $fints->execute($getSepaAccounts);
 if ($getSepaAccounts->needsTan()) {
-    handleTan($getSepaAccounts); // See login.php for the implementation.
+    handleStrongAuthentication($getSepaAccounts); // See login.php for the implementation.
 }
 $oneAccount = $getSepaAccounts->getAccounts()[0];
 
 $getBalance = \Fhp\Action\GetBalance::create($oneAccount, true);
 $fints->execute($getBalance);
 if ($getBalance->needsTan()) {
-    handleTan($getBalance); // See login.php for the implementation.
+    handleStrongAuthentication($getBalance); // See login.php for the implementation.
 }
 
 /** @var \Fhp\Segment\SAL\HISAL $hisal */

--- a/Samples/directDebit_Sephpa.php
+++ b/Samples/directDebit_Sephpa.php
@@ -22,7 +22,7 @@ $fints = require_once 'login.php';
 $getSepaAccounts = \Fhp\Action\GetSEPAAccounts::create();
 $fints->execute($getSepaAccounts);
 if ($getSepaAccounts->needsTan()) {
-    handleTan($getSepaAccounts); // See login.php for the implementation.
+    handleStrongAuthentication($getSepaAccounts); // See login.php for the implementation.
 }
 $oneAccount = $getSepaAccounts->getAccounts()[0];
 
@@ -47,5 +47,5 @@ $xml = $directDebitFile->generateXml(date("Y-m-d\TH:i:s", time()));
 $sendSEPADirectDebit = \Fhp\Action\SendSEPADirectDebit::create($oneAccount, $xml);
 $fints->execute($sendSEPADirectDebit);
 if ($sendSEPADirectDebit->needsTan()) {
-    handleTan($sendSEPADirectDebit); // See login.php for the implementation.
+    handleStrongAuthentication($sendSEPADirectDebit); // See login.php for the implementation.
 }

--- a/Samples/directDebit_phpSepaXml.php
+++ b/Samples/directDebit_phpSepaXml.php
@@ -56,12 +56,12 @@ $sepaDD->addDebitor(new SEPADebitor([ //this is who you want to get money from
 $getSepaAccounts = \Fhp\Action\GetSEPAAccounts::create();
 $fints->execute($getSepaAccounts);
 if ($getSepaAccounts->needsTan()) {
-    handleTan($getSepaAccounts); // See login.php for the implementation.
+    handleStrongAuthentication($getSepaAccounts); // See login.php for the implementation.
 }
 $oneAccount = $getSepaAccounts->getAccounts()[0];
 
 $sendSEPADirectDebit = \Fhp\Action\SendSEPADirectDebit::create($oneAccount, $sepaDD->toXML());
 $fints->execute($sendSEPADirectDebit);
 if ($sendSEPADirectDebit->needsTan()) {
-    handleTan($sendSEPADirectDebit); // See login.php for the implementation.
+    handleStrongAuthentication($sendSEPADirectDebit); // See login.php for the implementation.
 }

--- a/Samples/statementOfAccount.php
+++ b/Samples/statementOfAccount.php
@@ -15,7 +15,7 @@ $fints = require_once 'login.php';
 $getSepaAccounts = \Fhp\Action\GetSEPAAccounts::create();
 $fints->execute($getSepaAccounts);
 if ($getSepaAccounts->needsTan()) {
-    handleTan($getSepaAccounts); // See login.php for the implementation.
+    handleStrongAuthentication($getSepaAccounts); // See login.php for the implementation.
 }
 $oneAccount = $getSepaAccounts->getAccounts()[0];
 
@@ -24,7 +24,7 @@ $to = new \DateTime();
 $getStatement = \Fhp\Action\GetStatementOfAccount::create($oneAccount, $from, $to);
 $fints->execute($getStatement);
 if ($getStatement->needsTan()) {
-    handleTan($getStatement); // See login.php for the implementation.
+    handleStrongAuthentication($getStatement); // See login.php for the implementation.
 }
 
 $soa = $getStatement->getStatement();

--- a/Samples/transfer.php
+++ b/Samples/transfer.php
@@ -50,5 +50,5 @@ $sepaDD->addCreditor(new SEPACreditor([ //this is who you want to send money to
 $sendSEPATransfer = \Fhp\Action\SendSEPATransfer::create($oneAccount, $sepaDD->toXML());
 $fints->execute($sendSEPATransfer);
 if ($sendSEPATransfer->needsTan()) {
-    handleTan($sendSEPATransfer); // See login.php for the implementation.
+    handleStrongAuthentication($sendSEPATransfer); // See login.php for the implementation.
 }

--- a/lib/Fhp/BaseAction.php
+++ b/lib/Fhp/BaseAction.php
@@ -93,8 +93,9 @@ abstract class BaseAction implements \Serializable
     }
 
     /**
-     * @return bool If this returns true, the underlying operation has not completed because it is awaiting a TAN. You
-     *     should ask the user for this TAN and pass it to {@link submitTan()}.
+     * @return bool If this returns true, the underlying operation has not completed because it is awaiting a TAN or a
+     *     "decoupled" confirmation. You should ask the user for this TAN/confirmation and pass it to
+     *     {@link FinTs::submitTan()} or call {@link FinTs::checkDecoupledSubmission()}, respectively.
      */
     public function needsTan(): bool
     {
@@ -115,7 +116,7 @@ abstract class BaseAction implements \Serializable
      * Throws an exception unless this action has been successfully executed, i.e. in the following cases:
      *  - the action has not been {@link FinTs::execute()}-d at all or the {@link FinTs::execute()} call for it threw an
      *    exception,
-     *  - the action is awaiting a TAN that first needs to be supplied with {@link FinTs::submitTan()}.
+     *  - the action is awaiting a TAN/confirmation (as per {@link BaseAction::needsTan()}.
      *
      * After executing an action, you can use this function to make sure that it succeeded. This is especially useful
      * for actions that don't have any results (as each result getter would call {@link ensureDone()} internally).

--- a/lib/Fhp/Model/NoPsd2TanMode.php
+++ b/lib/Fhp/Model/NoPsd2TanMode.php
@@ -34,6 +34,12 @@ final class NoPsd2TanMode implements TanMode
     }
 
     /** {@inheritdoc} */
+    public function isDecoupled(): bool
+    {
+        return false;
+    }
+
+    /** {@inheritdoc} */
     public function getChallengeLabel(): string
     {
         return '';

--- a/lib/Fhp/Model/NoPsd2TanMode.php
+++ b/lib/Fhp/Model/NoPsd2TanMode.php
@@ -93,6 +93,36 @@ final class NoPsd2TanMode implements TanMode
         return false;
     }
 
+    /** {@inheritdoc} */
+    public function getMaxDecoupledChecks(): int
+    {
+        throw new \RuntimeException('Only allowed for decoupled TAN modes');
+    }
+
+    /** {@inheritdoc} */
+    public function getFirstDecoupledCheckDelaySeconds(): int
+    {
+        throw new \RuntimeException('Only allowed for decoupled TAN modes');
+    }
+
+    /** {@inheritdoc} */
+    public function getPeriodicDecoupledCheckDelaySeconds(): int
+    {
+        throw new \RuntimeException('Only allowed for decoupled TAN modes');
+    }
+
+    /** {@inheritdoc} */
+    public function allowsManualConfirmation(): bool
+    {
+        throw new \RuntimeException('Only allowed for decoupled TAN modes');
+    }
+
+    /** {@inheritdoc} */
+    public function allowsAutomatedPolling(): bool
+    {
+        throw new \RuntimeException('Only allowed for decoupled TAN modes');
+    }
+
     public function createHKTAN(): HKTAN
     {
         throw new \AssertionError('HKTAN should not be needed when the bank does not support PSD2');

--- a/lib/Fhp/Model/TanMode.php
+++ b/lib/Fhp/Model/TanMode.php
@@ -96,6 +96,59 @@ interface TanMode
     public function getAntwortHhdUcErforderlich(): bool;
 
     /**
+     * For decoupled TAN modes only.
+     * @return int The maximum number of times that {@link FinTs::checkDecoupledSubmission()} may be called for a given
+     *     {@link TanRequest}. The bank may treat exceeding this number like a wrong TAN input. 0 means infinity.
+     */
+    public function getMaxDecoupledChecks(): int;
+
+    /**
+     * For decoupled TAN modes only.
+     * @return int The minimum number of seconds to wait beween receiving the {@link TanRequest} and the first call to
+     *     {@link FinTs::checkDecoupledSubmission()}.
+     * @throws \RuntimeException If {@link TanMode::isDecoupled()} returns false.
+     */
+    public function getFirstDecoupledCheckDelaySeconds(): int;
+
+    /**
+     * For decoupled TAN modes only.
+     * @return int The minimum number of seconds to wait beween subsequent calls to
+     *     {@link FinTs::checkDecoupledSubmission()}.
+     * @throws \RuntimeException If {@link TanMode::isDecoupled()} returns false.
+     */
+    public function getPeriodicDecoupledCheckDelaySeconds(): int;
+
+    /**
+     * For decoupled TAN modes only.
+     *
+     * If this function returns true, the application, while waiting for the user to confirm on their secondary device,
+     * may ask the user to indicate manually when they have done so (as opposed to relying solely on automated polling
+     * if allowed by {@link TanMode::allowsAutomatedPolling()}, which may be only allowed at quite low frequencies
+     * depending on the bank).
+     *
+     * Note: If for whatever reason your application does not implement automated polling at all, it's probably safe to
+     * ignore the return value of this function and all the polling functions below and just let the user confirm
+     * manually either way. The server won't know whether a call to {@link FinTs::checkDecoupledSubmission()} was
+     * triggered by the user or by automation.
+     * To be extra safe, the application can use {@link FinTs::firstPollingDelaySeconds()} when receiving the
+     * {@link TanRequest} to calculate the earliest possible submission time, and upon manual confirmation
+     * {@link sleep()} for the remaining time if necessary.
+     *
+     * @return bool Whether manual confirmations by the user are allowed.
+     * @throws \RuntimeException If {@link TanMode::isDecoupled()} returns false.
+     */
+    public function allowsManualConfirmation(): bool;
+
+    /**
+     * For decoupled TAN modes only.
+     *
+     * If this function returns true, the application may poll the server periodically and automatically while waiting
+     * for the user to confirm on their secondary device, subject to the delays below.
+     * @return bool Whether automated polling is allowed.
+     */
+    public function allowsAutomatedPolling(): bool;
+
+    /**
      * This function is for internal use by the library implementation.
      * @return HKTAN&BaseSegment A newly created segment.
      */

--- a/lib/Fhp/Model/TanMode.php
+++ b/lib/Fhp/Model/TanMode.php
@@ -45,6 +45,13 @@ interface TanMode
     public function isProzessvariante2(): bool;
 
     /**
+     * @return bool True if the TAN mode is a "decoupled" one, meaning that there are no actual TANs passed back to the
+     *     server. Instead, the user just presses some kind of "confirm" button on a separate device and the client
+     *     application resumes processing with the server without submitting a TAN.
+     */
+    public function isDecoupled(): bool;
+
+    /**
      * @return string A user-readable label for the text field that displays the challenge to the user.
      */
     public function getChallengeLabel(): string;
@@ -58,12 +65,14 @@ interface TanMode
     /**
      * @return int The maximum length of TANs entered in this mode. The application can use this to restrict the TAN
      *     input field or to do client-side validation.
+     * @throws \RuntimeException If {@link TanMode::isDecoupled()} returns true.
      */
     public function getMaxTanLength(): int;
 
     /**
      * @return int The allowed TAN format. See the FORMAT_* constants above. The application can use this to
      *     restrict the TAN input field or to do client-side validation.
+     * @throws \RuntimeException If {@link TanMode::isDecoupled()} returns true.
      */
     public function getTanFormat(): int;
 

--- a/lib/Fhp/Model/TanRequest.php
+++ b/lib/Fhp/Model/TanRequest.php
@@ -17,7 +17,8 @@ interface TanRequest
     public function getProcessId(): string;
 
     /**
-     * @return ?string A challenge to be displayed to the user.
+     * @return ?string A challenge to be displayed to the user. In case of a decopled TAN mode, this may contain
+     *     important instructions for the user.
      */
     public function getChallenge(): ?string;
 

--- a/lib/Fhp/Segment/HIRMS/Rueckmeldungscode.php
+++ b/lib/Fhp/Segment/HIRMS/Rueckmeldungscode.php
@@ -6,7 +6,7 @@ namespace Fhp\Segment\HIRMS;
  * Enum for the response codes that the server can send.
  *
  * @link https://www.hbci-zka.de/dokumente/spezifikation_deutsch/FinTS_Rueckmeldungscodes_2019-07-22_final_version.pdf
- * @link https://www.hbci-zka.de/dokumente/spezifikation_deutsch/fintsv3/FinTS_3.0_Security_Sicherheitsverfahren_PINTAN_2018-02-23_final_version.pdf
+ * @link https://www.hbci-zka.de/dokumente/spezifikation_deutsch/fintsv3/FinTS_3.0_Security_Sicherheitsverfahren_PINTAN_2020-07-10_final_version.pdf
  */
 abstract class Rueckmeldungscode
 {
@@ -98,6 +98,12 @@ abstract class Rueckmeldungscode
      * Note that this library does not support HKPSA.
      */
     const ZUGANG_VORLAEUFIG_GESPERRT = 3938;
+
+    /**
+     * Starke Kundenauthentifizierung noch ausstehend.
+     * Indicates that the decoupled authentication is still outstanding.
+     */
+    const STARKE_KUNDENAUTHENTIFIZIERUNG_NOCH_AUSSTEHEND = 3956;
 
     /**
      * In einer Nachricht ist mindestens ein fehlerhafter Auftrag enthalten.

--- a/lib/Fhp/Segment/TAN/HITANSv7.php
+++ b/lib/Fhp/Segment/TAN/HITANSv7.php
@@ -1,0 +1,25 @@
+<?php /** @noinspection PhpUnused */
+
+namespace Fhp\Segment\TAN;
+
+use Fhp\Segment\BaseGeschaeftsvorfallparameter;
+
+/**
+ * Segment: Zwei-Schritt-TAN-Einreichung, Parameter (Version 7)
+ * Parameters for: HKTANv7
+ * Bezugssegment: HKVVB
+ * Sender: Kreditinstitut
+ *
+ * @link: https://www.hbci-zka.de/dokumente/spezifikation_deutsch/fintsv3/FinTS_3.0_Security_Sicherheitsverfahren_PINTAN_2020-07-10_final_version.pdf
+ * Section: B.5.2 c)
+ */
+class HITANSv7 extends BaseGeschaeftsvorfallparameter implements HITANS
+{
+    /** @var ParameterZweiSchrittTanEinreichungV7 */
+    public $parameterZweiSchrittTanEinreichung;
+
+    public function getParameterZweiSchrittTanEinreichung(): ParameterZweiSchrittTanEinreichung
+    {
+        return $this->parameterZweiSchrittTanEinreichung;
+    }
+}

--- a/lib/Fhp/Segment/TAN/HITANv6.php
+++ b/lib/Fhp/Segment/TAN/HITANv6.php
@@ -14,7 +14,8 @@ use Fhp\Syntax\Bin;
 class HITANv6 extends BaseSegment implements HITAN
 {
     /**
-     * @var string Allowed values: 1 (for Prozessvariante 1), 2, 3, 4. See {@link HKTANv6::$$tanProzess} for details.
+     * @var string Allowed values: 1 (for Prozessvariante 1), 2, 3, 4. See {@link HKTANv6::$tanProzess} for details.
+     *     NOTE: This field is re-used in HITANv7, where the value 'S' is also allowed.
      */
     public $tanProzess;
     /**
@@ -26,7 +27,7 @@ class HITANv6 extends BaseSegment implements HITAN
     public $auftragsHashwert;
     /**
      * Special value "noref" means that no TAN is needed.
-     * M: bei TAN-Prozess=2, 3, 4
+     * M: bei TAN-Prozess=2, 3, 4 (and S)
      * O: TAN-Prozess=1
      * @var string|null Max length: 35
      */
@@ -38,7 +39,7 @@ class HITANv6 extends BaseSegment implements HITAN
      * presenting the challenge to the user.
      *
      * M: bei TAN-Prozess=1, 3, 4
-     * O: bei TAN-Prozess=2
+     * O: bei TAN-Prozess=2 (and S)
      * @var string|null Max length: 2048
      */
     public $challenge;

--- a/lib/Fhp/Segment/TAN/HITANv7.php
+++ b/lib/Fhp/Segment/TAN/HITANv7.php
@@ -1,0 +1,15 @@
+<?php /** @noinspection PhpUnused */
+
+namespace Fhp\Segment\TAN;
+
+/**
+ * Segment: Geschäftsvorfall Zwei-Schritt-TAN-Einreichung Rückmeldung (Version 7)
+ *
+ * @link: https://www.hbci-zka.de/dokumente/spezifikation_deutsch/fintsv3/FinTS_3.0_Security_Sicherheitsverfahren_PINTAN_2020-07-10_final_version.pdf
+ * Section: B.5.2 b)
+ */
+class HITANv7 extends HITANv6 implements HITAN
+{
+    // NOTE: While all fields remain the same as with HITANv6, the $tanProzess field can now have the value 'S'.
+    // If it does, $auftragsreferenz is mandatory and $challenge is optional.
+}

--- a/lib/Fhp/Segment/TAN/HKTAN.php
+++ b/lib/Fhp/Segment/TAN/HKTAN.php
@@ -7,6 +7,7 @@ interface HKTAN
     // Note: TAN Prozess 1 is for Prozessvariante 1, which is not implemented at all in this library.
     const TAN_PROZESS_2 = '2'; // Prozessvariante 2 step 2
     const TAN_PROZESS_4 = '4'; // Prozessvariante 2 step 1 (yes, four is one!)
+    const TAN_PROZESS_S = 'S'; // Prozessvariante 2 step S
 
     public function setTanProzess(string $tanProzess): void;
 

--- a/lib/Fhp/Segment/TAN/HKTANFactory.php
+++ b/lib/Fhp/Segment/TAN/HKTANFactory.php
@@ -51,12 +51,40 @@ class HKTANFactory
      * @param TanMode $tanMode Parameters retrieved from the server during dialog initialization that describe how the
      *     TAN processes need to be parameterized.
      * @param string $auftragsreferenz The reference number received from the server in step 1 response (HITAN).
-     * @return BaseSegment A HKTAN instance to tell the server the reference of the previously submitted order.
+     * @return BaseSegment A HKTAN instance to tell the server the reference of the previously submitted action.
      */
     public static function createProzessvariante2Step2(TanMode $tanMode, string $auftragsreferenz): BaseSegment
     {
         $result = $tanMode->createHKTAN();
         $result->setTanProzess(HKTAN::TAN_PROZESS_2);
+        $result->setAuftragsreferenz($auftragsreferenz);
+        $result->setWeitereTanFolgt(false); // No Mehrfach-TAN support, so we'll never send true here.
+        return $result;
+    }
+
+    /**
+     * This is TAN-Prozess=S, which is an alternative, repeated step 2 of Prozessvariante 2 for decoupled TAN modes.
+     * The TAN mode being "decoupled" means that the challenge and TAN submission (or simply transaction confirmation)
+     * happen entirely on the side channel (e.g. on the user's phone) and don't involve the application that triggered
+     * the action (i.e. the application using phpFinTs). This means that the application never submits a TAN (never
+     * calls {@link createProzessvariante2Step2()}). In order to learn when the authentication has completed, the
+     * application can use this process step 'S' to poll the server.
+     * @param TanMode $tanMode Parameters retrieved from the server during dialog initialization that describe how the
+     *     TAN processes need to be parameterized. Must be a "decoupled" mode.
+     * @param string $auftragsreferenz The reference number received from the server in step 1 response (HITAN).
+     * @return BaseSegment A HKTAN instance to ask the server about the authentication status of the previously
+     *     submitted action.
+     */
+    public static function createProzessvariante2StepS(TanMode $tanMode, string $auftragsreferenz): BaseSegment
+    {
+        if (!$tanMode->isDecoupled()) {
+            throw new \InvalidArgumentException('Cannot use step S with non-decoupled TAN mode');
+        }
+        $result = $tanMode->createHKTAN();
+        if ($result->getVersion() < 7) {
+            throw new \InvalidArgumentException('Step S is only supported with HKTAN version 7+');
+        }
+        $result->setTanProzess(HKTAN::TAN_PROZESS_S);
         $result->setAuftragsreferenz($auftragsreferenz);
         $result->setWeitereTanFolgt(false); // No Mehrfach-TAN support, so we'll never send true here.
         return $result;

--- a/lib/Fhp/Segment/TAN/HKTANv6.php
+++ b/lib/Fhp/Segment/TAN/HKTANv6.php
@@ -27,12 +27,18 @@ class HKTANv6 extends BaseSegment implements HKTAN
      *    (from the server's HITAN). Along with this HKTAN the client sends the TAN (response to the challenge from
      *    step 1) in the same message. The server responds with the same reference (but no more challenge) to confirm
      *    that the TAN was accepted.
+     * S: Only supported in HKTANv7 (which inherits this field). In Prozessvariante 2 for decoupled modes, instead of
+     *    exectuting the step 2 above, the client polls the server regularly using step S to find out if the
+     *    authentication process on the side channel (e.g. the user's smartphone) has completed. This HKTAN contains a
+     *    reference ($auftragsreferenz) to a previously posted order (from the server's HITAN). The server responds with
+     *    the same reference and a status code TODO.
      *
      * Note: It is not up to the application/library to choose this process, but rather it needs to execute the process
      * configured in the BPD ({@link VerfahrensparameterZweiSchrittVerfahren} field $tanProzess). In practice,
      * Prozessvariante 2 is much more common.
      *
-     * @var string Allowed values: 1 (for Prozessvariante 1), 2, 3, 4
+     * @var string Allowed values: 1 (for Prozessvariante 1), 2, 3, 4.
+     *     NOTE: This field is re-used in HITANv7, where the value 'S' is also allowed.
      */
     public $tanProzess;
     /**
@@ -55,13 +61,13 @@ class HKTANv6 extends BaseSegment implements HKTAN
      */
     public $auftragsHashwert;
     /**
-     * M: bei TAN-Prozess=2, 3
+     * M: bei TAN-Prozess=2, 3 (and S)
      * O: TAN-Prozess=1, 4
      * @var string|null Max length: 36
      */
     public $auftragsreferenz;
     /**
-     * M: bei TAN-Prozess=1, 2
+     * M: bei TAN-Prozess=1, 2 (and S)
      * N: bei TAN-Prozess=3, 4
      * @var bool|null
      */

--- a/lib/Fhp/Segment/TAN/HKTANv7.php
+++ b/lib/Fhp/Segment/TAN/HKTANv7.php
@@ -1,0 +1,15 @@
+<?php /** @noinspection PhpUnused */
+
+namespace Fhp\Segment\TAN;
+
+/**
+ * Segment: Geschäftsvorfall Zwei-Schritt-TAN-Einreichung (Version 7)
+ *
+ * @link: https://www.hbci-zka.de/dokumente/spezifikation_deutsch/fintsv3/FinTS_3.0_Security_Sicherheitsverfahren_PINTAN_2020-07-10_final_version.pdf
+ * Section: B.5.2 a)
+ */
+class HKTANv7 extends HKTANv6
+{
+    // NOTE: While all fields remain the same as with HKTANv6, the $tanProzess field can now have the value 'S'.
+    // If it does, $auftragsreferenz and $weitereTanFolgt are mandatory.
+}

--- a/lib/Fhp/Segment/TAN/ParameterZweiSchrittTanEinreichungV7.php
+++ b/lib/Fhp/Segment/TAN/ParameterZweiSchrittTanEinreichungV7.php
@@ -1,0 +1,32 @@
+<?php /** @noinspection PhpUnused */
+
+namespace Fhp\Segment\TAN;
+
+use Fhp\Segment\BaseDeg;
+
+class ParameterZweiSchrittTanEinreichungV7 extends BaseDeg implements ParameterZweiSchrittTanEinreichung
+{
+    /** @var bool */
+    public $einschrittVerfahrenErlaubt;
+    /** @var bool */
+    public $mehrAlsEinTanPflichtigerAuftragProNachrichtErlaubt;
+    /**
+     * 0: Auftrags-Hashwert nicht unterstützt
+     * 1: RIPEMD-160
+     * 2: SHA-1
+     * @var int
+     */
+    public $auftragsHashwertverfahren;
+    /** @var VerfahrensparameterZweiSchrittVerfahrenV7[] @Max(98) */
+    public $verfahrensparameterZweiSchrittVerfahren;
+
+    public function isEinschrittVerfahrenErlaubt(): bool
+    {
+        return $this->einschrittVerfahrenErlaubt;
+    }
+
+    public function getVerfahrensparameterZweiSchrittVerfahren(): array
+    {
+        return $this->verfahrensparameterZweiSchrittVerfahren;
+    }
+}

--- a/lib/Fhp/Segment/TAN/VerfahrensparameterZweiSchrittVerfahrenV6.php
+++ b/lib/Fhp/Segment/TAN/VerfahrensparameterZweiSchrittVerfahrenV6.php
@@ -137,6 +137,36 @@ class VerfahrensparameterZweiSchrittVerfahrenV6 extends BaseDeg implements TanMo
     }
 
     /** {@inheritdoc} */
+    public function getMaxDecoupledChecks(): int
+    {
+        throw new \RuntimeException('Only allowed for decoupled TAN modes');
+    }
+
+    /** {@inheritdoc} */
+    public function getFirstDecoupledCheckDelaySeconds(): int
+    {
+        throw new \RuntimeException('Only allowed for decoupled TAN modes');
+    }
+
+    /** {@inheritdoc} */
+    public function getPeriodicDecoupledCheckDelaySeconds(): int
+    {
+        throw new \RuntimeException('Only allowed for decoupled TAN modes');
+    }
+
+    /** {@inheritdoc} */
+    public function allowsManualConfirmation(): bool
+    {
+        throw new \RuntimeException('Only allowed for decoupled TAN modes');
+    }
+
+    /** {@inheritdoc} */
+    public function allowsAutomatedPolling(): bool
+    {
+        throw new \RuntimeException('Only allowed for decoupled TAN modes');
+    }
+
+    /** {@inheritdoc} */
     public function createHKTAN(): HKTAN
     {
         return HKTANv6::createEmpty();

--- a/lib/Fhp/Segment/TAN/VerfahrensparameterZweiSchrittVerfahrenV7.php
+++ b/lib/Fhp/Segment/TAN/VerfahrensparameterZweiSchrittVerfahrenV7.php
@@ -5,23 +5,33 @@ namespace Fhp\Segment\TAN;
 use Fhp\Model\TanMode;
 use Fhp\Segment\BaseDeg;
 
-class VerfahrensparameterZweiSchrittVerfahrenV6 extends BaseDeg implements TanMode
+class VerfahrensparameterZweiSchrittVerfahrenV7 extends BaseDeg implements TanMode
 {
     /** @var int Allowed values: 900 through 997 */
     public $sicherheitsfunktion;
-    /** @var string Allowed values: 1, 2; See specification or {@link HKTANv6::$$tanProzess} for details. */
+    /** @var int Allowed values: 1, 2; See specification or {@link HKTANv7::$$tanProzess} for details. */
     public $tanProzess;
     /** @var string */
     public $technischeIdentifikationTanVerfahren;
-    /** @var string|null Max length: 32 */
-    public $zkaTanVerfahren;
+    /**
+     * Allowed values:
+     * - HHD
+     * - HHDUC
+     * - HHDOPT1
+     * - mobileTAN
+     * - App
+     * - Decoupled
+     * - DecoupledPush
+     * @var string|null Max length: 32
+     */
+    public $dkTanVerfahren;
     /** @var string|null Max length: 10 */
-    public $versionZkaTanVerfahren;
+    public $versionDkTanVerfahren;
     /** @var string Max length: 30 */
     public $nameDesZweiSchrittVerfahrens;
-    /** @var int */
+    /** @var int|null Present iff !isDecoupled. */
     public $maximaleLaengeDesTanEingabewertes;
-    /** @var int Allowed values: 1 = numerisch, 2 = alfanumerisch */
+    /** @var int|null Present iff !isDecoupled. Allowed values: 1 = numerisch, 2 = alfanumerisch */
     public $erlaubtesFormat;
     /** @var string */
     public $textZurBelegungDesRueckgabewertes;
@@ -57,6 +67,16 @@ class VerfahrensparameterZweiSchrittVerfahrenV6 extends BaseDeg implements TanMo
     public $antwortHhdUcErforderlich;
     /** @var int|null */
     public $anzahlUnterstuetzterAktiverTanMedien;
+    /** @var int|null Present iff isDecoupled. 0 means infinity. */
+    public $maximaleAnzahlStatusabfragen;
+    /** @var int|null Present iff isDecoupled. In seconds. */
+    public $wartezeitVorErsterStatusabfrage;
+    /** @var int|null Present iff isDecoupled. In seconds. */
+    public $wartezeitVorNaechsterStatusabfrage;
+    /** @var bool|null Maybe present if isDecoupled. */
+    public $manuelleBestaetigungMoeglich;
+    /** @var bool|null Maybe present if isDecoupled. */
+    public $automatisierteStatusabfragenErlaubt;
 
     /** {@inheritdoc} */
     public function getId(): int
@@ -79,7 +99,7 @@ class VerfahrensparameterZweiSchrittVerfahrenV6 extends BaseDeg implements TanMo
     /** {@inheritdoc} */
     public function isDecoupled(): bool
     {
-        return false;
+        return $this->dkTanVerfahren === 'Decoupled' || $this->dkTanVerfahren === 'DecoupledPush';
     }
 
     /** {@inheritdoc} */
@@ -121,12 +141,24 @@ class VerfahrensparameterZweiSchrittVerfahrenV6 extends BaseDeg implements TanMo
     /** {@inheritdoc} */
     public function getMaxTanLength(): int
     {
+        if ($this->isDecoupled()) {
+            throw new \RuntimeException('getMaxTanLength is not available for decoupled TAN modes');
+        }
+        if ($this->maximaleLaengeDesTanEingabewertes === null) {
+            throw new \AssertionError('maximaleLaengeDesTanEingabewertes is unexpectedly absent');
+        }
         return $this->maximaleLaengeDesTanEingabewertes;
     }
 
     /** {@inheritdoc} */
     public function getTanFormat(): int
     {
+        if ($this->isDecoupled()) {
+            throw new \RuntimeException('getTanFormat is not available for decoupled TAN modes');
+        }
+        if ($this->erlaubtesFormat === null) {
+            throw new \AssertionError('erlaubtesFormat is unexpectedly absent');
+        }
         return $this->erlaubtesFormat;
     }
 
@@ -139,6 +171,6 @@ class VerfahrensparameterZweiSchrittVerfahrenV6 extends BaseDeg implements TanMo
     /** {@inheritdoc} */
     public function createHKTAN(): HKTAN
     {
-        return HKTANv6::createEmpty();
+        return HKTANv7::createEmpty();
     }
 }

--- a/lib/Fhp/Segment/TAN/VerfahrensparameterZweiSchrittVerfahrenV7.php
+++ b/lib/Fhp/Segment/TAN/VerfahrensparameterZweiSchrittVerfahrenV7.php
@@ -169,6 +169,66 @@ class VerfahrensparameterZweiSchrittVerfahrenV7 extends BaseDeg implements TanMo
     }
 
     /** {@inheritdoc} */
+    public function getMaxDecoupledChecks(): int
+    {
+        if (!$this->isDecoupled()) {
+            throw new \RuntimeException('Only allowed for decoupled TAN modes');
+        }
+        if ($this->maximaleAnzahlStatusabfragen === null) {
+            throw new \AssertionError('maximaleAnzahlStatusabfragen is unexpectedly absent');
+        }
+        return $this->maximaleAnzahlStatusabfragen;
+    }
+
+    /** {@inheritdoc} */
+    public function getFirstDecoupledCheckDelaySeconds(): int
+    {
+        if (!$this->isDecoupled()) {
+            throw new \RuntimeException('Only allowed for decoupled TAN modes');
+        }
+        if ($this->wartezeitVorErsterStatusabfrage === null) {
+            throw new \AssertionError('wartezeitVorErsterStatusabfrage is unexpectedly absent');
+        }
+        return $this->wartezeitVorErsterStatusabfrage;
+    }
+
+    /** {@inheritdoc} */
+    public function getPeriodicDecoupledCheckDelaySeconds(): int
+    {
+        if (!$this->isDecoupled()) {
+            throw new \RuntimeException('Only allowed for decoupled TAN modes');
+        }
+        if ($this->wartezeitVorNaechsterStatusabfrage === null) {
+            throw new \AssertionError('wartezeitVorNaechsterStatusabfrage is unexpectedly absent');
+        }
+        return $this->wartezeitVorNaechsterStatusabfrage;
+    }
+
+    /** {@inheritdoc} */
+    public function allowsManualConfirmation(): bool
+    {
+        if (!$this->isDecoupled()) {
+            throw new \RuntimeException('Only allowed for decoupled TAN modes');
+        }
+        if ($this->manuelleBestaetigungMoeglich === null) {
+            throw new \AssertionError('manuelleBestaetigungMoeglich is unexpectedly absent');
+        }
+        return $this->manuelleBestaetigungMoeglich;
+    }
+
+    /** {@inheritdoc} */
+    public function allowsAutomatedPolling(): bool
+    {
+        if (!$this->isDecoupled()) {
+            throw new \RuntimeException('Only allowed for decoupled TAN modes');
+        }
+        if ($this->automatisierteStatusabfragenErlaubt === null) {
+            throw new \AssertionError('automatisierteStatusabfragenErlaubt is unexpectedly absent');
+        }
+        return $this->automatisierteStatusabfragenErlaubt;
+    }
+
+    /** {@inheritdoc} */
     public function createHKTAN(): HKTAN
     {
         return HKTANv7::createEmpty();


### PR DESCRIPTION
See #309 for background.

While the integration tests ensure that no existing (HKTANv6-based) authentication is broken, the new decoupled authentication is entirely untested and based solely on the [new specification](https://www.hbci-zka.de/dokumente/spezifikation_deutsch/fintsv3/FinTS_3.0_Security_Sicherheitsverfahren_PINTAN_2020-07-10_final_version.pdf) and specifically all the red parts in there.

Breaking Changes:
* `TanMode::getMaxTanLength()` and `TanMode::getTanFormat()` can now throw `\RuntimeException` (though they won't for existing "old" TanModes).
* There may now be TAN modes where `TanMode::isDecoupled()` returns `true`. Your application may want to filter out (not support) such TAN modes unless you explicitly implement support for decoupled modes (see `handleDecoupled()` in `Samples/login.php`).