### PR TITLE
Introduced Flicker Tan handling (only Version 1.4 so far)

### DIFF
--- a/Samples/login.php
+++ b/Samples/login.php
@@ -38,7 +38,7 @@ $fints = require_once 'init.php';
  * @param \Fhp\BaseAction $action Some action that requires strong authentication.
  * @throws CurlException|UnexpectedResponseException|ServerException See {@link FinTs::execute()} for details.
  */
-function handleStrongAuthentication(\Fhp\BaseAction $action)
+function handleStrongAuthentication(Fhp\BaseAction $action)
 {
     global $fints;
     if ($fints->getSelectedTanMode()->isDecoupled()) {
@@ -54,7 +54,7 @@ function handleStrongAuthentication(\Fhp\BaseAction $action)
  * @param \Fhp\BaseAction $action Some action that requires a TAN.
  * @throws CurlException|UnexpectedResponseException|ServerException See {@link FinTs::execute()} for details.
  */
-function handleTan(\Fhp\BaseAction $action)
+function handleTan(Fhp\BaseAction $action)
 {
     global $fints, $options, $credentials;
 
@@ -71,13 +71,21 @@ function handleTan(\Fhp\BaseAction $action)
 
     // Challenge Image for PhotoTan/ChipTan
     if ($tanRequest->getChallengeHhdUc()) {
-        $challengeImage = new \Fhp\Model\TanRequestChallengeImage(
-            $tanRequest->getChallengeHhdUc()
-        );
-        echo 'There is a challenge image.' . PHP_EOL;
-        // Save the challenge image somewhere
-        // Alternative: HTML sample code
-        echo '<img src="data:' . htmlspecialchars($challengeImage->getMimeType()) . ';base64,' . base64_encode($challengeImage->getData()) . '" />' . PHP_EOL;
+        try {
+            $flicker = new \Fhp\Model\TanRequestChallengeFlicker\TanRequestChallengeFlicker($tanRequest->getChallengeHhdUc());
+            echo 'There is a challenge flicker.' . PHP_EOL;
+            // save or output svg
+            echo $flicker->getSVG();
+        } catch (InvalidArgumentException $e) {
+            // was not a flicker
+            $challengeImage = new \Fhp\Model\TanRequestChallengeImage(
+                $tanRequest->getChallengeHhdUc()
+            );
+            echo 'There is a challenge image.' . PHP_EOL;
+            // Save the challenge image somewhere
+            // Alternative: HTML sample code
+            echo '<img src="data:' . htmlspecialchars($challengeImage->getMimeType()) . ';base64,' . base64_encode($challengeImage->getData()) . '" />' . PHP_EOL;
+        }
     }
 
     // Optional: Instead of printing the above to the console, you can relay the information (challenge and TAN medium)
@@ -124,7 +132,7 @@ function handleTan(\Fhp\BaseAction $action)
  * @param \Fhp\BaseAction $action Some action that requires decoupled authentication.
  * @throws CurlException|UnexpectedResponseException|ServerException See {@link FinTs::execute()} for details.
  */
-function handleDecoupled(\Fhp\BaseAction $action)
+function handleDecoupled(Fhp\BaseAction $action)
 {
     global $fints;
 

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
   "require": {
     "php": ">=7.1",
     "psr/log": "~1.0",
-    "ext-curl": "*"
+    "ext-curl": "*",
+    "meyfa/php-svg": "^0.11.2"
   },
   "require-dev": {
     "phpunit/phpunit": "9.5.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,61 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ec2dccada288475cf9884395088821cd",
+    "content-hash": "abfe36fd5b28ea790f8626727dfd0150",
     "packages": [
+        {
+            "name": "meyfa/php-svg",
+            "version": "v0.11.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/meyfa/php-svg.git",
+                "reference": "619033e906043a48439bf1661ba0b07b3624d9d6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/meyfa/php-svg/zipball/619033e906043a48439bf1661ba0b07b3624d9d6",
+                "reference": "619033e906043a48439bf1661ba0b07b3624d9d6",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "meyfa/phpunit-assert-gd": "^1.1",
+                "phpmd/phpmd": "@stable",
+                "phpunit/phpunit": "^4.8"
+            },
+            "suggest": {
+                "ext-gd": "Needed to rasterize images",
+                "ext-simplexml": "Needed to read SVG strings and files"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "SVG\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabian Meyer",
+                    "homepage": "http://meyfa.net"
+                }
+            ],
+            "description": "Read, edit, write, and render SVG files with PHP",
+            "homepage": "https://github.com/meyfa/php-svg",
+            "keywords": [
+                "svg"
+            ],
+            "support": {
+                "issues": "https://github.com/meyfa/php-svg/issues",
+                "source": "https://github.com/meyfa/php-svg/tree/v0.11.2"
+            },
+            "time": "2021-05-25T07:38:49+00:00"
+        },
         {
             "name": "psr/log",
             "version": "1.1.3",
@@ -4252,5 +4305,5 @@
         "ext-curl": "*"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/lib/Fhp/Model/TanRequestChallengeFlicker/FlickerTanDataElement.php
+++ b/lib/Fhp/Model/TanRequestChallengeFlicker/FlickerTanDataElement.php
@@ -1,0 +1,176 @@
+<?php
+
+namespace Fhp\Model\TanRequestChallengeFlicker;
+
+class FlickerTanDataElement
+{
+    public const ENC_ASCII = '1';
+    public const ENC_ASC = self::ENC_ASCII;
+    public const ENC_BCD = '0';
+
+    /**
+     * @var string the encoding (either self::ENC_ASC or self::ENC_BCD)
+     */
+    protected $enc;
+
+    /**
+     * @var string the raw data string
+     */
+    protected $data;
+
+    /**
+     * @var string the highest bit of the generated header
+     */
+    protected $headerHighBit;
+
+    /**
+     * @param $challenge string raw challenge text
+     * @return array [string $reducedChallenge, FlickerTanDataElement $dataElementObject]
+     */
+    public static function parseNextBlock(string $challenge): array
+    {
+        if (empty($challenge)) {
+            return [$challenge, new self('')];
+        }
+        $length = (int) substr($challenge, 0, 2);
+        $data = substr($challenge, 2, $length);
+        if (strlen($data) !== $length) {
+            throw new \InvalidArgumentException('Parsing went wromg');
+        }
+        $rest = substr($challenge, 2 + $length);
+        return [$rest, new self($data)];
+    }
+
+    /**
+     * The needed encoding will be automatically determined by the type of data
+     * @param string $data the raw data
+     */
+    protected function __construct(string $data)
+    {
+        $this->data = $data;
+        $this->headerHighBit = 0;
+        if (is_numeric($this->data) || empty($this->data)) {
+            $this->enc = self::ENC_BCD;
+        } else {
+            $this->enc = self::ENC_ASC;
+        }
+    }
+
+    /**
+     * @return int amount of bytes in data
+     */
+    protected function getLength(): int
+    {
+        if ($this->enc === self::ENC_BCD) {
+            return ceil(strlen($this->data) / 2);
+        }
+        return strlen($this->data);
+    }
+
+    /**
+     * @return string returns the hex representation from the header of the data element as string with length 2
+     */
+    public function getHeaderHex(): string
+    {
+        $lengthBin = str_pad(base_convert($this->getLength(), 10, 2), 6, '0', STR_PAD_LEFT);
+        $headerHex = base_convert($this->headerHighBit . $this->enc . $lengthBin, 2, 16);
+        return str_pad($headerHex, 2, '0', STR_PAD_LEFT);
+    }
+
+    /**
+     * @return string returns the hex representation of the data, depending on the set encoding
+     */
+    public function getDataHex(): string
+    {
+        if ($this->enc === self::ENC_BCD) {
+            // base 10 and hex BCD encoded numbers are the same in range 0 to 9
+            $hexData = $this->data;
+            // Pad on Byte lenght
+            if (strlen($hexData) % 2 === 1) {
+                $hexData .= 'F';
+            }
+            return $hexData;
+        }
+        // ASCII encoding
+        $hexData = '';
+        foreach (str_split($this->data) as $char) {
+            $hexData .= base_convert(ord($char), 10, 16);
+        }
+        return $hexData;
+    }
+
+    /**
+     * @return string returns the hex representation of the Data Element incl header information
+     */
+    public function toHex(): string
+    {
+        if (empty($this->data)) {
+            return '';
+        }
+        return $this->getHeaderHex() . $this->getDataHex();
+    }
+
+    /**
+     * @param string $hex which will be converted
+     * @param int $length to which the byte will be padded (default: 8)
+     * @return string binary representation of hex value as string with length $length
+     */
+    public static function hexToByte(string $hex, int $length = 8): string
+    {
+        $byte = base_convert($hex, 16, 2);
+        return str_pad($byte, $length, '0', STR_PAD_LEFT);
+    }
+
+    /**
+     * @return int calculates Luhn Checksum of this object
+     */
+    public function getLuhnChecksum(): int
+    {
+        return $this->calcLuhn($this->getDataHex());
+    }
+
+    /**
+     * @return int calculates the Luhn checksum of an hex string
+     */
+    protected function calcLuhn(string $hex): int
+    {
+        $sum = 0;
+        $doubleIt = false;
+        foreach (str_split($hex) as $char) {
+            $number = (int) base_convert($char, 16, 10);
+            if ($doubleIt) {
+                $number *= 2;
+                $decRep = str_split($number);
+                foreach ($decRep as $value) {
+                    $sum += (int) $value;
+                }
+            } else {
+                $sum += $number;
+            }
+            $doubleIt = !$doubleIt;
+        }
+        return $sum;
+    }
+
+    /**
+     * Some handy debug info
+     */
+    public function __debugInfo(): ?array
+    {
+        return [
+            'header' => $this->getHeaderHex(),
+            'data' => $this->data,
+            'hex-data' => $this->getDataHex(),
+            'hex' => $this->toHex(),
+            'luhn' => $this->getLuhnChecksum(),
+        ];
+    }
+
+    /**
+     * @return string hex representation of object
+     */
+    public function __toString()
+    {
+        return $this->toHex();
+    }
+}

--- a/lib/Fhp/Model/TanRequestChallengeFlicker/FlickerTanStartCode.php
+++ b/lib/Fhp/Model/TanRequestChallengeFlicker/FlickerTanStartCode.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Fhp\Model\TanRequestChallengeFlicker;
+
+use InvalidArgumentException;
+
+class FlickerTanStartCode extends FlickerTanDataElement
+{
+    /**
+     * @var string[] of the control bytes in hex representation
+     */
+    private $controlBytes;
+
+    /**
+     * Parses Header information, control bytes and start code
+     * @return array [string, FlickerTanStartCode]
+     */
+    public static function parseNextBlock(string $challenge): array
+    {
+        $header = substr($challenge, 0, 2);
+        $rest = substr($challenge, 2);
+        $byte = self::hexToByte($header);
+        /* LS encoded base 16 idx:
+         * 2 - 7: length start code
+         * 1: 0=BCD 1=ASC // never set
+         * 0: 0=without ctrl byte 1=with ctrl byte */
+        $hasControl = $byte[0] === '1';
+        $length = (int) base_convert(substr($byte, 2, 6), 2, 10);
+        [$ctrlBytes, $rest] = self::parseControlBytes($rest, $hasControl);
+        $data = substr($rest, 0, $length);
+        $rest = substr($rest, $length);
+        return [$rest, new self($ctrlBytes, $data)];
+    }
+
+    /**
+     * @param array $ctrlBytes
+     * @param string $data
+     * @throws InvalidArgumentException if $ctrlBytes are unequal to ['01'] -> old version not supported so far
+     */
+    protected function __construct(array $ctrlBytes, string $data)
+    {
+        if ($ctrlBytes !== ['01']) {
+            throw new InvalidArgumentException('Other versions then 1.4 are not supported');
+        }
+        parent::__construct($data);
+        $this->controlBytes = $ctrlBytes;
+        $this->headerHighBit = '1';
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function toHex(): string
+    {
+        return $this->getHeaderHex() . implode('', $this->controlBytes) . $this->getDataHex();
+    }
+
+    /**
+     * Helper function to parse the control bytes
+     * @param $challenge
+     * @param $hasControl
+     * @return array
+     */
+    private static function parseControlBytes($challenge, $hasControl): array
+    {
+        $controlBytes = [];
+        $rest = $challenge;
+        while ($hasControl) {
+            $ctrl = substr($challenge, 0, 2);
+            $controlBytes[] = $ctrl;
+            $rest = substr($challenge, 2);
+            $hasControl = self::hexToByte($ctrl)[0] === '1';
+        }
+        return [$controlBytes, $rest];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getLuhnChecksum(): int
+    {
+        $luhn = 0;
+        foreach ($this->controlBytes as $ctrl) {
+            $luhn = $this->calcLuhn($ctrl);
+        }
+        $luhn += parent::getLuhnChecksum(); // Luhn from Startcode data
+        return $luhn;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function __debugInfo(): ?array
+    {
+        return [
+            'header' => $this->getHeaderHex(),
+            'ctrl' => $this->controlBytes,
+            'data' => $this->data,
+            'hex-data' => $this->getDataHex(),
+            'luhn' => $this->getLuhnChecksum(),
+        ];
+    }
+}

--- a/lib/Fhp/Model/TanRequestChallengeFlicker/FlickerTanSvg.php
+++ b/lib/Fhp/Model/TanRequestChallengeFlicker/FlickerTanSvg.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace Fhp\Model\TanRequestChallengeFlicker;
+
+use SVG\Nodes\Presentation\SVGAnimate;
+use SVG\Nodes\Shapes\SVGPolygon;
+use SVG\Nodes\Shapes\SVGRect;
+use SVG\SVG;
+
+/**
+ * inspired by @see https://github.com/willuhn/hbci4java/blob/master/src/org/kapott/hbci/manager/FlickerCode.java
+ * documentation @see tan_hhd_uc_v14.pdf
+ */
+class FlickerTanSvg extends SVG
+{
+    /**
+     * @var string[] the code in half-bit representation (string has length 4)
+     */
+    private $bitPatterns;
+
+    /**
+     * @var int blink frequency in Hz [1/s] should be between 2 and 20 Hz by documentation, but many TAN Generators are able to fetch 40 Hz as well
+     */
+    private $frequency;
+
+    /**
+     * @param int $flickerFrequenz in Hz [1/s]
+     * @param int $width width of the svg, aspect ratio 2:1 is recommended, but not enforced
+     * @param int $height height of the svg
+     */
+    public function __construct(string $hexCode, int $flickerFrequenz = 10, int $width = 210, int $height = 130)
+    {
+        $this->frequency = $flickerFrequenz;
+        // prefix sync identifier
+        $this->bitPatterns[] = '1111';
+        $this->bitPatterns[] = '0000';
+        $this->bitPatterns[] = '1111';
+        $this->bitPatterns[] = '1111';
+        // convert hex code to flicker pattern
+        $len = strlen($hexCode);
+        for ($i = 0; $i < $len; $i += 2) {
+            $byte = base_convert(substr($hexCode, $i, 2), 16, 2);
+            // add missing zeros to the left
+            $byte = str_pad($byte, 8, '0', STR_PAD_LEFT);
+            // reverse order of half-bytes;  flicker pattern is | clock | 2^0 | 2^1 | 2^2 | 2^3 |
+            $firstHalfByte = strrev(substr($byte, 0, 4));
+            $secondHalfByte = strrev(substr($byte, 4, 4));
+            // change order from first and second half byte (@see C.2)
+            $this->bitPatterns[] = $secondHalfByte;
+            $this->bitPatterns[] = $firstHalfByte;
+        }
+
+        // do the svg
+        parent::__construct($width, $height);
+        $doc = $this->getDocument();
+        // set relative coordinates, which are not dependent on render size
+        $doc->setAttribute('viewBox', '0 0 210 105');
+        $doc->setAttribute('preserveAspectRatio', 'none');
+        // init background rect
+        $bg = (new SVGRect(0, 0, 210, 105))
+            ->setRX(7.5)
+            ->setRY(7.5)
+            ->setStyle('fill', 'black');
+        $doc->addChild($bg);
+        $triLeft = (new SVGPolygon([
+            [25, 18], // middle bottom
+            [32, 5], // top right
+            [18, 5], // top left
+        ]))->setStyle('fill', 'grey');
+        $doc->addChild($triLeft);
+        $triRight = (new SVGPolygon([
+            [160 + 25, 18], // middle bottom
+            [160 + 32, 5], // top right
+            [160 + 18, 5], // top left
+        ]))->setStyle('fill', 'grey');
+        $doc->addChild($triRight);
+
+        // init flicker rectangles
+        for ($i = 0; $i < 5; ++$i) {
+            $rect = new SVGRect(40 * $i + 10, 20, 30, 75);
+            $animation = $this->getAnimation($i);
+            $rect->addChild($animation);
+            $doc->addChild($rect);
+        }
+        //var_dump($this->bitPatterns);
+    }
+
+    /**
+     * @param int $channelNumber flickerRectangles numbered from left to right, 0 is clock, 1 is 2^0, ..., 4 is 2^3 half byte representation
+     * @return SVGAnimate
+     */
+    public function getAnimation(int $channelNumber): SVGAnimate
+    {
+        $timePerHalfByte = 1 / ($this->frequency) * 2;
+        $animation = (new SVGAnimate())
+            ->setAttribute('attributeName', 'fill')
+            ->setAttribute('calcMode', 'discrete')
+            ->setAttribute('repeatCount', 'indefinite');
+        if ($channelNumber === 0) {
+            // first rectangle is the clock
+            return $animation
+                ->setAttribute('values', 'white;black;white')
+                ->setAttribute('keyFrames', '0;0.5;1')
+                ->setAttribute('dur', $timePerHalfByte . 's');
+        }
+        $colors = array_map(static function (string $pattern) use ($channelNumber) {
+            return $pattern[$channelNumber - 1] === '1' ? 'white' : 'black';
+        }, $this->bitPatterns);
+        $keyFrames = range(0, 1, 1.0 / count($this->bitPatterns));
+
+        return $animation
+            ->setAttribute('dur', ($timePerHalfByte * count($this->bitPatterns)) . 's')
+            ->setAttribute('values', implode(';', $colors))
+            ->setAttribute('keyFrames', implode(';', $keyFrames));
+    }
+}

--- a/lib/Fhp/Model/TanRequestChallengeFlicker/TanRequestChallengeFlicker.php
+++ b/lib/Fhp/Model/TanRequestChallengeFlicker/TanRequestChallengeFlicker.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace Fhp\Model\TanRequestChallengeFlicker;
+
+use Fhp\Syntax\Bin;
+use InvalidArgumentException;
+
+class TanRequestChallengeFlicker
+{
+    /**
+     * @var string original challenge data
+     */
+    private $challenge;
+
+    /**
+     * @var FlickerTanStartCode holds and parses the startcode block of the challenge
+     */
+    private $startCode;
+
+    /**
+     * @var FlickerTanDataElement Holds and parses the first DataElement of the challenge
+     */
+    private $de1;
+
+    /**
+     * @var FlickerTanDataElement Holds and parses the second DataElement of the challenge
+     */
+    private $de2;
+
+    /**
+     * @var FlickerTanDataElement Holds and parses the third DataElement of the challenge
+     */
+    private $de3;
+
+    public function __construct(Bin $challengeBin)
+    {
+        $this->challenge = $challengeBin->getData();
+        $this->parseChallenge();
+    }
+
+    private function parseChallenge(): void
+    {
+        $reducedChallenge = trim(str_replace(' ', '', $this->challenge));
+        // length of whole challenge (without lc) max 255 | encoding: base 10
+        $lc = (int) substr($reducedChallenge, 0, 3);
+        $reducedChallenge = substr($reducedChallenge, 3);
+        if (strlen($reducedChallenge) !== $lc) {
+            throw new InvalidArgumentException('Wrong length of TAN Challenge - only Version 1.4 supported');
+        }
+
+        [$reducedChallenge, $this->startCode] = FlickerTanStartCode::parseNextBlock($reducedChallenge);
+        [$reducedChallenge, $this->de1] = FlickerTanDataElement::parseNextBlock($reducedChallenge);
+        [$reducedChallenge, $this->de2] = FlickerTanDataElement::parseNextBlock($reducedChallenge);
+        [$reducedChallenge, $this->de3] = FlickerTanDataElement::parseNextBlock($reducedChallenge);
+
+        if (!empty($reducedChallenge)) {
+            throw new InvalidArgumentException("Challenge has unexpected ending $reducedChallenge");
+        }
+    }
+
+    private function calcXorChecksum(): string
+    {
+        $xor = 0b0000; // bin Representation of 0
+        $hex = str_split($this->getHexPayload());
+        foreach ($hex as $hexChar) {
+            $intVal = (int) base_convert($hexChar, 16, 10);
+            $xor ^= $intVal;
+        }
+        return base_convert($xor, 10, 16);
+    }
+
+    private function getHexPayload(): string
+    {
+        $hex = $this->startCode->toHex();
+        $hex .= $this->de1->toHex();
+        $hex .= $this->de2->toHex();
+        $hex .= $this->de3->toHex();
+        //var_dump(implode('|', str_split($hex, 2)));
+        $lc = strlen($hex) / 2 + 1;
+        $lc = str_pad(base_convert($lc, 10, 16), 2, '0', STR_PAD_LEFT);
+        return $lc . $hex;
+    }
+
+    private function calcLuhnChecksum(): int
+    {
+        $luhn = $this->startCode->getLuhnChecksum();
+        $luhn += $this->de1->getLuhnChecksum();
+        $luhn += $this->de2->getLuhnChecksum();
+        $luhn += $this->de3->getLuhnChecksum();
+        return (10 - ($luhn % 10)) % 10;
+    }
+
+    /**
+     * @return string hex representation of challenge
+     */
+    public function getHex(): string
+    {
+        $payload = $this->getHexPayload();
+        $luhn = $this->calcLuhnChecksum();
+        $xor = $this->calcXorChecksum();
+
+        return $payload . $luhn . $xor;
+    }
+
+    /**
+     * @param int $freq frequency of the flicker challenge
+     * @param int $width width of the flicker challenge
+     * @return FlickerTanSvg SVG File with flicker code
+     */
+    public function getSVG(int $freq = 10, int $width = 300): FlickerTanSvg
+    {
+        $hexCode = $this->getHex();
+        return new FlickerTanSvg($hexCode, $freq, $width, $width / 2);
+    }
+
+    public function __debugInfo(): ?array
+    {
+        return [
+            'startcode' => $this->startCode,
+            'de1' => $this->de1,
+            'de2' => $this->de2,
+            'de3' => $this->de3,
+            'payload' => $this->getHexPayload(),
+            'luhn' => $this->calcLuhnChecksum(),
+            'xor' => $this->calcXorChecksum(),
+        ];
+    }
+}

--- a/lib/Tests/Fhp/Model/TanRequestChallengeFlicker/TanRequestChallengeFlickerTest.php
+++ b/lib/Tests/Fhp/Model/TanRequestChallengeFlicker/TanRequestChallengeFlickerTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Fhp\Model\TanRequestChallengeFlicker;
+
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+
+class TanRequestChallengeFlickerTest extends TestCase
+{
+    const OLD_VERSION = '';
+    const BESTAND_ABFRAGEN_IN1 = '038 8A 01 2392302069 22 DE12500105170648489890'; // example iban
+    const BESTAND_ABFRAGEN_IN2 = '038 8A 01 2392307899 22 DE12500105170648489890'; // example iban
+    const BESTAND_ABFRAGEN_OUT1 = '1f8501239230206956444531323530303130353137303634383438393839305e';
+    const BESTAND_ABFRAGEN_OUT2 = '1f8501239230789956444531323530303130353137303634383438393839300c';
+
+    public function testGetHex1(): void
+    {
+        $flicker = new TanRequestChallengeFlicker(self::BESTAND_ABFRAGEN_IN1);
+        $this->assertEquals(self::BESTAND_ABFRAGEN_OUT1, $flicker->getHex());
+    }
+
+    public function testGetHex2(): void
+    {
+        $flicker = new TanRequestChallengeFlicker(self::BESTAND_ABFRAGEN_IN2);
+        $this->assertEquals(self::BESTAND_ABFRAGEN_OUT2, $flicker->getHex());
+    }
+
+    public function testGetHexOldVersion(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $flicker = new TanRequestChallengeFlicker(self::OLD_VERSION);
+    }
+}


### PR DESCRIPTION
Introduced Flicker Tan Version 1.4 
Used SVG Libary. Let me know if the dependency should be dropped 
I have added some sample code to the Samples, it will work together with browser.php but it seems client support was and is missing (no tan files are saved)

Note: even before my new require the composer.lock was not installable in php 7.1 (without update) therefore i tested and generated the lockfile with php 7.4 