### PR TITLE
Fix minor PSR-0 violation

### DIFF
--- a/lib/Tests/Fhp/Model/FlickerTan/TanRequestChallengeFlickerTest.php
+++ b/lib/Tests/Fhp/Model/FlickerTan/TanRequestChallengeFlickerTest.php
@@ -1,7 +1,8 @@
 <?php
 
-namespace Fhp\Model\FlickerTan;
+namespace Tests\Fhp\Model\FlickerTan;
 
+use Fhp\Model\FlickerTan\TanRequestChallengeFlicker;
 use Fhp\Syntax\Bin;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
@@ -22,7 +23,7 @@ class TanRequestChallengeFlickerTest extends TestCase
     public function testGetHexOldVersion(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        $flicker = new TanRequestChallengeFlicker(new Bin(self::SC_OLD_VERSION));
+        new TanRequestChallengeFlicker(new Bin(self::SC_OLD_VERSION));
     }
 
     public function testGetHex1(): void


### PR DESCRIPTION
Gets rid of this warning:
```
$ composer update
Class Fhp\Model\FlickerTan\TanRequestChallengeFlickerTest located in ./vendor/nemiah/php-fints/lib/Tests/Fhp/Model/FlickerTan/TanRequestChallengeFlickerTest.php does not comply with psr-0 autoloading standard. Skipping.
```