### PR TITLE
Move field types from phpdoc to native property types

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,6 @@ script:
   - ./vendor/bin/phpunit
 dist: bionic
 php:
-  - '7.4'
   - '8.0'
   - '8.1.0'
+  - '8.2.0'

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     }
   },
   "require": {
-    "php": ">=7.1",
+    "php": ">=8.0",
     "psr/log": "^1|^2|^3",
     "ext-curl": "*",
     "ext-mbstring": "*"

--- a/lib/Fhp/Action/GetStatementOfAccount.php
+++ b/lib/Fhp/Action/GetStatementOfAccount.php
@@ -201,9 +201,9 @@ class GetStatementOfAccount extends PaginateableAction
 
     private function parseMt940()
     {
-        if (strpos(strtolower($this->bankName), 'sparda') !== false) {
+        if (str_contains(strtolower($this->bankName), 'sparda')) {
             $parser = new SpardaMT940();
-        } elseif (strpos(strtolower($this->bankName), 'postbank') !== false) {
+        } elseif (str_contains(strtolower($this->bankName), 'postbank')) {
             $parser = new PostbankMT940();
         } else {
             $parser = new MT940();

--- a/lib/Fhp/MT940/Dialect/SpardaMT940.php
+++ b/lib/Fhp/MT940/Dialect/SpardaMT940.php
@@ -77,7 +77,7 @@ class SpardaMT940 extends MT940
 
         $desc = parent::extractStructuredDataFromRemittanceLines($correctedLines, $gvc, $rawLines, $transaction);
 
-        if (isset($desc['SVWZ']) && strpos($desc['SVWZ'], 'Dauerauftrag') === 0) {
+        if (isset($desc['SVWZ']) && str_starts_with($desc['SVWZ'], 'Dauerauftrag')) {
             $gvc = '152';
             $rawLines[0] = 'Dauerauftrag-Gutschrift';
         }

--- a/lib/Fhp/MT940/MT940.php
+++ b/lib/Fhp/MT940/MT940.php
@@ -61,9 +61,9 @@ class MT940
                 } elseif (
                     // found transaction
                     // trx:61:1603310331DR637,39N033NONREF
-                    0 === strpos($day[$i], '61:')
+                    str_starts_with($day[$i], '61:')
                     && isset($day[$i + 1])
-                    && 0 === strpos($day[$i + 1], '86:')
+                    && str_starts_with($day[$i + 1], '86:')
                 ) {
                     $transaction = substr($day[$i], 3);
                     $description = substr($day[$i + 1], 3);

--- a/lib/Fhp/Segment/AUB/HIAUBSv9.php
+++ b/lib/Fhp/Segment/AUB/HIAUBSv9.php
@@ -12,6 +12,5 @@ use Fhp\Segment\BaseGeschaeftsvorfallparameter;
  */
 class HIAUBSv9 extends BaseGeschaeftsvorfallparameter
 {
-    /** @var ParameterAuslandsueberweisungV2 */
-    public $parameter;
+    public ParameterAuslandsueberweisungV2 $parameter;
 }

--- a/lib/Fhp/Segment/AUB/HKAUBv9.php
+++ b/lib/Fhp/Segment/AUB/HKAUBv9.php
@@ -2,7 +2,6 @@
 
 namespace Fhp\Segment\AUB;
 
-use Fhp\DataTypes\Bin;
 use Fhp\Segment\BaseSegment;
 
 /**
@@ -13,12 +12,10 @@ use Fhp\Segment\BaseSegment;
  */
 class HKAUBv9 extends BaseSegment
 {
-    /** @var \Fhp\Segment\Common\Kti */
-    public $kontoverbindungInternational;
+    public \Fhp\Segment\Common\Kti $kontoverbindungInternational;
 
-    /** @var int Max length: 4 */
-    public $DTAZVHandbuch;
+    /** Max length: 4 */
+    public int $DTAZVHandbuch;
 
-    /** @var Bin */
-    public $DTAZVDatensatz;
+    public \Fhp\Syntax\Bin $DTAZVDatensatz;
 }

--- a/lib/Fhp/Segment/AUB/ParameterAuslandsueberweisungV2.php
+++ b/lib/Fhp/Segment/AUB/ParameterAuslandsueberweisungV2.php
@@ -6,24 +6,11 @@ use Fhp\Segment\BaseDeg;
 
 class ParameterAuslandsueberweisungV2 extends BaseDeg
 {
-    /** @var int */
-    public $DTAZVHandbuch;
-
-    /** @var int */
-    public $maximaleAnzahlTSaetze;
-
-    /** @var float */
-    public $meldepflichtgrenzbetrag;
-
-    /** @var string|null */
-    public $unterstuetzteMeldesaetze;
-
-    /** @var string|null */
-    public $zugelasseneWeisungsschluessel;
-
-    /** @var string|null */
-    public $maximaleAnzahlDerZugelassenenWeisungschluessel;
-
-    /** @var string|null */
-    public $erlaubteZahlungsarten;
+    public int $DTAZVHandbuch;
+    public int $maximaleAnzahlTSaetze;
+    public float $meldepflichtgrenzbetrag;
+    public ?string $unterstuetzteMeldesaetze = null;
+    public ?string $zugelasseneWeisungsschluessel = null;
+    public ?string $maximaleAnzahlDerZugelassenenWeisungschluessel = null;
+    public ?string $erlaubteZahlungsarten = null;
 }

--- a/lib/Fhp/Segment/AnonymousSegment.php
+++ b/lib/Fhp/Segment/AnonymousSegment.php
@@ -94,8 +94,9 @@ final class AnonymousSegment extends BaseSegment implements \Serializable
 
     /**
      * Just to override the super factory.
+     * @noinspection PhpUnnecessaryStaticReferenceInspection
      */
-    public static function createEmpty()
+    public static function createEmpty(): static
     {
         // Note: createEmpty() normally runs the constructor and then fills the Segmentkopf, but that is not possible
         // for AnonymousSegment. Callers should just call the constructor itself.

--- a/lib/Fhp/Segment/AnonymousSegment.php
+++ b/lib/Fhp/Segment/AnonymousSegment.php
@@ -13,9 +13,8 @@ final class AnonymousSegment extends BaseSegment implements \Serializable
     /**
      * The type plus version of the segment, i.e. the class name of the class that would normally implement it.
      * This is redundant with super::$segmentkopf, but it's useful to repeat here so that it shows up in a debugger.
-     * @var string
      */
-    public $type;
+    public string $type;
 
     /**
      * Contains the data elements of the segment. Some of them can be scalar values (represented as strings), and others
@@ -27,7 +26,7 @@ final class AnonymousSegment extends BaseSegment implements \Serializable
      *
      * @var string[]|string[][]
      */
-    private $elements = [];
+    private array $elements;
 
     /**
      * @param string[]|string[][] $elements

--- a/lib/Fhp/Segment/BME/HIBMESv1.php
+++ b/lib/Fhp/Segment/BME/HIBMESv1.php
@@ -15,8 +15,7 @@ use Fhp\Segment\DSE\SEPADirectDebitMinimalLeadTimeProvider;
  */
 class HIBMESv1 extends BaseGeschaeftsvorfallparameter implements HIDXES
 {
-    /** @var ParameterTerminierteSEPAFirmenSammellastschriftEinreichenV1 */
-    public $parameter;
+    public ParameterTerminierteSEPAFirmenSammellastschriftEinreichenV1 $parameter;
 
     public function getParameter(): SEPADirectDebitMinimalLeadTimeProvider
     {

--- a/lib/Fhp/Segment/BME/HIBMESv2.php
+++ b/lib/Fhp/Segment/BME/HIBMESv2.php
@@ -15,8 +15,7 @@ use Fhp\Segment\DSE\SEPADirectDebitMinimalLeadTimeProvider;
  */
 class HIBMESv2 extends BaseGeschaeftsvorfallparameter implements HIDXES
 {
-    /** @var ParameterTerminierteSEPAFirmenSammellastschriftEinreichenV2 */
-    public $parameter;
+    public ParameterTerminierteSEPAFirmenSammellastschriftEinreichenV2 $parameter;
 
     public function getParameter(): SEPADirectDebitMinimalLeadTimeProvider
     {

--- a/lib/Fhp/Segment/BME/ParameterTerminierteSEPAFirmenSammellastschriftEinreichenV1.php
+++ b/lib/Fhp/Segment/BME/ParameterTerminierteSEPAFirmenSammellastschriftEinreichenV1.php
@@ -6,12 +6,7 @@ use Fhp\Segment\BSE\ParameterTerminierteSEPAFirmenEinzellastschriftEinreichenV1;
 
 class ParameterTerminierteSEPAFirmenSammellastschriftEinreichenV1 extends ParameterTerminierteSEPAFirmenEinzellastschriftEinreichenV1
 {
-    /** @var int */
-    public $maximaleAnzahlDirectDebitTransferTransactionInformation;
-
-    /** @var bool */
-    public $summenfeldBenoetigt;
-
-    /** @var bool */
-    public $einzelbuchungErlaubt;
+    public int $maximaleAnzahlDirectDebitTransferTransactionInformation;
+    public bool $summenfeldBenoetigt;
+    public bool $einzelbuchungErlaubt;
 }

--- a/lib/Fhp/Segment/BME/ParameterTerminierteSEPAFirmenSammellastschriftEinreichenV2.php
+++ b/lib/Fhp/Segment/BME/ParameterTerminierteSEPAFirmenSammellastschriftEinreichenV2.php
@@ -6,18 +6,11 @@ use Fhp\Segment\BSE\ParameterTerminierteSEPAFirmenLastschriftEinreichenV2;
 
 class ParameterTerminierteSEPAFirmenSammellastschriftEinreichenV2 extends ParameterTerminierteSEPAFirmenLastschriftEinreichenV2
 {
-    /** @var int */
-    public $maximaleAnzahlDirectDebitTransferTransactionInformation;
-
-    /** @var bool */
-    public $summenfeldBenoetigt;
-
-    /** @var bool */
-    public $einzelbuchungErlaubt;
-
-    /** @var string|null Max Length: 4096 */
-    public $zulaessigePurposecodes;
-
+    public int $maximaleAnzahlDirectDebitTransferTransactionInformation;
+    public bool $summenfeldBenoetigt;
+    public bool $einzelbuchungErlaubt;
+    /** Max Length: 4096 */
+    public ?string $zulaessigePurposecodes = null;
     /** @var string[]|null @Max(9) Max Length: 256 */
-    public $unterstuetzteSEPADatenformate;
+    public ?array $unterstuetzteSEPADatenformate = null;
 }

--- a/lib/Fhp/Segment/BSE/HIBSESv1.php
+++ b/lib/Fhp/Segment/BSE/HIBSESv1.php
@@ -15,8 +15,7 @@ use Fhp\Segment\DSE\SEPADirectDebitMinimalLeadTimeProvider;
  */
 class HIBSESv1 extends BaseGeschaeftsvorfallparameter implements HIDXES
 {
-    /** @var ParameterTerminierteSEPAFirmenEinzellastschriftEinreichenV1 */
-    public $parameter;
+    public ParameterTerminierteSEPAFirmenEinzellastschriftEinreichenV1 $parameter;
 
     public function getParameter(): SEPADirectDebitMinimalLeadTimeProvider
     {

--- a/lib/Fhp/Segment/BSE/HIBSESv2.php
+++ b/lib/Fhp/Segment/BSE/HIBSESv2.php
@@ -15,8 +15,7 @@ use Fhp\Segment\DSE\SEPADirectDebitMinimalLeadTimeProvider;
  */
 class HIBSESv2 extends BaseGeschaeftsvorfallparameter implements HIDXES
 {
-    /** @var ParameterTerminierteSEPAFirmenEinzellastschriftEinreichenV2 */
-    public $parameter;
+    public ParameterTerminierteSEPAFirmenEinzellastschriftEinreichenV2 $parameter;
 
     public function getParameter(): SEPADirectDebitMinimalLeadTimeProvider
     {

--- a/lib/Fhp/Segment/BSE/ParameterTerminierteSEPAFirmenEinzellastschriftEinreichenV1.php
+++ b/lib/Fhp/Segment/BSE/ParameterTerminierteSEPAFirmenEinzellastschriftEinreichenV1.php
@@ -8,17 +8,12 @@ use Fhp\Segment\DSE\SEPADirectDebitMinimalLeadTimeProvider;
 
 class ParameterTerminierteSEPAFirmenEinzellastschriftEinreichenV1 extends BaseDeg implements SEPADirectDebitMinimalLeadTimeProvider
 {
-    /** @var int Must be => 1 */
-    public $minimaleVorlaufzeitFNALRCUR;
-
-    /** @var int */
-    public $maximaleVorlaufzeitFNALRCUR;
-
-    /** @var int Must be => 1 */
-    public $minimaleVorlaufzeitFRSTOOFF;
-
-    /** @var int */
-    public $maximaleVorlaufzeitFRSTOOFF;
+    /** Must be => 1 */
+    public int $minimaleVorlaufzeitFNALRCUR;
+    public int $maximaleVorlaufzeitFNALRCUR;
+    /** Must be => 1 */
+    public int $minimaleVorlaufzeitFRSTOOFF;
+    public int $maximaleVorlaufzeitFRSTOOFF;
 
     public function getMinimalLeadTime(string $seqType): ?MinimaleVorlaufzeitSEPALastschrift
     {

--- a/lib/Fhp/Segment/BSE/ParameterTerminierteSEPAFirmenEinzellastschriftEinreichenV2.php
+++ b/lib/Fhp/Segment/BSE/ParameterTerminierteSEPAFirmenEinzellastschriftEinreichenV2.php
@@ -4,9 +4,9 @@ namespace Fhp\Segment\BSE;
 
 class ParameterTerminierteSEPAFirmenEinzellastschriftEinreichenV2 extends ParameterTerminierteSEPAFirmenLastschriftEinreichenV2
 {
-    /** @var string|null Max Length: 4096 */
-    public $zulaessigePurposecodes;
+    /** Max Length: 4096 */
+    public ?string $zulaessigePurposecodes = null;
 
     /** @var string[]|null @Max(9) Max length: 256 */
-    public $unterstuetzteSEPADatenformate;
+    public ?array $unterstuetzteSEPADatenformate = null;
 }

--- a/lib/Fhp/Segment/BSE/ParameterTerminierteSEPAFirmenLastschriftEinreichenV2.php
+++ b/lib/Fhp/Segment/BSE/ParameterTerminierteSEPAFirmenLastschriftEinreichenV2.php
@@ -8,14 +8,11 @@ use Fhp\Segment\DSE\SEPADirectDebitMinimalLeadTimeProvider;
 
 abstract class ParameterTerminierteSEPAFirmenLastschriftEinreichenV2 extends BaseDeg implements SEPADirectDebitMinimalLeadTimeProvider
 {
-    /** @var string */
-    public $minimaleVorlaufzeitCodiert;
-
-    /** @var string */
-    public $maximaleVorlaufzeitCodiert;
+    public string $minimaleVorlaufzeitCodiert;
+    public string $maximaleVorlaufzeitCodiert;
 
     /** @return MinimaleVorlaufzeitSEPALastschrift[] */
-    public function getMinimalLeadTime(string $seqType)
+    public function getMinimalLeadTime(string $seqType): array
     {
         return array_map(function ($value) use ($seqType) {
             return $value[$seqType] ?? null;

--- a/lib/Fhp/Segment/BaseDeg.php
+++ b/lib/Fhp/Segment/BaseDeg.php
@@ -13,9 +13,8 @@ abstract class BaseDeg implements \Serializable
 {
     /**
      * Reference to the descriptor for this type of segment.
-     * @var DegDescriptor|null
      */
-    private $descriptor = null;
+    private ?DegDescriptor $descriptor = null;
 
     /**
      * @return DegDescriptor The descriptor for this Deg type.
@@ -90,7 +89,7 @@ abstract class BaseDeg implements \Serializable
      * @param string $rawElements The serialized wire format for a data element group.
      * @return static The parsed value.
      */
-    public static function parse(string $rawElements)
+    public static function parse(string $rawElements): static
     {
         if (static::class === BaseDeg::class) {
             throw new UnsupportedException('Must not call BaseDeg::parse() on the base class');

--- a/lib/Fhp/Segment/BaseDescriptor.php
+++ b/lib/Fhp/Segment/BaseDescriptor.php
@@ -153,8 +153,8 @@ abstract class BaseDescriptor
      */
     private static function getBoolAnnotation(string $name, string $docComment): bool
     {
-        return str_contains("@$name ", $docComment)
-            || str_contains("@$name())", $docComment);
+        return str_contains($docComment, "@$name ")
+            || str_contains($docComment, "@$name())");
     }
 
     /**

--- a/lib/Fhp/Segment/BaseDescriptor.php
+++ b/lib/Fhp/Segment/BaseDescriptor.php
@@ -52,11 +52,11 @@ abstract class BaseDescriptor
                 throw new \InvalidArgumentException("Need type on property $property");
             }
             $maxCount = static::getIntAnnotation('Max', $docComment);
-            if (substr($type, -5) === '|null') { // Nullable field
+            if (str_ends_with($type, '|null')) { // Nullable field
                 $descriptor->optional = true;
                 $type = substr($type, 0, -5);
             }
-            if (substr($type, -2) === '[]') { // Array/repeated field
+            if (str_ends_with($type, '[]')) { // Array/repeated field
                 if ($maxCount === null) {
                     throw new \InvalidArgumentException("Repeated property $property needs @Max() annotation");
                 }
@@ -153,8 +153,8 @@ abstract class BaseDescriptor
      */
     private static function getBoolAnnotation(string $name, string $docComment): bool
     {
-        return strpos("@$name ", $docComment) !== false
-            || strpos("@$name())", $docComment) !== false;
+        return str_contains("@$name ", $docComment)
+            || str_contains("@$name())", $docComment);
     }
 
     /**
@@ -185,7 +185,7 @@ abstract class BaseDescriptor
         }
         if ($typeName === 'Bin') {
             $typeName = Bin::class;
-        } elseif (strpos($typeName, '\\') === false) {
+        } elseif (!str_contains($typeName, '\\')) {
             // Let's assume it's a relative type name, e.g. `X` mentioned in a file that starts with `namespace Fhp\Y`
             // would become `\Fhp\X\Y`.
             $typeName = $contextClass->getNamespaceName() . '\\' . $typeName;

--- a/lib/Fhp/Segment/BaseDescriptor.php
+++ b/lib/Fhp/Segment/BaseDescriptor.php
@@ -9,10 +9,10 @@ use Fhp\Syntax\Bin;
  */
 abstract class BaseDescriptor
 {
-    /** @var string Example: "Fhp\Segment\TAN\HITANSv6" (Segment) or "Fhp\Common\Kik" (Deg) */
-    public $class;
-    /** @var int Example: 1 */
-    public $version = 1;
+    /** Example: "Fhp\Segment\TAN\HITANSv6" (Segment) or "Fhp\Common\Kik" (Deg) */
+    public string $class;
+    /** Example: 1 */
+    public int $version = 1;
 
     /**
      * Descriptors for the elements inside the segment/Deg in the order of the wire format. The indices in this array
@@ -20,15 +20,14 @@ abstract class BaseDescriptor
      * documentation does not specify it (anymore).
      * @var ElementDescriptor[]
      */
-    public $elements = [];
+    public array $elements = [];
 
     /**
      * The last index that can be present in an exploded serialized segment/DEG. If one were to append a new field to
      * segment/DEG described by this descriptor, it would get index $maxIndex+1.
      * Usually $maxIndex==array_key_last($elements), but when the last element is repeated, then $maxIndex is larger.
-     * @var int
      */
-    public $maxIndex;
+    public int $maxIndex;
 
     protected function __construct(\ReflectionClass $clazz)
     {
@@ -99,7 +98,7 @@ abstract class BaseDescriptor
      * @throws \InvalidArgumentException If any of the fields in the given object is not valid according to the schema
      *     defined by this descriptor.
      */
-    public function validateObject($obj)
+    public function validateObject($obj): void
     {
         if (!is_a($obj, $this->class)) {
             throw new \InvalidArgumentException("Expected $this->class, got " . gettype($obj));
@@ -114,7 +113,7 @@ abstract class BaseDescriptor
      * @return \Generator|\ReflectionProperty[] All non-static public properties of the given class and its parents, but
      *     with the parents' properties *first*.
      */
-    private static function enumerateProperties(\ReflectionClass $clazz)
+    private static function enumerateProperties(\ReflectionClass $clazz): array|\Generator
     {
         if ($clazz->getParentClass() !== false) {
             yield from static::enumerateProperties($clazz->getParentClass());
@@ -192,7 +191,7 @@ abstract class BaseDescriptor
      *     classes in the same package.
      * @return string|\ReflectionClass The class that the type name refers to, or the scalar type name as a string.
      */
-    private static function resolveType(string $typeName, \ReflectionClass $contextClass)
+    private static function resolveType(string $typeName, \ReflectionClass $contextClass): \ReflectionClass|string
     {
         if (ElementDescriptor::isScalarType($typeName)) {
             return $typeName;

--- a/lib/Fhp/Segment/BaseGeschaeftsvorfallparameter.php
+++ b/lib/Fhp/Segment/BaseGeschaeftsvorfallparameter.php
@@ -17,20 +17,17 @@ abstract class BaseGeschaeftsvorfallparameter extends BaseSegment
 {
     /**
      * Maximum number of request segments of this kind that can be included in a single request message
-     * @var int
      */
-    public $maximaleAnzahlAuftraege;
+    public int $maximaleAnzahlAuftraege;
     /**
      * Minimum number of signatures required for this kind of business transaction. Note that zero signatures is
      * equivalent to an anonymous connection and one signature (the most common case) can be satisfied with PIN/TAN.
-     * @var int
      */
-    public $anzahlSignaturenMindestens;
+    public int $anzahlSignaturenMindestens;
     /**
      * Minimum cryptographic security required for this transaction type, where 0 means none.
-     * @var int
      */
-    public $sicherheitsklasse;
+    public int $sicherheitsklasse;
 
     // NOTE: Parameters specific to the respective transaction type follow here and are implemented in sub-classes.
 }

--- a/lib/Fhp/Segment/BaseGeschaeftsvorfallparameterOld.php
+++ b/lib/Fhp/Segment/BaseGeschaeftsvorfallparameterOld.php
@@ -15,15 +15,13 @@ abstract class BaseGeschaeftsvorfallparameterOld extends BaseSegment
 {
     /**
      * Maximum number of request segments of this kind that can be included in a single request message
-     * @var int
      */
-    public $maximaleAnzahlAuftraege;
+    public int $maximaleAnzahlAuftraege;
     /**
      * Minimum number of signatures required for this kind of business transaction. Note that zero signatures is
      * equivalent to an anonymous connection and one signature (the most common case) can be satisfied with PIN/TAN.
-     * @var int
      */
-    public $anzahlSignaturenMindestens;
+    public int $anzahlSignaturenMindestens;
 
     // NOTE: There is no Sicherheitsklasse here.
 

--- a/lib/Fhp/Segment/BaseSegment.php
+++ b/lib/Fhp/Segment/BaseSegment.php
@@ -54,7 +54,7 @@ abstract class BaseSegment implements SegmentInterface, \Serializable
      * @param int $segmentNumber The new segment number.
      * @return $this The same instance.
      */
-    public function setSegmentNumber(int $segmentNumber): BaseSegment
+    public function setSegmentNumber(int $segmentNumber): static
     {
         $this->segmentkopf->segmentnummer = $segmentNumber;
         return $this;
@@ -125,7 +125,7 @@ abstract class BaseSegment implements SegmentInterface, \Serializable
      *     the end). This should be ISO-8859-1-encoded.
      * @return static The parsed segment.
      */
-    public static function parse(string $rawSegment): BaseSegment
+    public static function parse(string $rawSegment): static
     {
         if (static::class === BaseSegment::class) {
             // Called as BaseSegment::parse(), so we need to determine the right segment type/class.
@@ -139,7 +139,7 @@ abstract class BaseSegment implements SegmentInterface, \Serializable
     /**
      * @return static A new segment of the type on which this function was called, with the Segmentkopf initialized.
      */
-    public static function createEmpty()
+    public static function createEmpty(): static
     {
         if (static::class === BaseSegment::class) {
             throw new \InvalidArgumentException('Must not call BaseSegment::createEmpty() on the super class');

--- a/lib/Fhp/Segment/BaseSegment.php
+++ b/lib/Fhp/Segment/BaseSegment.php
@@ -13,16 +13,9 @@ use Fhp\Syntax\Serializer;
  */
 abstract class BaseSegment implements SegmentInterface, \Serializable
 {
-    /**
-     * Reference to the descriptor for this type of segment.
-     * @var SegmentDescriptor|null
-     */
-    private $descriptor = null;
-
-    /**
-     * @var Segmentkopf
-     */
-    public $segmentkopf;
+    /** Reference to the descriptor for this type of segment. */
+    private ?SegmentDescriptor $descriptor = null;
+    public Segmentkopf $segmentkopf;
 
     /**
      * @return SegmentDescriptor The descriptor for this segment's type.

--- a/lib/Fhp/Segment/CAZ/GebuchteCamtUmsaetze.php
+++ b/lib/Fhp/Segment/CAZ/GebuchteCamtUmsaetze.php
@@ -3,6 +3,7 @@
 namespace Fhp\Segment\CAZ;
 
 use Fhp\Segment\BaseDeg;
+use Fhp\Syntax\Bin;
 
 /**
  * Needed for
@@ -15,7 +16,7 @@ class GebuchteCamtUmsaetze extends BaseDeg
 {
     /** Allow for up to 999 Binary fields (XML files) */
     /** @var Bin[] @Max(999) */
-    public $gebuchteCamtUmsaetze;
+    public array $gebuchteCamtUmsaetze;
 
     /**
      * @return string[]

--- a/lib/Fhp/Segment/CAZ/HICAZSv1.php
+++ b/lib/Fhp/Segment/CAZ/HICAZSv1.php
@@ -12,8 +12,7 @@ use Fhp\Segment\BaseGeschaeftsvorfallparameter;
  */
 class HICAZSv1 extends BaseGeschaeftsvorfallparameter
 {
-    /** @var ParameterKontoumsaetzeCamt */
-    public $parameter;
+    public ParameterKontoumsaetzeCamt $parameter;
 
     public function getParameter(): ParameterKontoumsaetzeCamt
     {

--- a/lib/Fhp/Segment/CAZ/HICAZv1.php
+++ b/lib/Fhp/Segment/CAZ/HICAZv1.php
@@ -16,36 +16,25 @@ use Fhp\Syntax\Bin;
  */
 class HICAZv1 extends BaseSegment
 {
-    /**
-     * Kontoverbindung international
-     * @var \Fhp\Segment\Common\Kti
-     */
-    public $kontoverbindungInternational;
+    public \Fhp\Segment\Common\Kti $kontoverbindungInternational;
 
-    /**
-     * Der camt-Descriptor beschreibt Ort, Name und Version einer camt Schema-Definition als URN.
-     * @var string
-     */
-    public $camtDescriptor;
+    /** Der camt-Descriptor beschreibt Ort, Name und Version einer camt Schema-Definition als URN. */
+    public string $camtDescriptor;
 
     /**
      * Umsätze, die auf dem Kundenkonto erfolgt sind und zum Zeitpunkt des Kundenauftrags vom Kreditinstitut bereits
      * gebucht wurden.
      * Gebuchte camt-Umsätze werden als camt.052 message für Umsatzabfragen bzw. camt.053 message für den elektronischen
      * Kontoauszug (s. [Datenformate]) bereitgestellt und werden als transparentes Datenformat im Sinne von FinTS transportiert
-     *
-     * @var \Fhp\Segment\CAZ\GebuchteCamtUmsaetze
      */
-    public $gebuchteUmsaetze;
+    public GebuchteCamtUmsaetze $gebuchteUmsaetze;
 
     /**
      * Noch nicht gebuchte Umsätze, die dem Kunden im camt.052-Format zusätzlich rückgemeldet werden und zum Zeitpunkt
      * des Kundenauftrags vom Kreditinstitut noch nicht gebucht wurden. Nicht gebuchte Umsätze können nicht auftreten,
      * wenn der vom Kunden angegebene Zeitraum in der Vergangenheit liegt.
-     *
-     * @var Bin|null
      */
-    public $nichtGebuchteUmsaetze;
+    public ?Bin $nichtGebuchteUmsaetze = null;
 
     public function getKontoverbindungInternational(): \Fhp\Segment\Common\Kti
     {

--- a/lib/Fhp/Segment/CAZ/HKCAZv1.php
+++ b/lib/Fhp/Segment/CAZ/HKCAZv1.php
@@ -14,22 +14,18 @@ use Fhp\Segment\Paginateable;
  */
 class HKCAZv1 extends BaseSegment implements Paginateable
 {
-    /** @var \Fhp\Segment\Common\Kti */
-    public $kontoverbindungInternational;
-
-    /** @var UnterstuetzteCamtMessages */
-    public $unterstuetzteCamtMessages;
-
-    /** @var bool Only allowed if {@link ParameterKontoumsaetzeCamt::$alleKontenErlaubt} says so. */
-    public $alleKonten;
-    /** @var string|null JJJJMMTT gemäß ISO 8601 */
-    public $vonDatum;
-    /** @var string|null JJJJMMTT gemäß ISO 8601 */
-    public $bisDatum;
-    /** @var int|null Only allowed if {@link ParameterKontoumsaetzeCamt::$eingabeAnzahlEintraegeErlaubt} says so. */
-    public $maximaleAnzahlEintraege;
-    /** @var string|null Max length: 35 */
-    public $aufsetzpunkt;
+    public \Fhp\Segment\Common\Kti $kontoverbindungInternational;
+    public UnterstuetzteCamtMessages $unterstuetzteCamtMessages;
+    /** Only allowed if {@link ParameterKontoumsaetzeCamt::$alleKontenErlaubt} says so. */
+    public bool $alleKonten;
+    /** JJJJMMTT gemäß ISO 8601 */
+    public ?string $vonDatum = null;
+    /** JJJJMMTT gemäß ISO 8601 */
+    public ?string $bisDatum = null;
+    /** Only allowed if {@link ParameterKontoumsaetzeCamt::$eingabeAnzahlEintraegeErlaubt} says so. */
+    public ?int $maximaleAnzahlEintraege = null;
+    /** Max length: 35 */
+    public ?string $aufsetzpunkt = null;
 
     public static function create(\Fhp\Segment\Common\Kti $kti, UnterstuetzteCamtMessages $unterstuetzteCamtMessages,
         bool $alleKonten, ?\DateTime $vonDatum, ?\DateTime $bisDatum, ?string $aufsetzpunkt = null): HKCAZv1
@@ -38,8 +34,8 @@ class HKCAZv1 extends BaseSegment implements Paginateable
         $result->kontoverbindungInternational = $kti;
         $result->unterstuetzteCamtMessages = $unterstuetzteCamtMessages;
         $result->alleKonten = $alleKonten;
-        $result->vonDatum = $vonDatum === null ? null : $vonDatum->format('Ymd');
-        $result->bisDatum = $bisDatum === null ? null : $bisDatum->format('Ymd');
+        $result->vonDatum = $vonDatum?->format('Ymd');
+        $result->bisDatum = $bisDatum?->format('Ymd');
         $result->aufsetzpunkt = $aufsetzpunkt;
 
         return $result;

--- a/lib/Fhp/Segment/CAZ/ParameterKontoumsaetzeCamt.php
+++ b/lib/Fhp/Segment/CAZ/ParameterKontoumsaetzeCamt.php
@@ -12,8 +12,7 @@ use Fhp\Segment\KAZ\ParameterKontoumsaetzeV2;
  */
 class ParameterKontoumsaetzeCamt extends ParameterKontoumsaetzeV2
 {
-    /** @var UnterstuetzteCamtMessages */
-    public $unterstuetzteCamtMessages;
+    public UnterstuetzteCamtMessages $unterstuetzteCamtMessages;
 
     public function getUnterstuetzteCamtMessages(): UnterstuetzteCamtMessages
     {

--- a/lib/Fhp/Segment/CAZ/UnterstuetzteCamtMessages.php
+++ b/lib/Fhp/Segment/CAZ/UnterstuetzteCamtMessages.php
@@ -13,9 +13,9 @@ use Fhp\Segment\BaseDeg;
 class UnterstuetzteCamtMessages extends BaseDeg
 {
     /** @var string[] @Max(99) */
-    public $camtDescriptor;
+    public array $camtDescriptor;
 
-    public static function create(array $camtDescriptor)
+    public static function create(array $camtDescriptor): UnterstuetzteCamtMessages
     {
         $result = new UnterstuetzteCamtMessages();
         $result->camtDescriptor = $camtDescriptor;

--- a/lib/Fhp/Segment/CCS/HKCCSv1.php
+++ b/lib/Fhp/Segment/CCS/HKCCSv1.php
@@ -13,14 +13,14 @@ use Fhp\Syntax\Bin;
  */
 class HKCCSv1 extends BaseSegment
 {
-    /** @var \Fhp\Segment\Common\Kti IBAN/BIC must match <DbtrAcct> and <DbtrAgt> in the XML Below. */
-    public $kontoverbindungInternational;
-    /** @var string Max length: 256 */
-    public $sepaDescriptor;
+    /** IBAN/BIC must match <DbtrAcct> and <DbtrAgt> in the XML Below. */
+    public \Fhp\Segment\Common\Kti $kontoverbindungInternational;
+    /** Max length: 256 */
+    public string $sepaDescriptor;
     /**
+     * The PAIN message in XML format.
      * HISPAS informs which XML schemas are allowed.
      * The <ReqdExctnDt> field must be 1999-01-01.
-     * @var Bin XML
      */
-    public $sepaPainMessage;
+    public Bin $sepaPainMessage;
 }

--- a/lib/Fhp/Segment/Common/AccountInfo.php
+++ b/lib/Fhp/Segment/Common/AccountInfo.php
@@ -7,9 +7,9 @@ namespace Fhp\Segment\Common;
  */
 interface AccountInfo
 {
-    /** @return string This is the IBAN, if available, or the plain account number otherwise. */
-    public function getAccountNumber();
+    /** This is the IBAN, if available, or the plain account number otherwise. */
+    public function getAccountNumber(): string;
 
-    /** @return string|null This is the BIC, if available, or the country-specific bank code otherwise. */
-    public function getBankIdentifier();
+    /** This is the BIC, if available, or the country-specific bank code otherwise. */
+    public function getBankIdentifier(): ?string;
 }

--- a/lib/Fhp/Segment/Common/Btg.php
+++ b/lib/Fhp/Segment/Common/Btg.php
@@ -9,12 +9,10 @@ use Fhp\Segment\BaseDeg;
  */
 class Btg extends BaseDeg
 {
-    /** @var float */
-    public $wert;
-    /** @var string */
-    public $waehrung;
+    public float $wert;
+    public string $waehrung;
 
-    public static function create(float $wert, string $waehrung = 'EUR')
+    public static function create(float $wert, string $waehrung = 'EUR'): Btg
     {
         $result = new Btg();
         $result->wert = $wert;

--- a/lib/Fhp/Segment/Common/Kik.php
+++ b/lib/Fhp/Segment/Common/Kik.php
@@ -14,10 +14,10 @@ class Kik extends BaseDeg
 {
     public const DEFAULT_COUNTRY_CODE = '280'; // Germany
 
-    /** @var string (ISO 3166-1; has leading zeros; Germany is 280, see also chapter E.4 */
-    public $laenderkennzeichen;
-    /** @var string|null Max length: 30 (Mandatory/absent depending on the country) */
-    public $kreditinstitutscode;
+    /** (ISO 3166-1; has leading zeros; Germany is 280, see also chapter E.4 */
+    public ?string $laenderkennzeichen;  // Officially it's mandatory, but in practice it can be missing.
+    /** Max length: 30 (Mandatory/absent depending on the country) */
+    public ?string $kreditinstitutscode = null;
 
     /** {@inheritdoc} */
     public function validate()

--- a/lib/Fhp/Segment/Common/Kti.php
+++ b/lib/Fhp/Segment/Common/Kti.php
@@ -14,19 +14,17 @@ use Fhp\Segment\BaseDeg;
  */
 class Kti extends BaseDeg implements AccountInfo
 {
-    /** @var string|null Max length: 34 */
-    public $iban;
-    /** @var string|null Max length: 11, required if IBAN is present. */
-    public $bic;
+    /** Max length: 34 */
+    public ?string $iban = null;
+    /** Max length: 11, required if IBAN is present. */
+    public ?string $bic = null;
 
     // The following fields can only be set if the BPD parameters allow it. If they are set, the fields above become
     // optional.
-    /** @var string|null Also known as Depotnummer. */
-    public $kontonummer;
-    /** @var string|null */
-    public $unterkontomerkmal;
-    /** @var Kik|null */
-    public $kreditinstitutskennung;
+    /** Also known as Depotnummer. */
+    public ?string $kontonummer = null;
+    public ?string $unterkontomerkmal = null;
+    public ?Kik $kreditinstitutskennung = null;
 
     /** {@inheritdoc} */
     public function validate()
@@ -61,13 +59,13 @@ class Kti extends BaseDeg implements AccountInfo
     }
 
     /** {@inheritdoc} */
-    public function getAccountNumber()
+    public function getAccountNumber(): string
     {
         return $this->iban ?? $this->kontonummer;
     }
 
     /** {@inheritdoc} */
-    public function getBankIdentifier()
+    public function getBankIdentifier(): ?string
     {
         return $this->bic ?? $this->kreditinstitutskennung->kreditinstitutscode;
     }

--- a/lib/Fhp/Segment/Common/Kto.php
+++ b/lib/Fhp/Segment/Common/Kto.php
@@ -15,10 +15,8 @@ use Fhp\Segment\BaseDeg;
  */
 class Kto extends BaseDeg implements AccountInfo
 {
-    /** @var string */
-    public $kontonummer; // Aka Depotnummer
-    /** @var Kik */
-    public $kik;
+    public string $kontonummer; // Aka Depotnummer
+    public Kik $kik;
 
     public static function create(string $kontonummer, Kik $kik): Kto
     {
@@ -34,13 +32,13 @@ class Kto extends BaseDeg implements AccountInfo
     }
 
     /** {@inheritdoc} */
-    public function getAccountNumber()
+    public function getAccountNumber(): string
     {
         return $this->kontonummer;
     }
 
     /** {@inheritdoc} */
-    public function getBankIdentifier()
+    public function getBankIdentifier(): ?string
     {
         return $this->kik->kreditinstitutscode;
     }

--- a/lib/Fhp/Segment/Common/KtvV3.php
+++ b/lib/Fhp/Segment/Common/KtvV3.php
@@ -19,12 +19,9 @@ use Fhp\Segment\BaseDeg;
  */
 class KtvV3 extends BaseDeg implements AccountInfo
 {
-    /** @var string */
-    public $kontonummer;
-    /** @var string|null */
-    public $unterkontomerkmal;
-    /** @var Kik */
-    public $kik;
+    public ?string $kontonummer = null;  // Officially it's mandatory, but in practice it can be missing.
+    public ?string $unterkontomerkmal = null;
+    public ?Kik $kik = null;  // Officially it's mandatory, but in practice it can be missing.
 
     public static function create(string $kontonummer, ?string $unterkontomerkmal, Kik $kik): KtvV3
     {
@@ -41,13 +38,13 @@ class KtvV3 extends BaseDeg implements AccountInfo
     }
 
     /** {@inheritdoc} */
-    public function getAccountNumber()
+    public function getAccountNumber(): string
     {
-        return $this->kontonummer;
+        return $this->kontonummer ?: '';
     }
 
     /** {@inheritdoc} */
-    public function getBankIdentifier()
+    public function getBankIdentifier(): ?string
     {
         return $this->kik->kreditinstitutscode;
     }

--- a/lib/Fhp/Segment/Common/Ktz.php
+++ b/lib/Fhp/Segment/Common/Ktz.php
@@ -13,27 +13,25 @@ use Fhp\Segment\BaseDeg;
  */
 class Ktz extends BaseDeg implements AccountInfo
 {
-    /** @var bool Whether it's a SEPA account that has IBAN/BIC, or not (e.g. a stock depot) */
-    public $kontoverwendungSepa;
-    /** @var string|null Max length: 34 */
-    public $iban;
-    /** @var string|null Max length: 11, required if IBAN is present. */
-    public $bic;
-    /** @var string Also known as Depotnummer. */
-    public $kontonummer;
-    /** @var string|null */
-    public $unterkontomerkmal;
-    /** @var Kik */
-    public $kreditinstitutskennung;
+    /** Whether it's a SEPA account that has IBAN/BIC, or not (e.g. a stock depot) */
+    public bool $kontoverwendungSepa;
+    /** Max length: 34 */
+    public ?string $iban = null;
+    /** Max length: 11, required if IBAN is present. */
+    public ?string $bic = null;
+    /** Also known as Depotnummer. */
+    public string $kontonummer;
+    public ?string $unterkontomerkmal = null;
+    public Kik $kreditinstitutskennung;
 
     /** {@inheritdoc} */
-    public function getAccountNumber()
+    public function getAccountNumber(): string
     {
         return $this->iban ?? $this->kontonummer;
     }
 
     /** {@inheritdoc} */
-    public function getBankIdentifier()
+    public function getBankIdentifier(): ?string
     {
         return $this->bic ?? $this->kreditinstitutskennung->kreditinstitutscode;
     }

--- a/lib/Fhp/Segment/Common/Kursqualitaet.php
+++ b/lib/Fhp/Segment/Common/Kursqualitaet.php
@@ -15,6 +15,5 @@ class Kursqualitaet extends BaseDeg
     public const DELAYED = 1;  // delayed-Kurs
     public const REALTIME = 2; // Echtzeit-Kurs
 
-    /** @var int */
-    public $kursqualitaet;
+    public int $kursqualitaet;
 }

--- a/lib/Fhp/Segment/Common/Sdo.php
+++ b/lib/Fhp/Segment/Common/Sdo.php
@@ -24,15 +24,13 @@ class Sdo extends BaseDeg
      * Allowed values:
      *  "C" = Credit (the signum of $wert is positive)
      *  "D" = Debit (the signum of $wert is negative)
-     * @var string
      */
-    public $sollHabenKennzeichen;
-    /** @var Btg */
-    public $betrag;
-    /** @var string JJJJMMTT gemäß ISO 8601 */
-    public $datum;
-    /** @var string|null hhmmss gemäß ISO 8601, local time (no time zone support). */
-    public $uhrzeit;
+    public string $sollHabenKennzeichen;
+    public Btg $betrag;
+    /** JJJJMMTT gemäß ISO 8601 */
+    public string $datum;
+    /** hhmmss gemäß ISO 8601, local time (no time zone support). */
+    public ?string $uhrzeit = null;
 
     public function getAmount(): float
     {
@@ -55,7 +53,7 @@ class Sdo extends BaseDeg
         return \DateTime::createFromFormat('Ymd His', $this->datum . ' ' . ($this->uhrzeit ?? '000000'));
     }
 
-    public static function create(float $amount, string $currency, \DateTime $timestamp)
+    public static function create(float $amount, string $currency, \DateTime $timestamp): Sdo
     {
         $result = new Sdo();
         $result->sollHabenKennzeichen = $amount < 0 ? self::DEBIT : self::CREDIT;

--- a/lib/Fhp/Segment/Common/Tsp.php
+++ b/lib/Fhp/Segment/Common/Tsp.php
@@ -12,10 +12,10 @@ use Fhp\Segment\BaseDeg;
  */
 class Tsp extends BaseDeg
 {
-    /** @var string JJJJMMTT gemäß ISO 8601 */
-    public $datum;
-    /** @var string|null hhmmss gemäß ISO 8601, local time (no time zone support). */
-    public $uhrzeit;
+    /** JJJJMMTT gemäß ISO 8601 */
+    public string $datum;
+    /** hhmmss gemäß ISO 8601, local time (no time zone support). */
+    public ?string $uhrzeit = null;
 
     public static function create(string $datum, ?string $uhrzeit): Tsp
     {

--- a/lib/Fhp/Segment/DME/HIDMESv1.php
+++ b/lib/Fhp/Segment/DME/HIDMESv1.php
@@ -15,8 +15,7 @@ use Fhp\Segment\DSE\SEPADirectDebitMinimalLeadTimeProvider;
  */
 class HIDMESv1 extends BaseGeschaeftsvorfallparameter implements HIDXES
 {
-    /** @var ParameterTerminierteSEPASammellastschriftEinreichenV1 */
-    public $parameter;
+    public ParameterTerminierteSEPASammellastschriftEinreichenV1 $parameter;
 
     public function getParameter(): SEPADirectDebitMinimalLeadTimeProvider
     {

--- a/lib/Fhp/Segment/DME/HIDMESv2.php
+++ b/lib/Fhp/Segment/DME/HIDMESv2.php
@@ -15,8 +15,7 @@ use Fhp\Segment\DSE\SEPADirectDebitMinimalLeadTimeProvider;
  */
 class HIDMESv2 extends BaseGeschaeftsvorfallparameter implements HIDXES
 {
-    /** @var ParameterTerminierteSEPASammellastschriftEinreichenV2 */
-    public $parameter;
+    public ParameterTerminierteSEPASammellastschriftEinreichenV2 $parameter;
 
     public function getParameter(): SEPADirectDebitMinimalLeadTimeProvider
     {

--- a/lib/Fhp/Segment/DME/HKDMEv1.php
+++ b/lib/Fhp/Segment/DME/HKDMEv1.php
@@ -13,18 +13,18 @@ use Fhp\Syntax\Bin;
  */
 class HKDMEv1 extends BaseSegment
 {
-    /** @var \Fhp\Segment\Common\Kti IBAN/BIC must match <DbtrAcct> and <DbtrAgt> in the XML Below. */
-    public $kontoverbindungInternational;
+    /** IBAN/BIC must match <DbtrAcct> and <DbtrAgt> in the XML Below. */
+    public \Fhp\Segment\Common\Kti $kontoverbindungInternational;
 
-    /** @var \Fhp\Segment\Common\Btg|null Required if BDP „Summenfeld benötigt“ = J */
-    public $summenfeld;
+    /** Required if BDP „Summenfeld benötigt“ = J */
+    public ?\Fhp\Segment\Common\Btg $summenfeld = null;
 
-    /** @var bool|null Optional only if „Einzelbuchung erlaubt“ = J */
-    public $einzelbuchungGewuenscht;
+    /** Optional only if „Einzelbuchung erlaubt“ = J */
+    public ?bool $einzelbuchungGewuenscht = null;
 
-    /** @var string Max length: 256 */
-    public $sepaDescriptor;
+    /** Max length: 256 */
+    public string $sepaDescriptor;
 
     /** @var Bin XML */
-    public $sepaPainMessage;
+    public Bin $sepaPainMessage;
 }

--- a/lib/Fhp/Segment/DME/ParameterTerminierteSEPASammellastschriftEinreichenV1.php
+++ b/lib/Fhp/Segment/DME/ParameterTerminierteSEPASammellastschriftEinreichenV1.php
@@ -6,12 +6,7 @@ use Fhp\Segment\DSE\ParameterTerminierteSEPAEinzellastschriftEinreichenV1;
 
 class ParameterTerminierteSEPASammellastschriftEinreichenV1 extends ParameterTerminierteSEPAEinzellastschriftEinreichenV1
 {
-    /** @var int */
-    public $maximaleAnzahlDirectDebitTransferTransactionInformation;
-
-    /** @var bool */
-    public $summenfeldBenoetigt;
-
-    /** @var bool */
-    public $einzelbuchungErlaubt;
+    public int $maximaleAnzahlDirectDebitTransferTransactionInformation;
+    public bool $summenfeldBenoetigt;
+    public bool $einzelbuchungErlaubt;
 }

--- a/lib/Fhp/Segment/DME/ParameterTerminierteSEPASammellastschriftEinreichenV2.php
+++ b/lib/Fhp/Segment/DME/ParameterTerminierteSEPASammellastschriftEinreichenV2.php
@@ -6,18 +6,11 @@ use Fhp\Segment\DSE\ParameterTerminierteSEPALastschriftEinreichenV2;
 
 class ParameterTerminierteSEPASammellastschriftEinreichenV2 extends ParameterTerminierteSEPALastschriftEinreichenV2
 {
-    /** @var int */
-    public $maximaleAnzahlDirectDebitTransferTransactionInformation;
-
-    /** @var bool */
-    public $summenfeldBenoetigt;
-
-    /** @var bool */
-    public $einzelbuchungErlaubt;
-
-    /** @var string|null Max Length: 4096 */
-    public $zulaessigePurposecodes;
-
+    public int $maximaleAnzahlDirectDebitTransferTransactionInformation;
+    public bool $summenfeldBenoetigt;
+    public bool $einzelbuchungErlaubt;
+    /** Max Length: 4096 */
+    public ?string $zulaessigePurposecodes = null;
     /** @var string[]|null @Max(9) Max Length: 256 */
-    public $unterstuetzteSEPADatenformate;
+    public ?array $unterstuetzteSEPADatenformate = null;
 }

--- a/lib/Fhp/Segment/DSE/HIDSESv1.php
+++ b/lib/Fhp/Segment/DSE/HIDSESv1.php
@@ -13,8 +13,7 @@ use Fhp\Segment\BaseSegment;
  */
 class HIDSESv1 extends BaseGeschaeftsvorfallparameter implements HIDXES
 {
-    /** @var ParameterTerminierteSEPAEinzellastschriftEinreichenV1 */
-    public $parameter;
+    public ParameterTerminierteSEPAEinzellastschriftEinreichenV1 $parameter;
 
     public function getParameter(): SEPADirectDebitMinimalLeadTimeProvider
     {

--- a/lib/Fhp/Segment/DSE/HIDSESv2.php
+++ b/lib/Fhp/Segment/DSE/HIDSESv2.php
@@ -13,8 +13,7 @@ use Fhp\Segment\BaseSegment;
  */
 class HIDSESv2 extends BaseGeschaeftsvorfallparameter implements HIDXES
 {
-    /** @var ParameterTerminierteSEPAEinzellastschriftEinreichenV2 */
-    public $parameter;
+    public ParameterTerminierteSEPAEinzellastschriftEinreichenV2 $parameter;
 
     public function getParameter(): SEPADirectDebitMinimalLeadTimeProvider
     {

--- a/lib/Fhp/Segment/DSE/HKDSEv1.php
+++ b/lib/Fhp/Segment/DSE/HKDSEv1.php
@@ -13,12 +13,12 @@ use Fhp\Syntax\Bin;
  */
 class HKDSEv1 extends BaseSegment
 {
-    /** @var \Fhp\Segment\Common\Kti IBAN/BIC must match <DbtrAcct> and <DbtrAgt> in the XML Below. */
-    public $kontoverbindungInternational;
+    /** IBAN/BIC must match <DbtrAcct> and <DbtrAgt> in the XML Below. */
+    public \Fhp\Segment\Common\Kti $kontoverbindungInternational;
 
-    /** @var string Max length: 256 */
-    public $sepaDescriptor;
+    /** Max length: 256 */
+    public string $sepaDescriptor;
 
-    /** @var Bin XML */
-    public $sepaPainMessage;
+    /** XML */
+    public Bin $sepaPainMessage;
 }

--- a/lib/Fhp/Segment/DSE/MinimaleVorlaufzeitSEPALastschrift.php
+++ b/lib/Fhp/Segment/DSE/MinimaleVorlaufzeitSEPALastschrift.php
@@ -24,17 +24,17 @@ class MinimaleVorlaufzeitSEPALastschrift
         ['FRST', 'OOFF'],
     ];
 
-    /** @var int Must be 0,1,2 */
-    public $unterstuetzteSEPALastschriftartenCodiert;
+    /** Must be 0,1,2 */
+    public int $unterstuetzteSEPALastschriftartenCodiert;
 
-    /** @var int Must be 0,1,2 */
-    public $sequenceTypeCodiert;
+    /** Must be 0,1,2 */
+    public int $sequenceTypeCodiert;
 
-    /** @var int In Days */
-    public $minimaleSEPAVorlaufzeit;
+    /** In Days */
+    public int $minimaleSEPAVorlaufzeit;
 
-    /** @var string After this time the request will fail when the value of is used, for example 130000 meaning 1pm */
-    public $cutOffZeit;
+    /** After this time the request will fail when the value of is used, for example 130000 meaning 1pm */
+    public string $cutOffZeit;
 
     public static function create(int $minimaleSEPAVorlaufzeit, string $cutOffZeit, ?int $unterstuetzteSEPALastschriftartenCodiert = null,
         ?int $sequenceTypeCodiert = null): MinimaleVorlaufzeitSEPALastschrift

--- a/lib/Fhp/Segment/DSE/ParameterTerminierteSEPAEinzellastschriftEinreichenV1.php
+++ b/lib/Fhp/Segment/DSE/ParameterTerminierteSEPAEinzellastschriftEinreichenV1.php
@@ -6,17 +6,12 @@ use Fhp\Segment\BaseDeg;
 
 class ParameterTerminierteSEPAEinzellastschriftEinreichenV1 extends BaseDeg implements SEPADirectDebitMinimalLeadTimeProvider
 {
-    /** @var int Must be => 1 */
-    public $minimaleVorlaufzeitFNALRCUR;
-
-    /** @var int */
-    public $maximaleVorlaufzeitFNALRCUR;
-
-    /** @var int Must be => 1 */
-    public $minimaleVorlaufzeitFRSTOOFF;
-
-    /** @var int */
-    public $maximaleVorlaufzeitFRSTOOFF;
+    /** Must be => 1 */
+    public int $minimaleVorlaufzeitFNALRCUR;
+    public int $maximaleVorlaufzeitFNALRCUR;
+    /** Must be => 1 */
+    public int $minimaleVorlaufzeitFRSTOOFF;
+    public int $maximaleVorlaufzeitFRSTOOFF;
 
     public function getMinimalLeadTime(string $seqType): ?MinimaleVorlaufzeitSEPALastschrift
     {

--- a/lib/Fhp/Segment/DSE/ParameterTerminierteSEPAEinzellastschriftEinreichenV2.php
+++ b/lib/Fhp/Segment/DSE/ParameterTerminierteSEPAEinzellastschriftEinreichenV2.php
@@ -4,9 +4,9 @@ namespace Fhp\Segment\DSE;
 
 class ParameterTerminierteSEPAEinzellastschriftEinreichenV2 extends ParameterTerminierteSEPALastschriftEinreichenV2
 {
-    /** @var string|null Max Length: 4096 */
-    public $zulaessigePurposecodes;
+    /** Max Length: 4096 */
+    public ?string $zulaessigePurposecodes = null;
 
     /** @var string[]|null @Max(9) Max length: 256 */
-    public $unterstuetzteSEPADatenformate;
+    public ?array $unterstuetzteSEPADatenformate = null;
 }

--- a/lib/Fhp/Segment/DSE/ParameterTerminierteSEPALastschriftEinreichenV2.php
+++ b/lib/Fhp/Segment/DSE/ParameterTerminierteSEPALastschriftEinreichenV2.php
@@ -6,13 +6,10 @@ use Fhp\Segment\BaseDeg;
 
 abstract class ParameterTerminierteSEPALastschriftEinreichenV2 extends BaseDeg implements SEPADirectDebitMinimalLeadTimeProvider
 {
-    /** @var string */
-    public $minimaleVorlaufzeitCodiert;
+    public string $minimaleVorlaufzeitCodiert;
+    public string $maximaleVorlaufzeitCodiert;
 
-    /** @var string */
-    public $maximaleVorlaufzeitCodiert;
-
-    public function getMinimalLeadTime(string $seqType)
+    public function getMinimalLeadTime(string $seqType): array
     {
         return array_map(function ($value) use ($seqType) {
             return $value[$seqType] ?? null;

--- a/lib/Fhp/Segment/DSE/SEPADirectDebitMinimalLeadTimeProvider.php
+++ b/lib/Fhp/Segment/DSE/SEPADirectDebitMinimalLeadTimeProvider.php
@@ -4,6 +4,6 @@ namespace Fhp\Segment\DSE;
 
 interface SEPADirectDebitMinimalLeadTimeProvider
 {
-    /** @return MinimaleVorlaufzeitSEPALastschrift|MinimaleVorlaufzeitSEPALastschrift[]*/
-    public function getMinimalLeadTime(string $seqType);
+    /** @return MinimaleVorlaufzeitSEPALastschrift|MinimaleVorlaufzeitSEPALastschrift[]|null*/
+    public function getMinimalLeadTime(string $seqType): MinimaleVorlaufzeitSEPALastschrift|array|null;
 }

--- a/lib/Fhp/Segment/DegDescriptor.php
+++ b/lib/Fhp/Segment/DegDescriptor.php
@@ -9,7 +9,7 @@ namespace Fhp\Segment;
 class DegDescriptor extends BaseDescriptor
 {
     /** @var DegDescriptor[] */
-    private static $descriptors = [];
+    private static array $descriptors = [];
 
     /**
      * @param string $class The name of a sub-class of {@link BaseDeg}.

--- a/lib/Fhp/Segment/ElementDescriptor.php
+++ b/lib/Fhp/Segment/ElementDescriptor.php
@@ -13,36 +13,32 @@ class ElementDescriptor
 {
     /**
      * Name of the PHP field that this descriptor describes.
-     * @var string
      */
-    public $field;
+    public string $field;
 
     /**
      * The plain type of the PHP field (without array or nullable suffix). This is either a string, for scalar types, or
      * a \ReflectionClass for a sub-class of {@link BaseSegment} or {@link BaseDeg} for complex types.
-     * @var string|\ReflectionClass
      */
-    public $type;
+    public string|\ReflectionClass $type;
 
     /**
      * Whether the field must be present (at least once, if repeated) in every segment/Deg instance (false) or can be
      * omitted (true). This is auto-detected from the nullable suffix `|null` in the PHP type.
-     * @var bool
      */
-    public $optional = false;
+    public bool $optional = false;
 
     /**
      * Whether the field can have multiple values (if so, this field contains the maximum number of allowed values) or
      * not (if so, the value is zero). This is auto-detected from the array suffix `[]` in the PHP type.
-     * @var int
      */
-    public $repeated = 0;
+    public int $repeated = 0;
 
     /**
      * @param object $obj The object whose $field will be validated.
      * @throws \InvalidArgumentException If $obj->$field does not correspond to the schema in this descriptor.
      */
-    public function validateField($obj)
+    public function validateField($obj): void
     {
         if (!isset($obj->{$this->field})) {
             if ($this->optional) {
@@ -86,7 +82,7 @@ class ElementDescriptor
      * @param mixed $value The (non-null) value to be validated.
      * @throws \InvalidArgumentException If $value is not a valid $type.
      */
-    public function validateValue($value)
+    public function validateValue($value): void
     {
         if (is_string($this->type) && array_key_exists($this->type, static::TYPE_MAP)) {
             $expectedType = static::TYPE_MAP[$this->type];

--- a/lib/Fhp/Segment/HIBPA/HIBPAv3.php
+++ b/lib/Fhp/Segment/HIBPA/HIBPAv3.php
@@ -14,22 +14,14 @@ use Fhp\Segment\BaseSegment;
  */
 class HIBPAv3 extends BaseSegment
 {
-    /** @var int */
-    public $bpdVersion;
-    /** @var \Fhp\Segment\Common\Kik */
-    public $kreditinstitutskennung;
-    /** @var string Max length: 60 */
-    public $kreditinstitutsbezeichnung;
-    /** @var int */
-    public $anzahlGeschaeftsvorfallarten;
-    /** @var UnterstuetzteSprachenV2 */
-    public $unterstuetzteSprachen;
-    /** @var UnterstuetzteHbciVersionenV2 */
-    public $unterstuetzteHbciVersionen;
-    /** @var int|null */
-    public $maximaleNachrichtengroesse;
-    /** @var int|null */
-    public $minimalerTimeoutWert;
-    /** @var int|null */
-    public $maximalerTimeoutWert;
+    public int $bpdVersion;
+    public \Fhp\Segment\Common\Kik $kreditinstitutskennung;
+    /** Max length: 60 */
+    public string $kreditinstitutsbezeichnung;
+    public int $anzahlGeschaeftsvorfallarten;
+    public UnterstuetzteSprachenV2 $unterstuetzteSprachen;
+    public UnterstuetzteHbciVersionenV2 $unterstuetzteHbciVersionen;
+    public ?int $maximaleNachrichtengroesse = null;
+    public ?int $minimalerTimeoutWert = null;
+    public ?int $maximalerTimeoutWert = null;
 }

--- a/lib/Fhp/Segment/HIBPA/UnterstuetzteHbciVersionenV2.php
+++ b/lib/Fhp/Segment/HIBPA/UnterstuetzteHbciVersionenV2.php
@@ -14,5 +14,5 @@ use Fhp\Segment\BaseDeg;
 class UnterstuetzteHbciVersionenV2 extends BaseDeg
 {
     /** @var int[] @Max(9) */
-    public $unterstuetzteHbciVersion;
+    public array $unterstuetzteHbciVersion;
 }

--- a/lib/Fhp/Segment/HIBPA/UnterstuetzteSprachenV2.php
+++ b/lib/Fhp/Segment/HIBPA/UnterstuetzteSprachenV2.php
@@ -20,5 +20,5 @@ class UnterstuetzteSprachenV2 extends BaseDeg
      * 3: Französisch, Code ‚fr’ (French), Subset Französisch, Codeset 1 (Latin 1)
      * @var int[] @Max(9)
      */
-    public $unterstuetzteSprache;
+    public array $unterstuetzteSprache;
 }

--- a/lib/Fhp/Segment/HIPINS/GeschaeftsvorfallspezifischePinTanInformationen.php
+++ b/lib/Fhp/Segment/HIPINS/GeschaeftsvorfallspezifischePinTanInformationen.php
@@ -14,8 +14,8 @@ use Fhp\Segment\BaseDeg;
  */
 class GeschaeftsvorfallspezifischePinTanInformationen extends BaseDeg
 {
-    /** @var string Max length: 6; The segment name of the potential client request. */
-    public $segmentkennung;
-    /** @var bool Whether a TAN is needed. */
-    public $tanErforderlich;
+    /** Max length: 6; The segment name of the potential client request. */
+    public string $segmentkennung;
+    /** Whether a TAN is needed. */
+    public bool $tanErforderlich;
 }

--- a/lib/Fhp/Segment/HIPINS/HIPINSv1.php
+++ b/lib/Fhp/Segment/HIPINS/HIPINSv1.php
@@ -13,6 +13,5 @@ use Fhp\Segment\BaseGeschaeftsvorfallparameter;
  */
 class HIPINSv1 extends BaseGeschaeftsvorfallparameter
 {
-    /** @var ParameterPinTanSpezifischeInformationen */
-    public $parameter;
+    public ParameterPinTanSpezifischeInformationen $parameter;
 }

--- a/lib/Fhp/Segment/HIPINS/ParameterPinTanSpezifischeInformationen.php
+++ b/lib/Fhp/Segment/HIPINS/ParameterPinTanSpezifischeInformationen.php
@@ -13,16 +13,13 @@ use Fhp\Segment\BaseDeg;
  */
 class ParameterPinTanSpezifischeInformationen extends BaseDeg
 {
-    /** @var int|null */
-    public $minimalePinLaenge;
-    /** @var int|null */
-    public $maximalePinLaenge;
-    /** @var int|null */
-    public $maximaleTanLaenge;
-    /** @var string|null Max length: 30; Label for the username field in the UI. */
-    public $textZurBelegungDerBenutzerkennung;
-    /** @var string|null Max length: 30; */
-    public $textZurBelegungDerKundenId;
+    public ?int $minimalePinLaenge = null;
+    public ?int $maximalePinLaenge = null;
+    public ?int $maximaleTanLaenge = null;
+    /** Max length: 30; Label for the username field in the UI. */
+    public ?string $textZurBelegungDerBenutzerkennung = null;
+    /** Max length: 30; */
+    public ?string $textZurBelegungDerKundenId = null;
     /** @var GeschaeftsvorfallspezifischePinTanInformationen[] @Max(999) */
-    public $geschaeftsvorfallspezifischePinTanInformationen;
+    public array $geschaeftsvorfallspezifischePinTanInformationen;
 }

--- a/lib/Fhp/Segment/HIRMG/HIRMGv2.php
+++ b/lib/Fhp/Segment/HIRMG/HIRMGv2.php
@@ -21,5 +21,5 @@ class HIRMGv2 extends BaseSegment implements RueckmeldungContainer
     use FindRueckmeldungTrait; // For RueckmeldungContainer.
 
     /** @var \Fhp\Segment\HIRMS\Rueckmeldung[] @Max(99) */
-    public $rueckmeldung;
+    public array $rueckmeldung;
 }

--- a/lib/Fhp/Segment/HIRMS/HIRMSv2.php
+++ b/lib/Fhp/Segment/HIRMS/HIRMSv2.php
@@ -22,5 +22,5 @@ class HIRMSv2 extends BaseSegment implements RueckmeldungContainer
     use FindRueckmeldungTrait; // For RueckmeldungContainer.
 
     /** @var Rueckmeldung[] @Max(99) */
-    public $rueckmeldung;
+    public array $rueckmeldung;
 }

--- a/lib/Fhp/Segment/HIRMS/Rueckmeldung.php
+++ b/lib/Fhp/Segment/HIRMS/Rueckmeldung.php
@@ -13,25 +13,25 @@ use Fhp\Segment\BaseDeg;
  */
 class Rueckmeldung extends BaseDeg
 {
-    /** @var int See also the Rueckmeldungscode class/enum. */
-    public $rueckmeldungscode;
+    /** See also the Rueckmeldungscode class/enum. */
+    public int $rueckmeldungscode;
     /**
      * O: bei Verwendung im Segment HIRMS
      * N: bei Verwendung im Segment HIRMG
-     * @var string|null Max length: 7
+     * Max length: 7
      */
-    public $bezugsdatenelement;
-    /** @var string Max length: 80 */
-    public $rueckmeldungstext;
+    public ?string $bezugsdatenelement = null;
+    /** Max length: 80 */
+    public string $rueckmeldungstext;
     /** @var string[]|null @Max(10), max length each: 35 */
-    public $rueckmeldungsparameter;
+    public ?array $rueckmeldungsparameter = null;
 
     /**
      * This is not part of the FinTS wire format, but for convenience we store it here. If this Rueckmeldung pertains to
      * a particular segment of the request, then this will be its segment number.
-     * @var int|null @Ignore
+     * @Ignore
      */
-    public $referenceSegment;
+    public ?int $referenceSegment = null;
 
     public function __toString()
     {

--- a/lib/Fhp/Segment/HISYN/HISYNv4.php
+++ b/lib/Fhp/Segment/HISYN/HISYNv4.php
@@ -14,12 +14,12 @@ use Fhp\Segment\BaseSegment;
  */
 class HISYNv4 extends BaseSegment
 {
-    /** @var string|null Present if HKSYN.synchronisierungsmodus==0 */
-    public $kundensystemId;
-    /** @var int|null Present if HKSYN.synchronisierungsmodus==1 */
-    public $nachrichtennummer;
-    /** @var int|null Present if HKSYN.synchronisierungsmodus==2 */
-    public $sicherheitsreferenznummerFuerSignierschluessel;
-    /** @var int|null Present if HKSYN.synchronisierungsmodus==2 */
-    public $sicherheitsreferenznummerFuerDigitaleSignatur;
+    /** Present if HKSYN.synchronisierungsmodus==0 */
+    public ?string $kundensystemId = null;
+    /** Present if HKSYN.synchronisierungsmodus==1 */
+    public ?int $nachrichtennummer = null;
+    /** Present if HKSYN.synchronisierungsmodus==2 */
+    public ?int $sicherheitsreferenznummerFuerSignierschluessel = null;
+    /** Present if HKSYN.synchronisierungsmodus==2 */
+    public ?int $sicherheitsreferenznummerFuerDigitaleSignatur = null;
 }

--- a/lib/Fhp/Segment/HIUPA/HIUPAv4.php
+++ b/lib/Fhp/Segment/HIUPA/HIUPAv4.php
@@ -16,13 +16,9 @@ use Fhp\Segment\BaseSegment;
  */
 class HIUPAv4 extends BaseSegment
 {
-    /** @var string */
-    public $benutzerkennung;
-    /**
-     * Note: The bank may send UPD version 0, which means these UPD are the most recent but should not be persisted.
-     * @var int
-     */
-    public $updVersion;
+    public string $benutzerkennung;
+    /** Note: The bank may send UPD version 0, which means these UPD are the most recent but should not be persisted. */
+    public int $updVersion;
     /**
      * 0: If the bank does not explicitly declare a business transaction type (i.e. request segment type) as supported,
      *    it does not support it, so sending such a request to the bank will always lead to failure.
@@ -30,9 +26,9 @@ class HIUPAv4 extends BaseSegment
      *    will check online and accept/reject accordingly.
      * @var int
      */
-    public $updVerwendung;
-    /** @var string|null Max length: 35 */
-    public $benutzername;
-    /** @var string|null Max length: 2048 */
-    public $erweiterungAllgemein;
+    public int $updVerwendung;
+    /** Max length: 35 */
+    public ?string $benutzername = null;
+    /** Max length: 2048 */
+    public ?string $erweiterungAllgemein = null;
 }

--- a/lib/Fhp/Segment/HIUPD/ErlaubteGeschaeftsvorfaelleV1.php
+++ b/lib/Fhp/Segment/HIUPD/ErlaubteGeschaeftsvorfaelleV1.php
@@ -12,16 +12,15 @@ use Fhp\Segment\BaseDeg;
  */
 class ErlaubteGeschaeftsvorfaelleV1 extends BaseDeg implements ErlaubteGeschaeftsvorfaelle
 {
-    /** @var string References a segment type name (Segmentkennung) */
-    public $geschaeftsvorfall;
-    /** @var int Allowed values: 0, 1, 2, 3 */
-    public $anzahlBenoetigterSignaturen;
-    /** @var string|null Allowed values: E, T, W, M, Z */
-    public $limitart;
-    /** @var \Fhp\Segment\Common\Btg|null */
-    public $limitbetrag;
-    /** @var int|null If present, must be greater than 0 */
-    public $limitTage;
+    /** References a segment type name (Segmentkennung) */
+    public string $geschaeftsvorfall;
+    /** Allowed values: 0, 1, 2, 3 */
+    public int $anzahlBenoetigterSignaturen;
+    /** Allowed values: E, T, W, M, Z */
+    public ?string $limitart = null;
+    public ?\Fhp\Segment\Common\Btg $limitbetrag = null;
+    /** If present, must be greater than 0 */
+    public ?int $limitTage = null;
 
     /** {@inheritdoc} */
     public function getGeschaeftsvorfall(): string

--- a/lib/Fhp/Segment/HIUPD/ErlaubteGeschaeftsvorfaelleV2.php
+++ b/lib/Fhp/Segment/HIUPD/ErlaubteGeschaeftsvorfaelleV2.php
@@ -11,16 +11,16 @@ use Fhp\Segment\BaseDeg;
  */
 class ErlaubteGeschaeftsvorfaelleV2 extends BaseDeg implements ErlaubteGeschaeftsvorfaelle
 {
-    /** @var string References a segment type name (Segmentkennung) */
-    public $geschaeftsvorfall;
-    /** @var int Allowed values: 0, 1, 2, 3 */
-    public $anzahlBenoetigterSignaturen;
-    /** @var string|null Allowed values: E, T, W, M, Z */
-    public $limitart;
-    /** @var \Fhp\Segment\Common\Btg|null Not allowed for limitart==Z. */
-    public $limitbetrag;
-    /** @var int|null Only allowed for limitart==Z, must be greater than zero. */
-    public $limitTage;
+    /** References a segment type name (Segmentkennung) */
+    public string $geschaeftsvorfall;
+    /** Allowed values: 0, 1, 2, 3 */
+    public int $anzahlBenoetigterSignaturen;
+    /** Allowed values: E, T, W, M, Z */
+    public ?string $limitart = null;
+    /** Not allowed for limitart==Z. */
+    public ?\Fhp\Segment\Common\Btg $limitbetrag = null;
+    /** Only allowed for limitart==Z, must be greater than zero. */
+    public ?int $limitTage = null;
 
     /** {@inheritdoc} */
     public function getGeschaeftsvorfall(): string

--- a/lib/Fhp/Segment/HIUPD/HIUPDv4.php
+++ b/lib/Fhp/Segment/HIUPD/HIUPDv4.php
@@ -19,27 +19,20 @@ use Fhp\Segment\BaseSegment;
  */
 class HIUPDv4 extends BaseSegment implements HIUPD
 {
-    /** @var \Fhp\Segment\Common\KtvV3 */
-    public $kontoverbindung;
-    /** @var string */
-    public $kundenId;
-    /** @var string|null */
-    public $kontowaehrung;
-    /** @var string */
-    public $name1;
-    /** @var string|null */
-    public $name2;
-    /** @var string|null */
-    public $kontoproduktbezeichnung;
-    /** @var KontolimitV1|null */
-    public $kontolimit;
+    public \Fhp\Segment\Common\KtvV3 $kontoverbindung;
+    public string $kundenId;
+    public ?string $kontowaehrung = null;
+    public string $name1;
+    public ?string $name2 = null;
+    public ?string $kontoproduktbezeichnung = null;
+    public ?KontolimitV1 $kontolimit = null;
     /** @var ErlaubteGeschaeftsvorfaelleV1[]|null @Max(98) */
-    public $erlaubteGeschaeftsvorfaelle;
+    public ?array $erlaubteGeschaeftsvorfaelle = null;
 
     /** {@inheritdoc} */
     public function matchesAccount(SEPAAccount $account): bool
     {
-        return !is_null($this->kontoverbindung) && !is_null($this->kontoverbindung->kontonummer)
+        return !is_null($this->kontoverbindung->kontonummer)
             && $this->kontoverbindung->kontonummer == $account->getAccountNumber();
     }
 

--- a/lib/Fhp/Segment/HIUPD/HIUPDv6.php
+++ b/lib/Fhp/Segment/HIUPD/HIUPDv6.php
@@ -18,12 +18,11 @@ use Fhp\Segment\BaseSegment;
  */
 class HIUPDv6 extends BaseSegment implements HIUPD
 {
-    /** @var \Fhp\Segment\Common\KtvV3|null */ // Note: Specification wants version 2, but only specifies version 3.
-    public $kontoverbindung;
-    /** @var string|null Max length: 34 */
-    public $iban;
-    /** @var string */
-    public $kundenId;
+    // Note: Specification wants version 2, but only specifies version 3.
+    public ?\Fhp\Segment\Common\KtvV3 $kontoverbindung = null;
+    /** Max length: 34 */
+    public ?string $iban = null;
+    public string $kundenId;
     /**
      * 1 – 9: Kontokorrent-/Girokonto
      * 10 – 19: Sparkonto
@@ -35,28 +34,22 @@ class HIUPDv6 extends BaseSegment implements HIUPD
      * 70 – 79: Bausparvertrag
      * 80 – 89: Versicherungsvertrag
      * 90 – 99: Sonstige (nicht zuordenbar)
-     * @var int|null
      */
-    public $kontoart;
-    /** @var string|null */
-    public $kontowaehrung;
-    /** @var string */
-    public $name1;
-    /** @var string|null */
-    public $name2;
-    /** @var string|null */
-    public $kontoproduktbezeichnung;
-    /** @var KontolimitV2|null */
-    public $kontolimit;
+    public ?int $kontoart = null;
+    public ?string $kontowaehrung = null;
+    public string $name1;
+    public ?string $name2 = null;
+    public ?string $kontoproduktbezeichnung = null;
+    public ?KontolimitV2 $kontolimit = null;
     /** @var ErlaubteGeschaeftsvorfaelleV2[]|null @Max(999) */
-    public $erlaubteGeschaeftsvorfaelle;
+    public ?array $erlaubteGeschaeftsvorfaelle = null;
     /**
      * JSON-encoded extra information.
      * @link https://www.hbci-zka.de/dokumente/spezifikation_deutsch/fintsv3/FinTS_3.0_Formals_2017-10-06_final_version.pdf
      * Section: E.3.1 "Aufbau der UPD-Erweiterung, kontobezogen"
-     * @var string|null Max length: 2048
+     * Max length: 2048
      */
-    public $erweiterungKontobezogen;
+    public ?string $erweiterungKontobezogen = null;
 
     /** {@inheritdoc} */
     public function matchesAccount(SEPAAccount $account): bool

--- a/lib/Fhp/Segment/HIUPD/KontolimitV1.php
+++ b/lib/Fhp/Segment/HIUPD/KontolimitV1.php
@@ -12,10 +12,9 @@ use Fhp\Segment\BaseDeg;
  */
 class KontolimitV1 extends BaseDeg
 {
-    /** @var string Allowed values: E, T, W, M, Z */
-    public $limitart;
-    /** @var \Fhp\Segment\Common\Btg */
-    public $limitbetrag;
-    /** @var int|null If present, must be greater than 0 */
-    public $limitTage;
+    /** Allowed values: E, T, W, M, Z */
+    public string $limitart;
+    public \Fhp\Segment\Common\Btg $limitbetrag;
+    /** If present, must be greater than 0 */
+    public ?int $limitTage = null;
 }

--- a/lib/Fhp/Segment/HIUPD/KontolimitV2.php
+++ b/lib/Fhp/Segment/HIUPD/KontolimitV2.php
@@ -13,10 +13,10 @@ use Fhp\Segment\BaseDeg;
  */
 class KontolimitV2 extends BaseDeg
 {
-    /** @var string Allowed values: E, T, W, M, Z */
-    public $limitart;
-    /** @var \Fhp\Segment\Common\Btg|null Not allowed for limitart==Z. */
-    public $limitbetrag;
-    /** @var int|null Only allowed for limitart==Z, must be greater than zero. */
-    public $limitTage;
+    /** Allowed values: E, T, W, M, Z */
+    public string $limitart;
+    /** Not allowed for limitart==Z. */
+    public ?\Fhp\Segment\Common\Btg $limitbetrag = null;
+    /** Only allowed for limitart==Z, must be greater than zero. */
+    public ?int $limitTage = null;
 }

--- a/lib/Fhp/Segment/HKEND/HKENDv1.php
+++ b/lib/Fhp/Segment/HKEND/HKENDv1.php
@@ -12,8 +12,7 @@ use Fhp\Segment\BaseSegment;
  */
 class HKENDv1 extends BaseSegment
 {
-    /** @var string */
-    public $dialogId;
+    public string $dialogId;
 
     public static function create(string $dialogId): HKENDv1
     {

--- a/lib/Fhp/Segment/HKIDN/HKIDNv2.php
+++ b/lib/Fhp/Segment/HKIDN/HKIDNv2.php
@@ -21,19 +21,18 @@ class HKIDNv2 extends BaseSegment
     public const ANONYMOUS_KUNDEN_ID = '9999999999';
     public const MISSING_KUNDENSYSTEM_ID = '0';
 
-    /** @var \Fhp\Segment\Common\Kik */
-    public $kreditinstitutskennung;
-    /** @var string Max length: 30 */
-    public $kundenId;
-    /** @var string Max length: 30 */
-    public $kundensystemId;
+    public \Fhp\Segment\Common\Kik $kreditinstitutskennung;
+    /** Max length: 30 */
+    public string $kundenId;
+    /** Max length: 30 */
+    public string $kundensystemId;
     /**
      * 0: Kundensystem-ID wird nicht benötigt (HBCI DDV-Verfahren und chipkartenbasierte Verfahren ab
      *    Sicherheitsprofil-Version 3)
      * 1: Kundensystem-ID wird benötigt (sonstige HBCI RAH-/RDH- und PIN/TAN-Verfahren)
      * @var int
      */
-    public $kundensystemStatus = 1; // This library only supports PIN/TAN, hence 1 is the right choice.
+    public int $kundensystemStatus = 1; // This library only supports PIN/TAN, hence 1 is the right choice.
 
     public static function create(string $kreditinstitutionscode, Credentials $credentials, string $kundensystemId): HKIDNv2
     {

--- a/lib/Fhp/Segment/HKSYN/HKSYNv3.php
+++ b/lib/Fhp/Segment/HKSYN/HKSYNv3.php
@@ -18,7 +18,6 @@ class HKSYNv3 extends BaseSegment
      * 0: Neue Kundensystem-ID zurückmelden
      * 1: Letzte verarbeitete Nachrichtennummer zurückmelden
      * 2: Signatur-ID zurückmelden
-     * @var int integer
      */
-    public $synchronisierungsmodus = 0; // The only mode we need in practice.
+    public int $synchronisierungsmodus = 0; // The only mode we need in practice.
 }

--- a/lib/Fhp/Segment/HKVVB/HKVVBv3.php
+++ b/lib/Fhp/Segment/HKVVB/HKVVBv3.php
@@ -16,22 +16,19 @@ use Fhp\Segment\BaseSegment;
  */
 class HKVVBv3 extends BaseSegment
 {
-    /** @var int */
-    public $bpdVersion = 0; // 0 means no BPD stored at client-side yet.
-    /** @var int */
-    public $updVersion = 0; // 0 means no UPD stored at client-side yet.
+    public int $bpdVersion = 0; // 0 means no BPD stored at client-side yet.
+    public int $updVersion = 0; // 0 means no UPD stored at client-side yet.
     /**
      * 0: Standard
      * 1: Deutsch, Code ‚de’ (German), Subset Deutsch, Codeset 1 (Latin 1)
      * 2: Englisch, Code ‚en’ (English), Subset Englisch, Codeset 1 (Latin 1)
      * 3: Französisch, Code ‚fr’ (French), Subset Französisch, Codeset 1 (Latin 1)
-     * @var int
      */
-    public $dialogsprache = 0; // The bank's default is fine.
-    /** @var string Max length: 25 */
-    public $produktbezeichnung;
-    /** @var string Max length: 5 */
-    public $produktversion;
+    public int $dialogsprache = 0; // The bank's default is fine.
+    /** Max length: 25 */
+    public string $produktbezeichnung;
+    /** Max length: 5 */
+    public string $produktversion;
 
     public static function create(FinTsOptions $options, ?BPD $bpd, ?UPD $upd): HKVVBv3
     {

--- a/lib/Fhp/Segment/HNHBK/BezugsnachrichtV1.php
+++ b/lib/Fhp/Segment/HNHBK/BezugsnachrichtV1.php
@@ -13,8 +13,8 @@ use Fhp\Segment\BaseDeg;
  */
 class BezugsnachrichtV1 extends BaseDeg
 {
-    /** @var string References a previously sent {@link HNHBKv3::$dialogId} */
-    public $dialogId;
-    /** @var int References a previously sent {@link HNHBKv3::$nachrichtennummer} */
-    public $nachrichtennummer;
+    /** References a previously sent {@link HNHBKv3::$dialogId} */
+    public string $dialogId;
+    /** References a previously sent {@link HNHBKv3::$nachrichtennummer} */
+    public int $nachrichtennummer;
 }

--- a/lib/Fhp/Segment/HNHBK/HNHBKv3.php
+++ b/lib/Fhp/Segment/HNHBK/HNHBKv3.php
@@ -18,23 +18,20 @@ class HNHBKv3 extends BaseSegment
     /**
      * The length of the entire message (after encryption and compression) in bytes. While this is morally a number, the
      * specification requires padding it to 12 digits, so it is implemented as a string instead.
-     * @var string
      */
-    public $nachrichtengroesse = '000000000000'; // Ensure this field has always length 12.
+    public string $nachrichtengroesse = '000000000000'; // Ensure this field has always length 12.
     /**
      * Version 2.0.1 : 201 (Spezifikationsstatus: obsolet)
      * Version 2.1 : 210 (Spezifikationsstatus: obsolet)
      * Version 2.2 : 220 (Spezifikationsstatus: obsolet)
      * Version 3.0 : 300
-     * @var int
      */
-    public $hbciVersion = 300; // This library implements FinTS 3.0.
-    /** @var string */
-    public $dialogId;
-    /** @var int Must be positive. */
-    public $nachrichtennummer;
-    /** @var BezugsnachrichtV1|null Never sent to server, but always present in responses. */
-    public $bezugsnachricht;
+    public int $hbciVersion = 300; // This library implements FinTS 3.0.
+    public string $dialogId;
+    /** Must be positive. */
+    public int $nachrichtennummer;
+    /** Never sent to server, but always present in responses. */
+    public ?BezugsnachrichtV1 $bezugsnachricht = null;
 
     public function getNachrichtengroesse(): int
     {

--- a/lib/Fhp/Segment/HNHBS/HNHBSv1.php
+++ b/lib/Fhp/Segment/HNHBS/HNHBSv1.php
@@ -9,6 +9,6 @@ use Fhp\Segment\BaseSegment;
  */
 class HNHBSv1 extends BaseSegment
 {
-    /** @var int Must match the {@link HNHBKv2::$nachrichtennummer} in the same message. */
-    public $nachrichtennummer;
+    /** Must match the {@link HNHBKv2::$nachrichtennummer} in the same message. */
+    public int $nachrichtennummer;
 }

--- a/lib/Fhp/Segment/HNSHA/BenutzerdefinierteSignaturV1.php
+++ b/lib/Fhp/Segment/HNSHA/BenutzerdefinierteSignaturV1.php
@@ -13,10 +13,10 @@ use Fhp\Segment\BaseDeg;
  */
 class BenutzerdefinierteSignaturV1 extends BaseDeg
 {
-    /** @var string Max length: 99 */
-    public $pin;
-    /** @var string|null Max length: 99 */
-    public $tan;
+    /** Max length: 99 */
+    public string $pin;
+    /** Max length: 99 */
+    public ?string $tan = null;
 
     public static function create(string $pin, ?string $tan): BenutzerdefinierteSignaturV1
     {

--- a/lib/Fhp/Segment/HNSHA/HNSHAv2.php
+++ b/lib/Fhp/Segment/HNSHA/HNSHAv2.php
@@ -13,12 +13,11 @@ use Fhp\Segment\BaseSegment;
  */
 class HNSHAv2 extends BaseSegment
 {
-    /** @var string Max length: 14; A nonce, that matches the one in HNSHK */
-    public $sicherheitskontrollreferenz;
-    /** @var string|null Max length: 512; not allowed for PIN/TAN */
-    public $validierungsresultat;
-    /** @var BenutzerdefinierteSignaturV1|null */
-    public $benutzerdefinierteSignatur;
+    /** Max length: 14; A nonce, that matches the one in HNSHK */
+    public string $sicherheitskontrollreferenz;
+    /** Max length: 512; not allowed for PIN/TAN */
+    public ?string $validierungsresultat = null;
+    public ?BenutzerdefinierteSignaturV1 $benutzerdefinierteSignatur = null;
 
     /**
      * @param string $sicherheitskontrollreferenz The same number that was passed to HNSHK.

--- a/lib/Fhp/Segment/HNSHK/HNSHKv4.php
+++ b/lib/Fhp/Segment/HNSHK/HNSHKv4.php
@@ -20,46 +20,37 @@ use Fhp\Segment\Common\Kik;
  */
 class HNSHKv4 extends BaseSegment
 {
-    /** @var \Fhp\Segment\HNVSK\SicherheitsprofilV1 */
-    public $sicherheitsprofil;
+    public \Fhp\Segment\HNVSK\SicherheitsprofilV1 $sicherheitsprofil;
     /**
      * For the PIN/TAN profile (see section B.9.4), this must be:
      *   - 998 for Ein-Schritt-Verfahren, or
      *   - the value in the 900--997 range as received in
      *     {@link \Fhp\Segment\TAN\VerfahrensparameterZweiSchrittVerfahrenv6::$sicherheitsfunktion}
-     * @var int
      */
-    public $sicherheitsfunktion;
-    /** @var string Max length: 14; A nonce, that matches the one in HNSHA */
-    public $sicherheitskontrollreferenz;
+    public int $sicherheitsfunktion;
+    /** Max length: 14; A nonce, that matches the one in HNSHA */
+    public string $sicherheitskontrollreferenz;
     /**
      * 1: Signaturkopf und HBCI-Nutzdaten (SHM)
      * (not allowed: 2: Von Signaturkopf bis Signaturabschluss (SHT))
-     * @var int (Version 2)
+     * (Version 2)
      */
-    public $bereichDerSicherheitsapplikation = 1; // This is the only allowed value.
+    public int $bereichDerSicherheitsapplikation = 1; // This is the only allowed value.
     /**
      * 1: Der Unterzeichner ist Herausgeber der signierten Nachricht, z. B. Erfasser oder Erstsignatur (ISS)
      * 3: Der Unterzeichner unterstützt den Inhalt der Nachricht, z. B. bei Zweitsignatur (CON)
      * 4: Der Unterzeichner ist Zeuge, aber für den Inhalt der Nachricht nicht verantwortlich, z. B. Übermittler,
      *    welcher nicht Erfasser ist (WIT)
-     * @var int
      */
-    public $rolleDesSicherheitslieferanten = 1;
-    /** @var \Fhp\Segment\HNVSK\SicherheitsidentifikationDetailsV2 */
-    public $sicherheitsidentifikationDetails;
-    /** @var int */
-    public $sicherheitsreferenznummer = 1; // Not used / supported by this library, so just a dummy value.
-    /** @var \Fhp\Segment\HNVSK\SicherheitsdatumUndUhrzeitV2 */
-    public $sicherheitsdatumUndUhrzeit;
-    /** @var HashalgorithmusV2 */
-    public $hashalgorithmus;
-    /** @var SignaturalgorithmusV2 */
-    public $signaturalgorithmus;
-    /** @var \Fhp\Segment\HNVSK\SchluesselnameV3 */
-    public $schluesselname;
-    /** @var \Fhp\Segment\HNVSK\ZertifikatV2|null For the PIN/TAN profile, this must be empty (see section B.9.4). */
-    public $zertifikat;
+    public int $rolleDesSicherheitslieferanten = 1;
+    public \Fhp\Segment\HNVSK\SicherheitsidentifikationDetailsV2 $sicherheitsidentifikationDetails;
+    public int $sicherheitsreferenznummer = 1; // Not used / supported by this library, so just a dummy value.
+    public \Fhp\Segment\HNVSK\SicherheitsdatumUndUhrzeitV2 $sicherheitsdatumUndUhrzeit;
+    public HashalgorithmusV2 $hashalgorithmus;
+    public SignaturalgorithmusV2 $signaturalgorithmus;
+    public \Fhp\Segment\HNVSK\SchluesselnameV3 $schluesselname;
+    /** For the PIN/TAN profile, this must be empty (see section B.9.4). */
+    public ?\Fhp\Segment\HNVSK\ZertifikatV2 $zertifikat = null;
 
     /**
      * @param string $sicherheitskontrollreferenz A nonce (random number) to reference the corresponding HNSHA segment.

--- a/lib/Fhp/Segment/HNSHK/HashalgorithmusV2.php
+++ b/lib/Fhp/Segment/HNSHK/HashalgorithmusV2.php
@@ -16,9 +16,8 @@ class HashalgorithmusV2 extends BaseDeg
 {
     /**
      * 1: Owner Hashing (OHA)
-     * @var int
      */
-    public $verwendungDesHashalgorithmus = 1; // The only allowed value.
+    public int $verwendungDesHashalgorithmus = 1; // The only allowed value.
     /**
      * 1: SHA-1 (nicht zugelassen)
      * 2: belegt
@@ -27,14 +26,12 @@ class HashalgorithmusV2 extends BaseDeg
      * 5: SHA-512
      * 6: SHA-256 / SHA-256 (this means hashing twice, once in signature card and once in software)
      * 999: Gegenseitig vereinbart (ZZZ); (nicht zugelassen)
-     * @var int
      */
-    public $hashalgorithmus = 999; // The field is not used in PIN/TAN, so we put a dummy value.
+    public int $hashalgorithmus = 999; // The field is not used in PIN/TAN, so we put a dummy value.
     /**
      * 1: IVC (Initialization value, clear text)
-     * @var int
      */
-    public $bezeichnerFuerHashalgorithmusparameter = 1; // The only allowed value.
-    /** @var Bin|null Binary, max length: 512; not allowed for PIN/TAN */
-    public $wertDesHashalgorithmusparameters;
+    public int $bezeichnerFuerHashalgorithmusparameter = 1; // The only allowed value.
+    /** Binary, max length: 512; not allowed for PIN/TAN */
+    public ?Bin $wertDesHashalgorithmusparameters = null;
 }

--- a/lib/Fhp/Segment/HNSHK/SignaturalgorithmusV2.php
+++ b/lib/Fhp/Segment/HNSHK/SignaturalgorithmusV2.php
@@ -15,18 +15,15 @@ class SignaturalgorithmusV2 extends BaseDeg
 {
     /**
      * 6: Owner Signing (OSG)
-     * @var int
      */
-    public $verwendungDesSignaturalgorithmus = 6; // The only allowed value.
+    public int $verwendungDesSignaturalgorithmus = 6; // The only allowed value.
     /**
      * 1: nicht zugelassen
      * 10: RSA-Algorithmus (bei RAH)
-     * @var int
      */
-    public $signaturalgorithmus = 10; // The only allowed value (not actually used, just as a dummy for PIN/TAN).
+    public int $signaturalgorithmus = 10; // The only allowed value (not actually used, just as a dummy for PIN/TAN).
     /**
      * 19: RSASSA-PSS (bei RAH, RDH)
-     * @var int
      */
-    public $operationsmodus = 19; // The only allowed value (not actually used, just as a dummy for PIN/TAN).
+    public int $operationsmodus = 19; // The only allowed value (not actually used, just as a dummy for PIN/TAN).
 }

--- a/lib/Fhp/Segment/HNVSD/HNVSDv1.php
+++ b/lib/Fhp/Segment/HNVSD/HNVSDv1.php
@@ -24,9 +24,8 @@ class HNVSDv1 extends BaseSegment
     /**
      * Note: This field is called "encrypted", but for PIN/TAN it contains plaintext data anyway, because the encryption
      * is done in the transport layer (TLS).
-     * @var Bin Binary.
      */
-    public $datenVerschluesselt;
+    public Bin $datenVerschluesselt;
 
     /**
      * @param BaseSegment[] $segments Some segments that will be serialized into the data field.

--- a/lib/Fhp/Segment/HNVSK/HNVSKv3.php
+++ b/lib/Fhp/Segment/HNVSK/HNVSKv3.php
@@ -29,29 +29,22 @@ class HNVSKv3 extends BaseSegment
      */
     public const SEGMENT_NUMBER = 998;
 
-    /** @var SicherheitsprofilV1 */
-    public $sicherheitsprofil;
+    public SicherheitsprofilV1 $sicherheitsprofil;
     /**
      * For the PIN/TAN profile, this must be 998 (see section B.9.8).
-     * @var int
      */
-    public $sicherheitsfunktion = 998;
+    public int $sicherheitsfunktion = 998;
     /**
      * 1: Der Unterzeichner ist Herausgeber der signierten Nachricht, z. B. Erfasser oder Erstsignatur (ISS)
      * (Not allowed: 3: Der Unterzeichner unterstützt den Inhalt der Nachricht, z. B. bei Zweitsignatur (CON))
      * 4: Der Unterzeichner ist Zeuge, aber für den Inhalt der Nachricht nicht verantwortlich, z. B. Übermittler,
      *    welcher nicht Erfasser ist (WIT)
-     * @var int
      */
-    public $rolleDesSicherheitslieferanten = 1;
-    /** @var SicherheitsidentifikationDetailsV2 */
-    public $sicherheitsidentifikationDetails;
-    /** @var SicherheitsdatumUndUhrzeitV2 */
-    public $sicherheitsdatumUndUhrzeit;
-    /** @var VerschluesselungsalgorithmusV2 */
-    public $verschluesselungsalgorithmus;
-    /** @var SchluesselnameV3 */
-    public $schluesselname;
+    public int $rolleDesSicherheitslieferanten = 1;
+    public SicherheitsidentifikationDetailsV2 $sicherheitsidentifikationDetails;
+    public SicherheitsdatumUndUhrzeitV2 $sicherheitsdatumUndUhrzeit;
+    public VerschluesselungsalgorithmusV2 $verschluesselungsalgorithmus;
+    public SchluesselnameV3 $schluesselname;
     /**
      * 0: Keine Kompression (NULL)
      * 1: Lempel, Ziv, Welch (LZW)
@@ -62,11 +55,10 @@ class HNVSKv3 extends BaseSegment
      * 6: deflate (GZIP) (http://www.gzip.org/zlib)
      * 7: bzip2 (http://sourceware.cygnus.com/bzip2/)
      * 999: Gegenseitig vereinbart (ZZZ)
-     * @var int
      */
-    public $komprimierungsfunktion = 0; // This library does not support compression.
-    /** @var ZertifikatV2|null For the PIN/TAN profile, this must be empty (see section B.9.8). */
-    public $zertifikat;
+    public int $komprimierungsfunktion = 0; // This library does not support compression.
+    /** For the PIN/TAN profile, this must be empty (see section B.9.8). */
+    public ?ZertifikatV2 $zertifikat = null;
 
     /**
      * @param FinTsOptions $options See {@link FinTsOptions}.

--- a/lib/Fhp/Segment/HNVSK/SchluesselnameV3.php
+++ b/lib/Fhp/Segment/HNVSK/SchluesselnameV3.php
@@ -22,21 +22,18 @@ class SchluesselnameV3 extends BaseDeg
      */
     public const CHIFFRIERSCHLUESSEL = 'V';
 
-    /** @var \Fhp\Segment\Common\Kik */
-    public $kreditinstitutskennung;
-    /** @var string This is the username used for login. */
-    public $benutzerkennung;
+    public \Fhp\Segment\Common\Kik $kreditinstitutskennung;
+    /** This is the username used for login. */
+    public string $benutzerkennung;
     /**
      * D: Schlüssel zur Erzeugung digitaler Signaturen (DS-Schlüssel)
      * S: Signierschlüssel
      * V: Chiffrierschlüssel
-     * @var string (Version 2)
+     * (Version 2)
      */
-    public $schluesselart;
-    /** @var int */
-    public $schluesselnummer = 0; // Dummy value for PIN/TAN.
-    /** @var int */
-    public $schluesselversion = 0; // Dummy value for PIN/TAN.
+    public string $schluesselart;
+    public int $schluesselnummer = 0; // Dummy value for PIN/TAN.
+    public int $schluesselversion = 0; // Dummy value for PIN/TAN.
 
     public static function create(\Fhp\Segment\Common\Kik $kik, string $benutzerkennung, string $schluesselart): SchluesselnameV3
     {

--- a/lib/Fhp/Segment/HNVSK/SicherheitsdatumUndUhrzeitV2.php
+++ b/lib/Fhp/Segment/HNVSK/SicherheitsdatumUndUhrzeitV2.php
@@ -18,13 +18,12 @@ class SicherheitsdatumUndUhrzeitV2 extends BaseDeg
     /**
      * 1: Sicherheitszeitstempel (STS)
      * 6: Certificate Revocation Time (CRT)
-     * @var int
      */
-    public $datumUndZeitbezeichner = 1; // This library does not support recovation, so STS is all we need.
-    /** @var string|null JJJJMMTT gemäß ISO 8601 */
-    public $datum;
-    /** @var string|null hhmmss gemäß ISO 8601, local time (no time zone support). */
-    public $uhrzeit;
+    public int $datumUndZeitbezeichner = 1; // This library does not support recovation, so STS is all we need.
+    /** JJJJMMTT gemäß ISO 8601 */
+    public ?string $datum = null;
+    /** hhmmss gemäß ISO 8601, local time (no time zone support). */
+    public ?string $uhrzeit = null;
 
     /**
      * @return SicherheitsdatumUndUhrzeitV2 For the current time.

--- a/lib/Fhp/Segment/HNVSK/SicherheitsidentifikationDetailsV2.php
+++ b/lib/Fhp/Segment/HNVSK/SicherheitsidentifikationDetailsV2.php
@@ -16,13 +16,12 @@ class SicherheitsidentifikationDetailsV2 extends BaseDeg
     /**
      * 1: Message Sender (MS), wenn ein Kunde etwas an sein Kreditinstitut sendet.
      * 2: Message Receiver (MR), wenn das Kreditinstitut etwas an seinen Kunden sendet
-     * @var int
      */
-    public $bezeichnerFuerSicherheitspartei = 1; // Unless we receive another value that overwrites this one, we're sending.
-    /** @var string|null Only allowed and mandatory for Chip-card, so this library does not support it. */
-    public $cid = null;
-    /** @var string|null Must be set to the {@link FinTs::$kundensystemId}, or '0' during synchronization. */
-    public $identifizierungDerPartei;
+    public int $bezeichnerFuerSicherheitspartei = 1; // Unless we receive another value that overwrites this one, we're sending.
+    /** Only allowed and mandatory for Chip-card, so this library does not support it. */
+    public ?string $cid = null;
+    /** Must be set to the {@link FinTs::$kundensystemId}, or '0' during synchronization. */
+    public ?string $identifizierungDerPartei = null;
 
     /**
      * @param string $kundensystemId The Kundensystem-ID as retrieved from the bank previously, or '0' during

--- a/lib/Fhp/Segment/HNVSK/SicherheitsprofilV1.php
+++ b/lib/Fhp/Segment/HNVSK/SicherheitsprofilV1.php
@@ -20,10 +20,10 @@ class SicherheitsprofilV1 extends BaseDeg
     public const VERSION_EIN_SCHRITT_VERFAHREN = 1;
     public const VERSION_ZWEI_SCHRITT_VERFAHREN = 2;
 
-    /** @var string Allowed values: "PIN", "RAH" */
-    public $sicherheitsverfahren;
-    /** @var int Allowed values: 1, 2 (for "PIN"), 7, 9, 10 (for "RAH") */
-    public $versionDesSicherheitsverfahrens;
+    /** Allowed values: "PIN", "RAH" */
+    public string $sicherheitsverfahren;
+    /** Allowed values: 1, 2 (for "PIN"), 7, 9, 10 (for "RAH") */
+    public int $versionDesSicherheitsverfahrens;
 
     /**
      * @param TanMode|null $tanMode Optionally specifies which two-step TAN mode to use, defaults to 999 (single step).

--- a/lib/Fhp/Segment/HNVSK/VerschluesselungsalgorithmusV2.php
+++ b/lib/Fhp/Segment/HNVSK/VerschluesselungsalgorithmusV2.php
@@ -14,35 +14,32 @@ use Fhp\Syntax\Bin;
  */
 class VerschluesselungsalgorithmusV2 extends BaseDeg
 {
-    /** @var int Allowed values: 2: Owner Symmetric (OSY) */
-    public $verwendungDesVerschluesselungsalgorithmus = 2; // The only possible value.
+    /** Allowed values: 2: Owner Symmetric (OSY) */
+    public int $verwendungDesVerschluesselungsalgorithmus = 2; // The only possible value.
     /**
      * 2: Cipher Block Chaining (CBC)
      * 18: RSAES-PKCS#1 V1.5 (bei RAH, RDH)
      * 19: RSASSA-PSS (bei RAH, RDH)
-     * @var int
      */
-    public $operationsmodus = 2; // CBC is what we need for PIN/TAN.
+    public int $operationsmodus = 2; // CBC is what we need for PIN/TAN.
     /**
      * 13: 2-Key-Triple-DES (nicht zugelassen)
      * 14: AES-256 [AES]
      * The specification claims that value 13 is not allowed, but in practice and also in all the examples in the
      * specification, that's the value that is used.
-     * @var int
      */
-    public $verschluesselungsalgorithmus = 13;
-    /** @var Bin Binary, max length: 512 */
-    public $wertDesAlgorithmusparametersSchluessel;
+    public int $verschluesselungsalgorithmus = 13;
+    /** Binary, max length: 512 */
+    public Bin $wertDesAlgorithmusparametersSchluessel;
     /**
      * 5: Symmetrischer Schlüssel (nicht zugelassen) This is the recommended dummy value for PIN/TAN.
      * 6: Symmetrischer Schlüssel, verschlüsselt mit einem öffentlichen Schlüssel bei RAH und RDH (KYP).
-     * @var int
      */
-    public $bezeichnerFuerAlgorithmusparameterSchluessel = 5; // Dummy for PIN/TAN
-    /** @var int Allowed values: 1: Initialization value, clear text (IVC) */
-    public $bezeichnerFuerAlgorithmusparameterIv = 1; // The only possible value.
-    /** @var string|null Max length: 512 Not allowed for PIN/TAN */
-    public $wertDesAlgorithmusparametersIv;
+    public int $bezeichnerFuerAlgorithmusparameterSchluessel = 5; // Dummy for PIN/TAN
+    /** Allowed values: 1: Initialization value, clear text (IVC) */
+    public int $bezeichnerFuerAlgorithmusparameterIv = 1; // The only possible value.
+    /** Max length: 512 Not allowed for PIN/TAN */
+    public ?string $wertDesAlgorithmusparametersIv = null;
 
     public static function create(): VerschluesselungsalgorithmusV2
     {

--- a/lib/Fhp/Segment/HNVSK/ZertifikatV2.php
+++ b/lib/Fhp/Segment/HNVSK/ZertifikatV2.php
@@ -13,8 +13,8 @@ use Fhp\Segment\BaseDeg;
  */
 class ZertifikatV2 extends BaseDeg
 {
-    /** @var int Allowed values: 1, 2, 3 */
-    public $zertifikatstyp;
-    /** @var string Binary, max length 4096 */
-    public $zertifikatsinhalt;
+    /** Allowed values: 1, 2, 3 */
+    public int $zertifikatstyp;
+    /** Binary, max length 4096 */
+    public string $zertifikatsinhalt;
 }

--- a/lib/Fhp/Segment/KAZ/HIKAZSv4.php
+++ b/lib/Fhp/Segment/KAZ/HIKAZSv4.php
@@ -14,8 +14,7 @@ use Fhp\Segment\BaseGeschaeftsvorfallparameterOld;
  */
 class HIKAZSv4 extends BaseGeschaeftsvorfallparameterOld implements HIKAZS
 {
-    /** @var ParameterKontoumsaetzeV1 */
-    public $parameter;
+    public ParameterKontoumsaetzeV1 $parameter;
 
     public function getParameter(): ParameterKontoumsaetze
     {

--- a/lib/Fhp/Segment/KAZ/HIKAZSv5.php
+++ b/lib/Fhp/Segment/KAZ/HIKAZSv5.php
@@ -13,8 +13,7 @@ use Fhp\Segment\BaseGeschaeftsvorfallparameterOld;
  */
 class HIKAZSv5 extends BaseGeschaeftsvorfallparameterOld implements HIKAZS
 {
-    /** @var ParameterKontoumsaetzeV2 */
-    public $parameter;
+    public ParameterKontoumsaetzeV2 $parameter;
 
     public function getParameter(): ParameterKontoumsaetze
     {

--- a/lib/Fhp/Segment/KAZ/HIKAZSv6.php
+++ b/lib/Fhp/Segment/KAZ/HIKAZSv6.php
@@ -12,8 +12,7 @@ use Fhp\Segment\BaseGeschaeftsvorfallparameter;
  */
 class HIKAZSv6 extends BaseGeschaeftsvorfallparameter implements HIKAZS
 {
-    /** @var ParameterKontoumsaetzeV2 */
-    public $parameter;
+    public ParameterKontoumsaetzeV2 $parameter;
 
     public function getParameter(): ParameterKontoumsaetze
     {

--- a/lib/Fhp/Segment/KAZ/HIKAZv4.php
+++ b/lib/Fhp/Segment/KAZ/HIKAZv4.php
@@ -17,10 +17,10 @@ use Fhp\Syntax\Bin;
  */
 class HIKAZv4 extends BaseSegment implements HIKAZ
 {
-    /** @var Bin Uses SWIFT format MT940, version SRG 2001 */
-    public $gebuchteUmsaetze;
-    /** @var Bin|null Uses SWIFT format MT942, version SRG 2001 */
-    public $nichtGebuchteUmsaetze;
+    /** Uses SWIFT format MT940, version SRG 2001 */
+    public Bin $gebuchteUmsaetze;
+    /** Uses SWIFT format MT942, version SRG 2001 */
+    public ?Bin $nichtGebuchteUmsaetze = null;
 
     public function getGebuchteUmsaetze(): Bin
     {

--- a/lib/Fhp/Segment/KAZ/HKKAZv4.php
+++ b/lib/Fhp/Segment/KAZ/HKKAZv4.php
@@ -15,25 +15,23 @@ use Fhp\Segment\Paginateable;
  */
 class HKKAZv4 extends BaseSegment implements Paginateable
 {
-    /** @var \Fhp\Segment\Common\Kto */
-    public $kontoverbindungAuftraggeber;
-    /** @var string|null */
-    public $kontowaehrung;
-    /** @var string|null JJJJMMTT gemäß ISO 8601 */
-    public $vonDatum;
-    /** @var string|null JJJJMMTT gemäß ISO 8601 */
-    public $bisDatum;
-    /** @var int|null Only allowed if {@link ParameterKontoumsaetzeV1::$eingabeAnzahlEintraegeErlaubt} says so. */
-    public $maximaleAnzahlEintraege;
-    /** @var string|null Max length: 35 */
-    public $aufsetzpunkt;
+    public \Fhp\Segment\Common\Kto $kontoverbindungAuftraggeber;
+    public ?string $kontowaehrung = null;
+    /** JJJJMMTT gemäß ISO 8601 */
+    public ?string $vonDatum = null;
+    /** JJJJMMTT gemäß ISO 8601 */
+    public ?string $bisDatum = null;
+    /** Only allowed if {@link ParameterKontoumsaetzeV1::$eingabeAnzahlEintraegeErlaubt} says so. */
+    public ?int $maximaleAnzahlEintraege = null;
+    /** Max length: 35 */
+    public ?string $aufsetzpunkt = null;
 
     public static function create(\Fhp\Segment\Common\Kto $kto, ?\DateTime $vonDatum, ?\DateTime $bisDatum, ?string $aufsetzpunkt = null): HKKAZv4
     {
         $result = HKKAZv4::createEmpty();
         $result->kontoverbindungAuftraggeber = $kto;
-        $result->vonDatum = $vonDatum === null ? null : $vonDatum->format('Ymd');
-        $result->bisDatum = $bisDatum === null ? null : $bisDatum->format('Ymd');
+        $result->vonDatum = $vonDatum?->format('Ymd');
+        $result->bisDatum = $bisDatum?->format('Ymd');
         $result->aufsetzpunkt = $aufsetzpunkt;
         return $result;
     }

--- a/lib/Fhp/Segment/KAZ/HKKAZv5.php
+++ b/lib/Fhp/Segment/KAZ/HKKAZv5.php
@@ -15,26 +15,25 @@ use Fhp\Segment\Paginateable;
  */
 class HKKAZv5 extends BaseSegment implements Paginateable
 {
-    /** @var \Fhp\Segment\Common\KtvV3 */
-    public $kontoverbindungAuftraggeber;
-    /** @var bool Only allowed if {@link ParameterKontoumsaetzeV2::$alleKontenErlaubt} says so. */
-    public $alleKonten;
-    /** @var string|null JJJJMMTT gemäß ISO 8601 */
-    public $vonDatum;
-    /** @var string|null JJJJMMTT gemäß ISO 8601 */
-    public $bisDatum;
-    /** @var int|null Only allowed if {@link ParameterKontoumsaetzeV2::$eingabeAnzahlEintraegeErlaubt} says so. */
-    public $maximaleAnzahlEintraege;
-    /** @var string|null Max length: 35 */
-    public $aufsetzpunkt;
+    public \Fhp\Segment\Common\KtvV3 $kontoverbindungAuftraggeber;
+    /** Only allowed if {@link ParameterKontoumsaetzeV2::$alleKontenErlaubt} says so. */
+    public bool $alleKonten;
+    /** JJJJMMTT gemäß ISO 8601 */
+    public ?string $vonDatum = null;
+    /** JJJJMMTT gemäß ISO 8601 */
+    public ?string $bisDatum = null;
+    /** Only allowed if {@link ParameterKontoumsaetzeV2::$eingabeAnzahlEintraegeErlaubt} says so. */
+    public ?int $maximaleAnzahlEintraege = null;
+    /** Max length: 35 */
+    public ?string $aufsetzpunkt = null;
 
     public static function create(\Fhp\Segment\Common\KtvV3 $ktv, bool $alleKonten, ?\DateTime $vonDatum, ?\DateTime $bisDatum, ?string $aufsetzpunkt = null): HKKAZv5
     {
         $result = HKKAZv5::createEmpty();
         $result->kontoverbindungAuftraggeber = $ktv;
         $result->alleKonten = $alleKonten;
-        $result->vonDatum = $vonDatum === null ? null : $vonDatum->format('Ymd');
-        $result->bisDatum = $bisDatum === null ? null : $bisDatum->format('Ymd');
+        $result->vonDatum = $vonDatum?->format('Ymd');
+        $result->bisDatum = $bisDatum?->format('Ymd');
         $result->aufsetzpunkt = $aufsetzpunkt;
         return $result;
     }

--- a/lib/Fhp/Segment/KAZ/HKKAZv6.php
+++ b/lib/Fhp/Segment/KAZ/HKKAZv6.php
@@ -14,26 +14,25 @@ use Fhp\Segment\Paginateable;
  */
 class HKKAZv6 extends BaseSegment implements Paginateable
 {
-    /** @var \Fhp\Segment\Common\KtvV3 */
-    public $kontoverbindungAuftraggeber;
-    /** @var bool Only allowed if {@link ParameterKontoumsaetzeV2::$alleKontenErlaubt} says so. */
-    public $alleKonten;
-    /** @var string|null JJJJMMTT gemäß ISO 8601 */
-    public $vonDatum;
-    /** @var string|null JJJJMMTT gemäß ISO 8601 */
-    public $bisDatum;
-    /** @var int|null Only allowed if {@link ParameterKontoumsaetzeV2::$eingabeAnzahlEintraegeErlaubt} says so. */
-    public $maximaleAnzahlEintraege;
-    /** @var string|null Max length: 35 */
-    public $aufsetzpunkt;
+    public \Fhp\Segment\Common\KtvV3 $kontoverbindungAuftraggeber;
+    /** Only allowed if {@link ParameterKontoumsaetzeV2::$alleKontenErlaubt} says so. */
+    public bool $alleKonten;
+    /** JJJJMMTT gemäß ISO 8601 */
+    public ?string $vonDatum = null;
+    /** JJJJMMTT gemäß ISO 8601 */
+    public ?string $bisDatum = null;
+    /** Only allowed if {@link ParameterKontoumsaetzeV2::$eingabeAnzahlEintraegeErlaubt} says so. */
+    public ?int $maximaleAnzahlEintraege = null;
+    /** Max length: 35 */
+    public ?string $aufsetzpunkt = null;
 
     public static function create(\Fhp\Segment\Common\KtvV3 $ktv, bool $alleKonten, ?\DateTime $vonDatum, ?\DateTime $bisDatum, ?string $aufsetzpunkt = null): HKKAZv6
     {
         $result = HKKAZv6::createEmpty();
         $result->kontoverbindungAuftraggeber = $ktv;
         $result->alleKonten = $alleKonten;
-        $result->vonDatum = $vonDatum === null ? null : $vonDatum->format('Ymd');
-        $result->bisDatum = $bisDatum === null ? null : $bisDatum->format('Ymd');
+        $result->vonDatum = $vonDatum?->format('Ymd');
+        $result->bisDatum = $bisDatum?->format('Ymd');
         $result->aufsetzpunkt = $aufsetzpunkt;
         return $result;
     }

--- a/lib/Fhp/Segment/KAZ/HKKAZv7.php
+++ b/lib/Fhp/Segment/KAZ/HKKAZv7.php
@@ -14,26 +14,25 @@ use Fhp\Segment\Paginateable;
  */
 class HKKAZv7 extends BaseSegment implements Paginateable
 {
-    /** @var \Fhp\Segment\Common\Kti */
-    public $kontoverbindungInternational;
-    /** @var bool Only allowed if {@link ParameterKontoumsaetzeV2::$alleKontenErlaubt} says so. */
-    public $alleKonten;
-    /** @var string|null JJJJMMTT gemäß ISO 8601 */
-    public $vonDatum;
-    /** @var string|null JJJJMMTT gemäß ISO 8601 */
-    public $bisDatum;
-    /** @var int|null Only allowed if {@link ParameterKontoumsaetzeV2::$eingabeAnzahlEintraegeErlaubt} says so. */
-    public $maximaleAnzahlEintraege;
-    /** @var string|null Max length: 35 */
-    public $aufsetzpunkt;
+    public \Fhp\Segment\Common\Kti $kontoverbindungInternational;
+    /** Only allowed if {@link ParameterKontoumsaetzeV2::$alleKontenErlaubt} says so. */
+    public bool $alleKonten;
+    /** JJJJMMTT gemäß ISO 8601 */
+    public ?string $vonDatum = null;
+    /** JJJJMMTT gemäß ISO 8601 */
+    public ?string $bisDatum = null;
+    /** Only allowed if {@link ParameterKontoumsaetzeV2::$eingabeAnzahlEintraegeErlaubt} says so. */
+    public ?int $maximaleAnzahlEintraege = null;
+    /** Max length: 35 */
+    public ?string $aufsetzpunkt = null;
 
     public static function create(\Fhp\Segment\Common\Kti $kti, bool $alleKonten, ?\DateTime $vonDatum, ?\DateTime $bisDatum, ?string $aufsetzpunkt = null): HKKAZv7
     {
         $result = HKKAZv7::createEmpty();
         $result->kontoverbindungInternational = $kti;
         $result->alleKonten = $alleKonten;
-        $result->vonDatum = $vonDatum === null ? null : $vonDatum->format('Ymd');
-        $result->bisDatum = $bisDatum === null ? null : $bisDatum->format('Ymd');
+        $result->vonDatum = $vonDatum?->format('Ymd');
+        $result->bisDatum = $bisDatum?->format('Ymd');
         $result->aufsetzpunkt = $aufsetzpunkt;
         return $result;
     }

--- a/lib/Fhp/Segment/KAZ/ParameterKontoumsaetzeV1.php
+++ b/lib/Fhp/Segment/KAZ/ParameterKontoumsaetzeV1.php
@@ -14,10 +14,9 @@ use Fhp\Segment\BaseDeg;
  */
 class ParameterKontoumsaetzeV1 extends BaseDeg implements ParameterKontoumsaetze
 {
-    /** @var int Positive, number of days. */
-    public $speicherzeitraum;
-    /** @var bool */
-    public $eingabeAnzahlEintraegeErlaubt;
+    /** Positive, number of days. */
+    public int $speicherzeitraum;
+    public bool $eingabeAnzahlEintraegeErlaubt;
 
     public function getAlleKontenErlaubt(): bool
     {

--- a/lib/Fhp/Segment/KAZ/ParameterKontoumsaetzeV2.php
+++ b/lib/Fhp/Segment/KAZ/ParameterKontoumsaetzeV2.php
@@ -12,8 +12,7 @@ class ParameterKontoumsaetzeV2 extends ParameterKontoumsaetzeV1 implements Param
 {
     // NOTE: See ParameterKontoumsaetzeV1.
 
-    /** @var bool */
-    public $alleKontenErlaubt;
+    public bool $alleKontenErlaubt;
 
     public function getAlleKontenErlaubt(): bool
     {

--- a/lib/Fhp/Segment/SAL/HISALv4.php
+++ b/lib/Fhp/Segment/SAL/HISALv4.php
@@ -17,26 +17,18 @@ use Fhp\Segment\Common\AccountInfo;
  */
 class HISALv4 extends BaseSegment implements HISAL
 {
-    /** @var \Fhp\Segment\Common\Kto */
-    public $kontoverbindungAuftraggeber;
-    /** @var string */
-    public $kontoproduktbezeichnung;
-    /** @var string */
-    public $kontowaehrung;
-    /** @var \Fhp\Segment\Common\Sdo */
-    public $gebuchterSaldo;
-    /** @var \Fhp\Segment\Common\Sdo|null */
-    public $saldoDerVorgemerktenUmsaetze;
-    /** @var \Fhp\Segment\Common\Btg|null */
-    public $kreditlinie;
-    /** @var \Fhp\Segment\Common\Btg|null */
-    public $verfuegbarerBetrag;
-    /** @var \Fhp\Segment\Common\Btg|null */
-    public $bereitsVerfuegterBetrag;
-    /** @var string|null JJJJMMTT gemäß ISO 8601 */
-    public $buchungsdatumDesSaldos;
-    /** @var string|null hhmmss gemäß ISO 8601, local time (no time zone support). */
-    public $buchungsuhrzeitDesSaldos;
+    public \Fhp\Segment\Common\Kto $kontoverbindungAuftraggeber;
+    public string $kontoproduktbezeichnung;
+    public string $kontowaehrung;
+    public \Fhp\Segment\Common\Sdo $gebuchterSaldo;
+    public ?\Fhp\Segment\Common\Sdo $saldoDerVorgemerktenUmsaetze = null;
+    public ?\Fhp\Segment\Common\Btg $kreditlinie = null;
+    public ?\Fhp\Segment\Common\Btg $verfuegbarerBetrag = null;
+    public ?\Fhp\Segment\Common\Btg $bereitsVerfuegterBetrag = null;
+    /** JJJJMMTT gemäß ISO 8601 */
+    public ?string $buchungsdatumDesSaldos = null;
+    /** hhmmss gemäß ISO 8601, local time (no time zone support). */
+    public ?string $buchungsuhrzeitDesSaldos = null;
 
     public function getAccountInfo(): AccountInfo
     {

--- a/lib/Fhp/Segment/SAL/HISALv5.php
+++ b/lib/Fhp/Segment/SAL/HISALv5.php
@@ -17,28 +17,20 @@ use Fhp\Segment\Common\AccountInfo;
  */
 class HISALv5 extends BaseSegment implements HISAL
 {
-    /** @var \Fhp\Segment\Common\KtvV3 */
-    public $kontoverbindungAuftraggeber;
-    /** @var string */
-    public $kontoproduktbezeichnung;
-    /** @var string */
-    public $kontowaehrung;
-    /** @var \Fhp\Segment\Common\Sdo */
-    public $gebuchterSaldo;
-    /** @var \Fhp\Segment\Common\Sdo|null */
-    public $saldoDerVorgemerktenUmsaetze;
-    /** @var \Fhp\Segment\Common\Btg|null */
-    public $kreditlinie;
-    /** @var \Fhp\Segment\Common\Btg|null */
-    public $verfuegbarerBetrag;
-    /** @var \Fhp\Segment\Common\Btg|null */
-    public $bereitsVerfuegterBetrag;
-    /** @var string|null JJJJMMTT gemäß ISO 8601 */
-    public $buchungsdatumDesSaldos;
-    /** @var string|null hhmmss gemäß ISO 8601, local time (no time zone support). */
-    public $buchungsuhrzeitDesSaldos;
-    /** @var string|null JJJJMMTT gemäß ISO 8601 */
-    public $faelligkeit;
+    public \Fhp\Segment\Common\KtvV3 $kontoverbindungAuftraggeber;
+    public string $kontoproduktbezeichnung;
+    public string $kontowaehrung;
+    public \Fhp\Segment\Common\Sdo $gebuchterSaldo;
+    public ?\Fhp\Segment\Common\Sdo $saldoDerVorgemerktenUmsaetze = null;
+    public ?\Fhp\Segment\Common\Btg $kreditlinie = null;
+    public ?\Fhp\Segment\Common\Btg $verfuegbarerBetrag = null;
+    public ?\Fhp\Segment\Common\Btg $bereitsVerfuegterBetrag = null;
+    /** JJJJMMTT gemäß ISO 8601 */
+    public ?string $buchungsdatumDesSaldos = null;
+    /** hhmmss gemäß ISO 8601, local time (no time zone support). */
+    public ?string $buchungsuhrzeitDesSaldos = null;
+    /** JJJJMMTT gemäß ISO 8601 */
+    public ?string $faelligkeit = null;
 
     public function getAccountInfo(): AccountInfo
     {

--- a/lib/Fhp/Segment/SAL/HISALv6.php
+++ b/lib/Fhp/Segment/SAL/HISALv6.php
@@ -16,28 +16,19 @@ use Fhp\Segment\Common\AccountInfo;
  */
 class HISALv6 extends BaseSegment implements HISAL
 {
-    /** @var \Fhp\Segment\Common\KtvV3 */
-    public $kontoverbindungAuftraggeber;
-    /** @var string */
-    public $kontoproduktbezeichnung;
-    /** @var string */
-    public $kontowaehrung;
-    /** @var \Fhp\Segment\Common\Sdo */
-    public $gebuchterSaldo;
-    /** @var \Fhp\Segment\Common\Sdo|null */
-    public $saldoDerVorgemerktenUmsaetze;
-    /** @var \Fhp\Segment\Common\Btg|null */
-    public $kreditlinie;
-    /** @var \Fhp\Segment\Common\Btg|null */
-    public $verfuegbarerBetrag;
-    /** @var \Fhp\Segment\Common\Btg|null */
-    public $bereitsVerfuegterBetrag;
-    /** @var \Fhp\Segment\Common\Btg|null This field can only be filled if {@link HISALv6::$verfuegbarerBetrag} is zero. */
-    public $ueberziehung;
-    /** @var \Fhp\Segment\Common\Tsp|null */
-    public $buchungszeitpunkt;
-    /** @var string|null JJJJMMTT gemäß ISO 8601 */
-    public $faelligkeit;
+    public \Fhp\Segment\Common\KtvV3 $kontoverbindungAuftraggeber;
+    public string $kontoproduktbezeichnung;
+    public string $kontowaehrung;
+    public \Fhp\Segment\Common\Sdo $gebuchterSaldo;
+    public ?\Fhp\Segment\Common\Sdo $saldoDerVorgemerktenUmsaetze = null;
+    public ?\Fhp\Segment\Common\Btg $kreditlinie = null;
+    public ?\Fhp\Segment\Common\Btg $verfuegbarerBetrag = null;
+    public ?\Fhp\Segment\Common\Btg $bereitsVerfuegterBetrag = null;
+    /** This field can only be filled if {@link HISALv6::$verfuegbarerBetrag} is zero. */
+    public ?\Fhp\Segment\Common\Btg $ueberziehung = null;
+    public ?\Fhp\Segment\Common\Tsp $buchungszeitpunkt = null;
+    /** JJJJMMTT gemäß ISO 8601 */
+    public ?string $faelligkeit = null;
 
     public function getAccountInfo(): AccountInfo
     {

--- a/lib/Fhp/Segment/SAL/HISALv7.php
+++ b/lib/Fhp/Segment/SAL/HISALv7.php
@@ -16,28 +16,19 @@ use Fhp\Segment\Common\AccountInfo;
  */
 class HISALv7 extends BaseSegment implements HISAL
 {
-    /** @var \Fhp\Segment\Common\Kti */
-    public $kontoverbindungInternational;
-    /** @var string */
-    public $kontoproduktbezeichnung;
-    /** @var string */
-    public $kontowaehrung;
-    /** @var \Fhp\Segment\Common\Sdo */
-    public $gebuchterSaldo;
-    /** @var \Fhp\Segment\Common\Sdo|null */
-    public $saldoDerVorgemerktenUmsaetze;
-    /** @var \Fhp\Segment\Common\Btg|null */
-    public $kreditlinie;
-    /** @var \Fhp\Segment\Common\Btg|null */
-    public $verfuegbarerBetrag;
-    /** @var \Fhp\Segment\Common\Btg|null */
-    public $bereitsVerfuegterBetrag;
-    /** @var \Fhp\Segment\Common\Btg|null This field can only be filled if {@link HISALv7::$verfuegbarerBetrag} is zero. */
-    public $ueberziehung;
-    /** @var \Fhp\Segment\Common\Tsp|null */
-    public $buchungszeitpunkt;
-    /** @var string|null JJJJMMTT gemäß ISO 8601 */
-    public $faelligkeit;
+    public \Fhp\Segment\Common\Kti $kontoverbindungInternational;
+    public string $kontoproduktbezeichnung;
+    public string $kontowaehrung;
+    public \Fhp\Segment\Common\Sdo $gebuchterSaldo;
+    public ?\Fhp\Segment\Common\Sdo $saldoDerVorgemerktenUmsaetze = null;
+    public ?\Fhp\Segment\Common\Btg $kreditlinie = null;
+    public ?\Fhp\Segment\Common\Btg $verfuegbarerBetrag = null;
+    public ?\Fhp\Segment\Common\Btg $bereitsVerfuegterBetrag = null;
+    /** This field can only be filled if {@link HISALv7::$verfuegbarerBetrag} is zero. */
+    public ?\Fhp\Segment\Common\Btg $ueberziehung = null;
+    public ?\Fhp\Segment\Common\Tsp $buchungszeitpunkt = null;
+    /** JJJJMMTT gemäß ISO 8601 */
+    public ?string $faelligkeit = null;
 
     public function getAccountInfo(): AccountInfo
     {

--- a/lib/Fhp/Segment/SAL/HKSALv4.php
+++ b/lib/Fhp/Segment/SAL/HKSALv4.php
@@ -15,16 +15,12 @@ use Fhp\Segment\Paginateable;
  */
 class HKSALv4 extends BaseSegment implements Paginateable
 {
-    /** @var \Fhp\Segment\Common\Kto */
-    public $kontoverbindungAuftraggeber;
-    /** @var bool */
-    public $alleKonten;
-    /** @var string|null */
-    public $kontowaehrung;
-    /** @var int|null */
-    public $maximaleAnzahlEintraege;
-    /** @var string|null Max length: 35 */
-    public $aufsetzpunkt;
+    public \Fhp\Segment\Common\Kto $kontoverbindungAuftraggeber;
+    public bool $alleKonten;
+    public ?string $kontowaehrung = null;
+    public ?int $maximaleAnzahlEintraege = null;
+    /** Max length: 35 */
+    public ?string $aufsetzpunkt = null;
 
     public static function create(\Fhp\Segment\Common\Kto $kto, ?string $aufsetzpunkt = null): HKSALv4
     {

--- a/lib/Fhp/Segment/SAL/HKSALv5.php
+++ b/lib/Fhp/Segment/SAL/HKSALv5.php
@@ -15,14 +15,11 @@ use Fhp\Segment\Paginateable;
  */
 class HKSALv5 extends BaseSegment implements Paginateable
 {
-    /** @var \Fhp\Segment\Common\KtvV3 */
-    public $kontoverbindungAuftraggeber;
-    /** @var bool */
-    public $alleKonten;
-    /** @var int|null */
-    public $maximaleAnzahlEintraege;
-    /** @var string|null Max length: 35 */
-    public $aufsetzpunkt;
+    public \Fhp\Segment\Common\KtvV3 $kontoverbindungAuftraggeber;
+    public bool $alleKonten;
+    public ?int $maximaleAnzahlEintraege = null;
+    /** Max length: 35 */
+    public ?string $aufsetzpunkt = null;
 
     public static function create(\Fhp\Segment\Common\KtvV3 $ktv, bool $alleKonten, ?string $aufsetzpunkt = null): HKSALv5
     {

--- a/lib/Fhp/Segment/SAL/HKSALv6.php
+++ b/lib/Fhp/Segment/SAL/HKSALv6.php
@@ -14,14 +14,11 @@ use Fhp\Segment\Paginateable;
  */
 class HKSALv6 extends BaseSegment implements Paginateable
 {
-    /** @var \Fhp\Segment\Common\KtvV3 */
-    public $kontoverbindungAuftraggeber;
-    /** @var bool */
-    public $alleKonten;
-    /** @var int|null */
-    public $maximaleAnzahlEintraege;
-    /** @var string|null Max length: 35 */
-    public $aufsetzpunkt;
+    public \Fhp\Segment\Common\KtvV3 $kontoverbindungAuftraggeber;
+    public bool $alleKonten;
+    public ?int $maximaleAnzahlEintraege = null;
+    /** Max length: 35 */
+    public ?string $aufsetzpunkt = null;
 
     public static function create(\Fhp\Segment\Common\KtvV3 $ktv, bool $alleKonten, ?string $aufsetzpunkt = null): HKSALv6
     {

--- a/lib/Fhp/Segment/SAL/HKSALv7.php
+++ b/lib/Fhp/Segment/SAL/HKSALv7.php
@@ -14,14 +14,11 @@ use Fhp\Segment\Paginateable;
  */
 class HKSALv7 extends BaseSegment implements Paginateable
 {
-    /** @var \Fhp\Segment\Common\Kti */
-    public $kontoverbindungInternational;
-    /** @var bool */
-    public $alleKonten;
-    /** @var int|null */
-    public $maximaleAnzahlEintraege;
-    /** @var string|null Max length: 35 */
-    public $aufsetzpunkt;
+    public \Fhp\Segment\Common\Kti $kontoverbindungInternational;
+    public bool $alleKonten;
+    public ?int $maximaleAnzahlEintraege = null;
+    /** Max length: 35 */
+    public ?string $aufsetzpunkt = null;
 
     public static function create(\Fhp\Segment\Common\Kti $kti, bool $alleKonten, ?string $aufsetzpunkt = null): HKSALv7
     {

--- a/lib/Fhp/Segment/SPA/HISPASv1.php
+++ b/lib/Fhp/Segment/SPA/HISPASv1.php
@@ -12,10 +12,8 @@ use Fhp\Segment\BaseGeschaeftsvorfallparameter;
  */
 class HISPASv1 extends BaseGeschaeftsvorfallparameter implements HISPAS
 {
-    /** @var ParameterSepaKontoverbindungAnfordernV1 */
-    public $parameter;
+    public ParameterSepaKontoverbindungAnfordernV1 $parameter;
 
-    /** {@inheritdoc} */
     public function getParameter(): ParameterSepaKontoverbindungAnfordern
     {
         return $this->parameter;

--- a/lib/Fhp/Segment/SPA/HISPASv2.php
+++ b/lib/Fhp/Segment/SPA/HISPASv2.php
@@ -12,10 +12,8 @@ use Fhp\Segment\BaseGeschaeftsvorfallparameter;
  */
 class HISPASv2 extends BaseGeschaeftsvorfallparameter implements HISPAS
 {
-    /** @var ParameterSepaKontoverbindungAnfordernV2 */
-    public $parameter;
+    public ParameterSepaKontoverbindungAnfordernV2 $parameter;
 
-    /** {@inheritdoc} */
     public function getParameter(): ParameterSepaKontoverbindungAnfordern
     {
         return $this->parameter;

--- a/lib/Fhp/Segment/SPA/HISPAv1.php
+++ b/lib/Fhp/Segment/SPA/HISPAv1.php
@@ -14,7 +14,7 @@ use Fhp\Segment\BaseSegment;
 class HISPAv1 extends BaseSegment implements HISPA
 {
     /** @var \Fhp\Segment\Common\Ktz[]|null @Max(999) */
-    public $sepaKontoverbindung;
+    public ?array $sepaKontoverbindung = null;
 
     /** @return \Fhp\Segment\Common\Ktz[] */
     public function getSepaKontoverbindung(): array

--- a/lib/Fhp/Segment/SPA/HKSPAv1.php
+++ b/lib/Fhp/Segment/SPA/HKSPAv1.php
@@ -17,5 +17,5 @@ class HKSPAv1 extends BaseSegment
      * If left empty, all accounts will be returned.
      * @var \Fhp\Segment\Common\KtvV3[]|null @Max(999)
      */
-    public $kontoverbindung;
+    public ?array $kontoverbindung = null;
 }

--- a/lib/Fhp/Segment/SPA/HKSPAv2.php
+++ b/lib/Fhp/Segment/SPA/HKSPAv2.php
@@ -18,11 +18,11 @@ class HKSPAv2 extends BaseSegment implements Paginateable
      * If left empty, all accounts will be returned.
      * @var \Fhp\Segment\Common\KtvV3[]|null @Max(999)
      */
-    public $kontoverbindung;
-    /** @var int|null Only allowed if {@link ParameterSepaKontoverbindungAnfordernV2::$eingabeAnzahlEintraegeErlaubt} says so. */
-    public $maximaleAnzahlEintraege;
-    /** @var string|null For pagination. */
-    public $aufsetzpunkt;
+    public ?array $kontoverbindung = null;
+    /** Only allowed if {@link ParameterSepaKontoverbindungAnfordernV2::$eingabeAnzahlEintraegeErlaubt} says so. */
+    public ?int $maximaleAnzahlEintraege = null;
+    /** For pagination. */
+    public ?string $aufsetzpunkt = null;
 
     public function setPaginationToken(string $paginationToken)
     {

--- a/lib/Fhp/Segment/SPA/ParameterSepaKontoverbindungAnfordernV1.php
+++ b/lib/Fhp/Segment/SPA/ParameterSepaKontoverbindungAnfordernV1.php
@@ -15,12 +15,9 @@ class ParameterSepaKontoverbindungAnfordernV1 extends BaseDeg implements Paramet
 {
     use GetUnterstuetzteSepaDatenformateTrait;
 
-    /** @var bool */
-    public $einzelkontenabrufErlaubt;
-    /** @var bool */
-    public $nationaleKontoverbindungErlaubt;
-    /** @var bool */
-    public $strukturierterVerwendungszweckErlaubt;
+    public bool $einzelkontenabrufErlaubt;
+    public bool $nationaleKontoverbindungErlaubt;
+    public bool $strukturierterVerwendungszweckErlaubt;
     /** @var string[] @Max(99) Max length each: 256 */
-    public $unterstuetzteSepaDatenformate;
+    public array $unterstuetzteSepaDatenformate;
 }

--- a/lib/Fhp/Segment/SPA/ParameterSepaKontoverbindungAnfordernV2.php
+++ b/lib/Fhp/Segment/SPA/ParameterSepaKontoverbindungAnfordernV2.php
@@ -15,14 +15,10 @@ class ParameterSepaKontoverbindungAnfordernV2 extends BaseDeg implements Paramet
 {
     use GetUnterstuetzteSepaDatenformateTrait;
 
-    /** @var bool */
-    public $einzelkontenabrufErlaubt;
-    /** @var bool */
-    public $nationaleKontoverbindungErlaubt;
-    /** @var bool */
-    public $strukturierterVerwendungszweckErlaubt;
-    /** @var bool */
-    public $eingabeAnzahlEintraegeErlaubt;
+    public bool $einzelkontenabrufErlaubt;
+    public bool $nationaleKontoverbindungErlaubt;
+    public bool $strukturierterVerwendungszweckErlaubt;
+    public bool $eingabeAnzahlEintraegeErlaubt;
     /** @var string[] @Max(99) Max length each: 256 */
-    public $unterstuetzteSepaDatenformate;
+    public array $unterstuetzteSepaDatenformate;
 }

--- a/lib/Fhp/Segment/SegmentDescriptor.php
+++ b/lib/Fhp/Segment/SegmentDescriptor.php
@@ -9,7 +9,7 @@ namespace Fhp\Segment;
 class SegmentDescriptor extends BaseDescriptor
 {
     /** @var SegmentDescriptor[] */
-    private static $descriptors = [];
+    private static array $descriptors = [];
 
     /**
      * @param string $class The name of a sub-class of {@link BaseSegment}.
@@ -23,8 +23,8 @@ class SegmentDescriptor extends BaseDescriptor
         return static::$descriptors[$class];
     }
 
-    /** @var string Example: "HITANS" */
-    public $kennung;
+    /** Example: "HITANS" */
+    public string $kennung;
 
     /**
      * Please use the factory above.
@@ -51,7 +51,7 @@ class SegmentDescriptor extends BaseDescriptor
         }
     }
 
-    public function validateObject($obj) // Override
+    public function validateObject($obj): void // Override
     {
         parent::validateObject($obj);
         if (!($obj instanceof BaseSegment)) {

--- a/lib/Fhp/Segment/Segmentkopf.php
+++ b/lib/Fhp/Segment/Segmentkopf.php
@@ -7,27 +7,23 @@ class Segmentkopf extends BaseDeg
     /**
      * The name/type of the segment, e.g. "HITANS", corresponding to {@link SegmentDescriptor::$kennung}.
      * Max length: 6
-     * @var string
      */
-    public $segmentkennung;
+    public string $segmentkennung;
 
     /**
      * A number to refer to the segment within a message. Similar to an index, but they don't technically have to be
      * consecutive within a message.
-     * @var int
      */
-    public $segmentnummer;
+    public int $segmentnummer;
 
     /**
      * Version of the segment, corresponding to {@link SegmentDescriptor::$version}.
-     * @var int
      */
-    public $segmentversion;
+    public int $segmentversion;
 
     /**
      * Not allowed in requests, optionally present in responses.
      * In a response message, this refers to the {@link $segmentnummer} of a segment in the request message.
-     * @var int|null
      */
-    public $bezugselement;
+    public ?int $bezugselement = null;
 }

--- a/lib/Fhp/Segment/TAB/HITABv4.php
+++ b/lib/Fhp/Segment/TAB/HITABv4.php
@@ -17,11 +17,10 @@ class HITABv4 extends BaseSegment implements HITAB
      * 0: Kunde kann alle „aktiven“ Medien parallel nutzen
      * 1: Kunde kann genau ein Medium (z. B. ein Mobiltelefon oder einen TAN-Generator) zu einer Zeit nutzen
      * 2: Kunde kann ein Mobiltelefon und einen TAN-Generator parallel nutzen
-     * @var int
      */
-    public $tanEinsatzoption;
+    public int $tanEinsatzoption;
     /** @var TanMediumListeV4[]|null @Max(99) */
-    public $tanMediumListe;
+    public ?array $tanMediumListe = null;
 
     /** {@inheritdoc} */
     public function getTanMediumListe(): array

--- a/lib/Fhp/Segment/TAB/HITABv5.php
+++ b/lib/Fhp/Segment/TAB/HITABv5.php
@@ -17,11 +17,10 @@ class HITABv5 extends BaseSegment implements HITAB
      * 0: Kunde kann alle „aktiven“ Medien parallel nutzen
      * 1: Kunde kann genau ein Medium (z. B. ein Mobiltelefon oder einen TAN-Generator) zu einer Zeit nutzen
      * 2: Kunde kann ein Mobiltelefon und einen TAN-Generator parallel nutzen
-     * @var int
      */
-    public $tanEinsatzoption;
+    public int $tanEinsatzoption;
     /** @var TanMediumListeV5[]|null @Max(99) */
-    public $tanMediumListe;
+    public ?array $tanMediumListe = null;
 
     /** {@inheritdoc} */
     public function getTanMediumListe(): array

--- a/lib/Fhp/Segment/TAB/HKTABv4.php
+++ b/lib/Fhp/Segment/TAB/HKTABv4.php
@@ -17,16 +17,14 @@ class HKTABv4 extends BaseSegment
      * 0: Alle
      * 1: Aktiv
      * 2: Verfügbar
-     * @var int
      */
-    public $tanMediumArt = 0;
+    public int $tanMediumArt = 0;
     /**
      * A: Alle Medien
      * L: Liste
      * * G: TAN-Generator
      * M: Mobiltelefon mit mobileTAN
      * S: Secoder
-     * @var string
      */
-    public $tanMediumKlasse = 'A';
+    public string $tanMediumKlasse = 'A';
 }

--- a/lib/Fhp/Segment/TAB/HKTABv5.php
+++ b/lib/Fhp/Segment/TAB/HKTABv5.php
@@ -17,9 +17,8 @@ class HKTABv5 extends BaseSegment
      * 0: Alle
      * 1: Aktiv
      * 2: Verfügbar
-     * @var int
      */
-    public $tanMediumArt = 0;
+    public int $tanMediumArt = 0;
     /**
      * A: Alle Medien
      * L: Liste
@@ -27,7 +26,6 @@ class HKTABv5 extends BaseSegment
      * M: Mobiltelefon mit mobileTAN
      * S: Secoder
      * B: Bilateral vereinbart
-     * @var string
      */
-    public $tanMediumKlasse = 'A';
+    public string $tanMediumKlasse = 'A';
 }

--- a/lib/Fhp/Segment/TAB/TanMediumListeV4.php
+++ b/lib/Fhp/Segment/TAB/TanMediumListeV4.php
@@ -19,45 +19,42 @@ class TanMediumListeV4 extends BaseDeg implements TanMediumListe
      * G: TAN-Generator
      * M: Mobiltelefon mit mobileTAN
      * S: Secoder
-     * @var string
      */
-    public $tanMediumKlasse;
+    public string $tanMediumKlasse;
     /**
      * 1: Aktiv
      * 2: Verfügbar
      * 3: Aktiv Folgekarte
      * 4: Verfügbar Folgekarte
-     * @var int
      */
-    public $status;
-    /** @var string|null Only for tanMediumKlasse=='G' */
-    public $kartennummer;
-    /** @var string|null Only for tanMediumKlasse=='G' */
-    public $kartenfolgenummer;
-    /** @var int|null Only and optional for tanMediumKlasse=='G' and if BPD allows it */
-    public $kartenart;
-    /** @var \Fhp\Segment\Common\KtvV3|null Only and optional for tanMediumKlasse=='G' */
-    public $kontoverbindungAuftraggeber;
-    /** @var string|null JJJJMMTT gemäß ISO 8601 Only and optional for tanMediumKlasse=='G' */
-    public $gueltigAb;
-    /** @var string|null JJJJMMTT gemäß ISO 8601 Only and optional for tanMediumKlasse=='G' */
-    public $gueltigBis;
-    /** @var string|null Only for tanMediumKlasse=='L' */
-    public $tanListennumer;
-    /** @var string|null Must for tanMediumKlasse=='M', optional otherwise. Max length: 32 */
-    public $bezeichnungDesTanMediums;
-    /** @var string|null Only and optional for tanMediumKlasse=='M' */
-    public $mobiltelefonnummerVerschleiert;
-    /** @var string|null Only and optional for tanMediumKlasse=='M' */
-    public $mobiltelefonnummer;
-    /** @var \Fhp\Segment\Common\Kti|null Only and optional for tanMediumKlasse=='M' */
-    public $smsAbbuchungskonto;
-    /** @var int|null */
-    public $anzahlFreieTans;
-    /** @var string|null JJJJMMTT gemäß ISO 8601 * */
-    public $letzteBenutzung;
-    /** @var string|null JJJJMMTT gemäß ISO 8601 * */
-    public $freigeschaltetAm;
+    public int $status;
+    /** Only for tanMediumKlasse=='G' */
+    public ?string $kartennummer = null;
+    /** Only for tanMediumKlasse=='G' */
+    public ?string $kartenfolgenummer = null;
+    /** Only and optional for tanMediumKlasse=='G' and if BPD allows it */
+    public ?int $kartenart = null;
+    /** Only and optional for tanMediumKlasse=='G' */
+    public ?\Fhp\Segment\Common\KtvV3 $kontoverbindungAuftraggeber = null;
+    /** JJJJMMTT gemäß ISO 8601 Only and optional for tanMediumKlasse=='G' */
+    public ?string $gueltigAb = null;
+    /** JJJJMMTT gemäß ISO 8601 Only and optional for tanMediumKlasse=='G' */
+    public ?string $gueltigBis = null;
+    /** Only for tanMediumKlasse=='L' */
+    public ?string $tanListennumer = null;
+    /** Must for tanMediumKlasse=='M', optional otherwise. Max length: 32 */
+    public ?string $bezeichnungDesTanMediums = null;
+    /** Only and optional for tanMediumKlasse=='M' */
+    public ?string $mobiltelefonnummerVerschleiert = null;
+    /** Only and optional for tanMediumKlasse=='M' */
+    public ?string $mobiltelefonnummer = null;
+    /** Only and optional for tanMediumKlasse=='M' */
+    public ?\Fhp\Segment\Common\Kti $smsAbbuchungskonto = null;
+    public ?int $anzahlFreieTans = null;
+    /** JJJJMMTT gemäß ISO 8601 */
+    public ?string $letzteBenutzung = null;
+    /** JJJJMMTT gemäß ISO 8601 */
+    public ?string $freigeschaltetAm = null;
 
     /** {@inheritdoc} */
     public function getName(): string

--- a/lib/Fhp/Segment/TAB/TanMediumListeV5.php
+++ b/lib/Fhp/Segment/TAB/TanMediumListeV5.php
@@ -20,47 +20,44 @@ class TanMediumListeV5 extends BaseDeg implements TanMediumListe
      * M: Mobiltelefon mit mobileTAN
      * S: Secoder
      * B: Bilateral vereinbart
-     * @var string
      */
-    public $tanMediumKlasse;
+    public string $tanMediumKlasse;
     /**
      * 1: Aktiv
      * 2: Verfügbar
      * 3: Aktiv Folgekarte
      * 4: Verfügbar Folgekarte
-     * @var int
      */
-    public $status;
-    /** @var int|null Only for tanMediumKlasse=='B' */
-    public $sicherheitsfunktion;
-    /** @var string|null Only for tanMediumKlasse=='G' */
-    public $kartennummer;
-    /** @var string|null Only for tanMediumKlasse=='G' */
-    public $kartenfolgenummer;
-    /** @var int|null Only and optional for tanMediumKlasse=='G' and if BPD allows it */
-    public $kartenart;
-    /** @var \Fhp\Segment\Common\KtvV3|null Only and optional for tanMediumKlasse=='G' */
-    public $kontoverbindungAuftraggeber;
-    /** @var string|null JJJJMMTT gemäß ISO 8601 Only and optional for tanMediumKlasse=='G' */
-    public $gueltigAb;
-    /** @var string|null JJJJMMTT gemäß ISO 8601 Only and optional for tanMediumKlasse=='G' */
-    public $gueltigBis;
-    /** @var string|null Only for tanMediumKlasse=='L' */
-    public $tanListennumer;
-    /** @var string|null Must for tanMediumKlasse=='M', optional otherwise */
-    public $bezeichnungDesTanMediums;
-    /** @var string|null Only and optional for tanMediumKlasse=='M' */
-    public $mobiltelefonnummerVerschleiert;
-    /** @var string|null Only and optional for tanMediumKlasse=='M' */
-    public $mobiltelefonnummer;
-    /** @var \Fhp\Segment\Common\Kti|null Only and optional for tanMediumKlasse=='M' */
-    public $smsAbbuchungskonto;
-    /** @var int|null */
-    public $anzahlFreieTans;
-    /** @var string|null JJJJMMTT gemäß ISO 8601 * */
-    public $letzteBenutzung;
-    /** @var string|null JJJJMMTT gemäß ISO 8601 * */
-    public $freigeschaltetAm;
+    public int $status;
+    /** Only for tanMediumKlasse=='B' */
+    public ?int $sicherheitsfunktion = null;
+    /** Only for tanMediumKlasse=='G' */
+    public ?string $kartennummer = null;
+    /** Only for tanMediumKlasse=='G' */
+    public ?string $kartenfolgenummer = null;
+    /** Only and optional for tanMediumKlasse=='G' and if BPD allows it */
+    public ?int $kartenart = null;
+    /** Only and optional for tanMediumKlasse=='G' */
+    public ?\Fhp\Segment\Common\KtvV3 $kontoverbindungAuftraggeber = null;
+    /** JJJJMMTT gemäß ISO 8601 Only and optional for tanMediumKlasse=='G' */
+    public ?string $gueltigAb = null;
+    /** JJJJMMTT gemäß ISO 8601 Only and optional for tanMediumKlasse=='G' */
+    public ?string $gueltigBis = null;
+    /** Only for tanMediumKlasse=='L' */
+    public ?string $tanListennumer = null;
+    /** Must for tanMediumKlasse=='M', optional otherwise */
+    public ?string $bezeichnungDesTanMediums = null;
+    /** Only and optional for tanMediumKlasse=='M' */
+    public ?string $mobiltelefonnummerVerschleiert = null;
+    /** Only and optional for tanMediumKlasse=='M' */
+    public ?string $mobiltelefonnummer = null;
+    /** Only and optional for tanMediumKlasse=='M' */
+    public ?\Fhp\Segment\Common\Kti $smsAbbuchungskonto = null;
+    public ?int $anzahlFreieTans = null;
+    /** JJJJMMTT gemäß ISO 8601 */
+    public ?string $letzteBenutzung = null;
+    /** JJJJMMTT gemäß ISO 8601 */
+    public ?string $freigeschaltetAm = null;
 
     /** {@inheritdoc} */
     public function getName(): string

--- a/lib/Fhp/Segment/TAN/AntwortHhdUc.php
+++ b/lib/Fhp/Segment/TAN/AntwortHhdUc.php
@@ -13,14 +13,14 @@ use Fhp\Segment\BaseDeg;
  */
 class AntwortHhdUc extends BaseDeg
 {
-    /** @var string Max length 5 */
-    public $atc;
-    /** @var string Binary; Max length 256 */
-    public $applicationCryptogramAc;
-    /** @var string Binary; Max length 256 */
-    public $efIdData;
-    /** @var string Binary; Max length 256 */
-    public $cvr;
-    /** @var string Binary; Max length 256 */
-    public $versionsinfoDerChipTanApplication;
+    /** Max length 5 */
+    public string $atc;
+    /** Binary; Max length 256 */
+    public string $applicationCryptogramAc;
+    /** Binary; Max length 256 */
+    public string $efIdData;
+    /** Binary; Max length 256 */
+    public string $cvr;
+    /** Binary; Max length 256 */
+    public string $versionsinfoDerChipTanApplication;
 }

--- a/lib/Fhp/Segment/TAN/GueltigkeitsdatumUndUhrzeitFuerChallenge.php
+++ b/lib/Fhp/Segment/TAN/GueltigkeitsdatumUndUhrzeitFuerChallenge.php
@@ -13,8 +13,8 @@ use Fhp\Segment\BaseDeg;
  */
 class GueltigkeitsdatumUndUhrzeitFuerChallenge extends BaseDeg
 {
-    /** @var string JJJJMMTT gemäß ISO 8601 */
-    public $datum;
-    /** @var string hhmmss gemäß ISO 8601, local time (no time zone support). */
-    public $uhrzeit;
+    /** JJJJMMTT gemäß ISO 8601 */
+    public string $datum;
+    /** hhmmss gemäß ISO 8601, local time (no time zone support). */
+    public string $uhrzeit;
 }

--- a/lib/Fhp/Segment/TAN/HITANSv6.php
+++ b/lib/Fhp/Segment/TAN/HITANSv6.php
@@ -16,8 +16,7 @@ use Fhp\Segment\BaseGeschaeftsvorfallparameter;
  */
 class HITANSv6 extends BaseGeschaeftsvorfallparameter implements HITANS
 {
-    /** @var ParameterZweiSchrittTanEinreichungV6 */
-    public $parameterZweiSchrittTanEinreichung;
+    public ParameterZweiSchrittTanEinreichungV6 $parameterZweiSchrittTanEinreichung;
 
     public function getParameterZweiSchrittTanEinreichung(): ParameterZweiSchrittTanEinreichung
     {

--- a/lib/Fhp/Segment/TAN/HITANSv7.php
+++ b/lib/Fhp/Segment/TAN/HITANSv7.php
@@ -16,8 +16,7 @@ use Fhp\Segment\BaseGeschaeftsvorfallparameter;
  */
 class HITANSv7 extends BaseGeschaeftsvorfallparameter implements HITANS
 {
-    /** @var ParameterZweiSchrittTanEinreichungV7 */
-    public $parameterZweiSchrittTanEinreichung;
+    public ParameterZweiSchrittTanEinreichungV7 $parameterZweiSchrittTanEinreichung;
 
     public function getParameterZweiSchrittTanEinreichung(): ParameterZweiSchrittTanEinreichung
     {

--- a/lib/Fhp/Segment/TAN/HITANv6.php
+++ b/lib/Fhp/Segment/TAN/HITANv6.php
@@ -15,24 +15,23 @@ use Fhp\Syntax\Bin;
 class HITANv6 extends BaseSegment implements HITAN
 {
     /**
-     * @var string Allowed values: 1 (for Prozessvariante 1), 2, 3, 4. See {@link HKTANv6::$tanProzess} for details.
+     * Allowed values: 1 (for Prozessvariante 1), 2, 3, 4. See {@link HKTANv6::$tanProzess} for details.
      *     NOTE: This field is re-used in HITANv7, where the value 'S' is also allowed.
      */
-    public $tanProzess;
+    public string $tanProzess;
     /**
      * This will just return the same hash as was passed in HKTAN.
      * M: bei AuftragsHashwertverfahren<>0 und TAN-Prozess=1
      * N: sonst
-     * @var Bin|null
      */
-    public $auftragsHashwert;
+    public ?Bin $auftragsHashwert = null;
     /**
      * Special value "noref" means that no TAN is needed.
      * M: bei TAN-Prozess=2, 3, 4 (and S)
      * O: TAN-Prozess=1
-     * @var string|null Max length: 35
+     * Max length: 35
      */
-    public $auftragsreferenz;
+    public ?string $auftragsreferenz = null;
     /**
      * This is the challenge that needs to be presented to the user, so that they can generate and enter a TAN.
      * Special value "nochallenge" means that no TAN is needed. If $challengeStrukturiert in HITANS is set, this may
@@ -41,22 +40,20 @@ class HITANv6 extends BaseSegment implements HITAN
      *
      * M: bei TAN-Prozess=1, 3, 4
      * O: bei TAN-Prozess=2 (and S)
-     * @var string|null Max length: 2048
+     * Max length: 2048
      */
-    public $challenge;
-    /** @var Bin|null */
-    public $challengeHhdUc;
-    /** @var GueltigkeitsdatumUndUhrzeitFuerChallenge|null */
-    public $gueltigkeitsdatumUndUhrzeitFuerChallenge;
+    public ?string $challenge = null;
+    public ?Bin $challengeHhdUc = null;
+    public ?GueltigkeitsdatumUndUhrzeitFuerChallenge $gueltigkeitsdatumUndUhrzeitFuerChallenge = null;
     /**
      * Note: There are generally two ways to treat TAN media, see also HKTAN's $bezeichnungDesTanMediums field. This
      * field here is set if the user does not choose the TAN medium beforehand, but the bank chooses it instead.
      *
      * M: bei TAN-Prozess=1, 3, 4 und „Anzahl unterstützter aktiver TAN-Medien“ nicht vorhanden
      * O: sonst
-     * @var string|null Max length 32
+     * Max length 32
      */
-    public $bezeichnungDesTanMediums;
+    public ?string $bezeichnungDesTanMediums = null;
 
     /** {@inheritdoc} */
     public function getProcessId(): string

--- a/lib/Fhp/Segment/TAN/HKTANFactory.php
+++ b/lib/Fhp/Segment/TAN/HKTANFactory.php
@@ -27,14 +27,14 @@ class HKTANFactory
      */
     public static function createProzessvariante2Step1(TanMode $tanMode, ?string $tanMedium = null, string $segmentkennung = 'HKIDN'): BaseSegment
     {
-        if ($tanMode !== null && $tanMode->getSmsAbbuchungskontoErforderlich()) {
+        if ($tanMode->getSmsAbbuchungskontoErforderlich()) {
             throw new \InvalidArgumentException('SMS-Abbuchungskonto not supported');
         }
 
         $result = $tanMode->createHKTAN();
         $result->setTanProzess(HKTAN::TAN_PROZESS_4);
         $result->setSegmentkennung($segmentkennung);
-        if ($tanMode !== null && $tanMode->needsTanMedium()) {
+        if ($tanMode->needsTanMedium()) {
             if ($tanMedium === null) {
                 throw new \InvalidArgumentException('Missing tanMedium');
             }

--- a/lib/Fhp/Segment/TAN/HKTANv6.php
+++ b/lib/Fhp/Segment/TAN/HKTANv6.php
@@ -38,65 +38,58 @@ class HKTANv6 extends BaseSegment implements HKTAN
      * configured in the BPD ({@link VerfahrensparameterZweiSchrittVerfahren} field $tanProzess). In practice,
      * Prozessvariante 2 is much more common.
      *
-     * @var string Allowed values: 1 (for Prozessvariante 1), 2, 3, 4.
+     * Allowed values: 1 (for Prozessvariante 1), 2, 3, 4.
      *     NOTE: This field is re-used in HITANv7, where the value 'S' is also allowed.
      */
-    public $tanProzess;
+    public string $tanProzess;
     /**
      * M: bei TAN-Prozess=1
      * M: bei TAN-Prozess=4 und starker Authentifizierung
      * N: sonst
-     * @var string|null Max length: 6
+     * Max length: 6
      */
-    public $segmentkennung;
+    public ?string $segmentkennung = null;
     /**
      * M: bei TAN-Prozess=1 und „Auftraggeberkonto erforderlich“=2 und Kontoverbindung im Auftrag enthalten
      * N: sonst
-     * @var \Fhp\Segment\Common\Kti|null
      */
-    public $kontoverbindungInternationalAuftraggeber;
+    public ?\Fhp\Segment\Common\Kti $kontoverbindungInternationalAuftraggeber = null;
     /**
      * M: bei AuftragsHashwertverfahren<>0 und TAN-Prozess=1
      * N: sonst
-     * @var Bin|null
      */
-    public $auftragsHashwert;
+    public ?Bin $auftragsHashwert = null;
     /**
      * M: bei TAN-Prozess=2, 3 (and S)
      * O: TAN-Prozess=1, 4
-     * @var string|null Max length: 36
+     * Max length: 36
      */
-    public $auftragsreferenz;
+    public ?string $auftragsreferenz = null;
     /**
      * M: bei TAN-Prozess=1, 2 (and S)
      * N: bei TAN-Prozess=3, 4
-     * @var bool|null
      */
-    public $weitereTanFolgt;
+    public ?bool $weitereTanFolgt = null;
     /**
      * O: bei TAN-Prozess=2 und „Auftragsstorno erlaubt“=J
      * N: sons
-     * @var bool|null
      */
-    public $auftragStornieren;
+    public ?bool $auftragStornieren = null;
     /**
      * M: bei TAN-Prozess=1, 3, 4 und „SMSAbbuchungskonto erforderlich“=2
      * O: sonst
-     * @var \Fhp\Segment\Common\Kti|null
      */
-    public $smsAbbuchungskonto;
+    public ?\Fhp\Segment\Common\Kti $smsAbbuchungskonto = null;
     /**
      * M: bei TAN-Prozess=1 und „Challenge-Klasse erforderlich“=J
      * N: sonst
-     * @var int|null
      */
-    public $challengeKlasse;
+    public ?int $challengeKlasse = null;
     /**
      * O: bei TAN-Prozess=1 und „Challenge-Klasse erforderlich“=J
      * N: sonst
-     * @var ParameterChallengeKlasse|null
      */
-    public $parameterChallengeKlasse;
+    public ?ParameterChallengeKlasse $parameterChallengeKlasse = null;
     /**
      * Note: There are generally two ways to treat TAN media. Either the HITANS declares that multiple media are
      * available and the user has to choose one of them (possibly first using HKSPA to retrieve a list of options), in
@@ -106,15 +99,14 @@ class HKTANv6 extends BaseSegment implements HKTAN
      * M: bei TAN-Prozess=1, 3, 4 und „Anzahl unterstützter aktiver TAN-Medien“ > 1
      *    und „Bezeichnung des TAN-Mediums erforderlich“=2
      * O: sonst
-     * @var string|null Max length 32
+     * Max length 32
      */
-    public $bezeichnungDesTanMediums;
+    public ?string $bezeichnungDesTanMediums = null;
     /**
      * M: bei TAN-Prozess=2 und „Antwort HHD_UC erforderlich“=“J“
      * O: sonst
-     * @var AntwortHhdUc|null
      */
-    public $antwortHhdUc;
+    public ?AntwortHhdUc $antwortHhdUc = null;
 
     /**
      * @return HKTANv6 A dummy HKTANv6 segment to signal PSD2 readiness.

--- a/lib/Fhp/Segment/TAN/ParameterChallengeKlasse.php
+++ b/lib/Fhp/Segment/TAN/ParameterChallengeKlasse.php
@@ -13,6 +13,6 @@ use Fhp\Segment\BaseDeg;
  */
 class ParameterChallengeKlasse extends BaseDeg
 {
-    /** @var string|null Max length 999 */
-    public $challengeKlasseParameter;
+    /** Max length 999 */
+    public ?string $challengeKlasseParameter = null;
 }

--- a/lib/Fhp/Segment/TAN/ParameterZweiSchrittTanEinreichungV6.php
+++ b/lib/Fhp/Segment/TAN/ParameterZweiSchrittTanEinreichungV6.php
@@ -7,19 +7,16 @@ use Fhp\Segment\BaseDeg;
 
 class ParameterZweiSchrittTanEinreichungV6 extends BaseDeg implements ParameterZweiSchrittTanEinreichung
 {
-    /** @var bool */
-    public $einschrittVerfahrenErlaubt;
-    /** @var bool */
-    public $mehrAlsEinTanPflichtigerAuftragProNachrichtErlaubt;
+    public bool $einschrittVerfahrenErlaubt;
+    public bool $mehrAlsEinTanPflichtigerAuftragProNachrichtErlaubt;
     /**
      * 0: Auftrags-Hashwert nicht unterstützt
      * 1: RIPEMD-160
      * 2: SHA-1
-     * @var int
      */
-    public $auftragsHashwertverfahren;
+    public int $auftragsHashwertverfahren;
     /** @var VerfahrensparameterZweiSchrittVerfahrenV6[] @Max(98) */
-    public $verfahrensparameterZweiSchrittVerfahren;
+    public array $verfahrensparameterZweiSchrittVerfahren;
 
     public function isEinschrittVerfahrenErlaubt(): bool
     {

--- a/lib/Fhp/Segment/TAN/ParameterZweiSchrittTanEinreichungV7.php
+++ b/lib/Fhp/Segment/TAN/ParameterZweiSchrittTanEinreichungV7.php
@@ -7,19 +7,16 @@ use Fhp\Segment\BaseDeg;
 
 class ParameterZweiSchrittTanEinreichungV7 extends BaseDeg implements ParameterZweiSchrittTanEinreichung
 {
-    /** @var bool */
-    public $einschrittVerfahrenErlaubt;
-    /** @var bool */
-    public $mehrAlsEinTanPflichtigerAuftragProNachrichtErlaubt;
+    public bool $einschrittVerfahrenErlaubt;
+    public bool $mehrAlsEinTanPflichtigerAuftragProNachrichtErlaubt;
     /**
      * 0: Auftrags-Hashwert nicht unterstützt
      * 1: RIPEMD-160
      * 2: SHA-1
-     * @var int
      */
-    public $auftragsHashwertverfahren;
+    public int $auftragsHashwertverfahren;
     /** @var VerfahrensparameterZweiSchrittVerfahrenV7[] @Max(98) */
-    public $verfahrensparameterZweiSchrittVerfahren;
+    public array $verfahrensparameterZweiSchrittVerfahren;
 
     public function isEinschrittVerfahrenErlaubt(): bool
     {

--- a/lib/Fhp/Segment/TAN/VerfahrensparameterZweiSchrittVerfahrenV6.php
+++ b/lib/Fhp/Segment/TAN/VerfahrensparameterZweiSchrittVerfahrenV6.php
@@ -8,28 +8,24 @@ use Fhp\Segment\BaseDeg;
 
 class VerfahrensparameterZweiSchrittVerfahrenV6 extends BaseDeg implements TanMode
 {
-    /** @var int Allowed values: 900 through 997 */
-    public $sicherheitsfunktion;
-    /** @var string Allowed values: 1, 2; See specification or {@link HKTANv6::$$tanProzess} for details. */
-    public $tanProzess;
-    /** @var string */
-    public $technischeIdentifikationTanVerfahren;
-    /** @var string|null Max length: 32 */
-    public $zkaTanVerfahren;
-    /** @var string|null Max length: 10 */
-    public $versionZkaTanVerfahren;
-    /** @var string Max length: 30 */
-    public $nameDesZweiSchrittVerfahrens;
-    /** @var int */
-    public $maximaleLaengeDesTanEingabewertes;
-    /** @var int Allowed values: 1 = numerisch, 2 = alfanumerisch */
-    public $erlaubtesFormat;
-    /** @var string */
-    public $textZurBelegungDesRueckgabewertes;
-    /** @var int Allowed values: 1 through 256 */
-    public $maximaleLaengeDesRueckgabewertes;
-    /** @var bool */
-    public $mehrfachTanErlaubt;
+    /** Allowed values: 900 through 997 */
+    public int $sicherheitsfunktion;
+    /** Allowed values: 1, 2; See specification or {@link HKTANv6::$$tanProzess} for details. */
+    public string $tanProzess;
+    public string $technischeIdentifikationTanVerfahren;
+    /** Max length: 32 */
+    public ?string $zkaTanVerfahren = null;
+    /** Max length: 10 */
+    public ?string $versionZkaTanVerfahren = null;
+    /** Max length: 30 */
+    public string $nameDesZweiSchrittVerfahrens;
+    public int $maximaleLaengeDesTanEingabewertes;
+    /** Allowed values: 1 = numerisch, 2 = alfanumerisch */
+    public int $erlaubtesFormat;
+    public string $textZurBelegungDesRueckgabewertes;
+    /** Allowed values: 1 through 256 */
+    public int $maximaleLaengeDesRueckgabewertes;
+    public bool $mehrfachTanErlaubt;
     /**
      * In case of multi-TAN (see {@link $mehrfachTanErlaubt}), this specifies whether all TANs must be entered in the
      * same dialog and at the same time, or not.
@@ -37,27 +33,21 @@ class VerfahrensparameterZweiSchrittVerfahrenV6 extends BaseDeg implements TanMo
      * 2 TAN zeitversetzt / dialogübergreifend erlaubt
      * 3 beide Verfahren unterstützt
      * 4 nicht zutreffend
-     * @var int
      */
-    public $tanZeitUndDialogbezug;
-    /** @var bool */
-    public $auftragsstornoErlaubt;
-    /** @var int Allowed values: 0 (cannot), 2 (must) */
-    public $smsAbbuchungskontoErforderlich;
-    /** @var int Allowed values: 0 (cannot), 2 (must) */
-    public $auftraggeberkontoErforderlich;
-    /** @var bool */
-    public $challengeKlasseErforderlich;
-    /** @var bool */
-    public $challengeStrukturiert;
-    /** @var string Allowed values: 00 (cleartext PIN, no TAN), 01 (Schablone 01, encrypted PIN), 02 (reserved) */
-    public $initialisierungsmodus;
-    /** @var int Allowed values: 0 (cannot), 2 (must) */
-    public $bezeichnungDesTanMediumsErforderlich;
-    /** @var bool */
-    public $antwortHhdUcErforderlich;
-    /** @var int|null */
-    public $anzahlUnterstuetzterAktiverTanMedien;
+    public int $tanZeitUndDialogbezug;
+    public bool $auftragsstornoErlaubt;
+    /** Allowed values: 0 (cannot), 2 (must) */
+    public int $smsAbbuchungskontoErforderlich;
+    /** Allowed values: 0 (cannot), 2 (must) */
+    public int $auftraggeberkontoErforderlich;
+    public bool $challengeKlasseErforderlich;
+    public bool $challengeStrukturiert;
+    /** Allowed values: 00 (cleartext PIN, no TAN), 01 (Schablone 01, encrypted PIN), 02 (reserved) */
+    public string $initialisierungsmodus;
+    /** Allowed values: 0 (cannot), 2 (must) */
+    public int $bezeichnungDesTanMediumsErforderlich;
+    public bool $antwortHhdUcErforderlich;
+    public ?int $anzahlUnterstuetzterAktiverTanMedien = null;
 
     /** {@inheritdoc} */
     public function getId(): int

--- a/lib/Fhp/Segment/TAN/VerfahrensparameterZweiSchrittVerfahrenV7.php
+++ b/lib/Fhp/Segment/TAN/VerfahrensparameterZweiSchrittVerfahrenV7.php
@@ -8,12 +8,11 @@ use Fhp\Segment\BaseDeg;
 
 class VerfahrensparameterZweiSchrittVerfahrenV7 extends BaseDeg implements TanMode
 {
-    /** @var int Allowed values: 900 through 997 */
-    public $sicherheitsfunktion;
-    /** @var string Allowed values: 1, 2; See specification or {@link HKTANv7::$$tanProzess} for details. */
-    public $tanProzess;
-    /** @var string */
-    public $technischeIdentifikationTanVerfahren;
+    /** Allowed values: 900 through 997 */
+    public int $sicherheitsfunktion;
+    /** Allowed values: 1, 2; See specification or {@link HKTANv7::$$tanProzess} for details. */
+    public string $tanProzess;
+    public string $technischeIdentifikationTanVerfahren;
     /**
      * Allowed values:
      * - HHD
@@ -23,23 +22,21 @@ class VerfahrensparameterZweiSchrittVerfahrenV7 extends BaseDeg implements TanMo
      * - App
      * - Decoupled
      * - DecoupledPush
-     * @var string|null Max length: 32
+     * Max length: 32
      */
-    public $dkTanVerfahren;
-    /** @var string|null Max length: 10 */
-    public $versionDkTanVerfahren;
-    /** @var string Max length: 30 */
-    public $nameDesZweiSchrittVerfahrens;
-    /** @var int|null Present iff !isDecoupled. */
-    public $maximaleLaengeDesTanEingabewertes;
-    /** @var int|null Present iff !isDecoupled. Allowed values: 1 = numerisch, 2 = alfanumerisch */
-    public $erlaubtesFormat;
-    /** @var string */
-    public $textZurBelegungDesRueckgabewertes;
-    /** @var int Allowed values: 1 through 256 */
-    public $maximaleLaengeDesRueckgabewertes;
-    /** @var bool */
-    public $mehrfachTanErlaubt;
+    public ?string $dkTanVerfahren = null;
+    /** Max length: 10 */
+    public ?string $versionDkTanVerfahren = null;
+    /** Max length: 30 */
+    public string $nameDesZweiSchrittVerfahrens;
+    /** Present iff !isDecoupled. */
+    public ?int $maximaleLaengeDesTanEingabewertes = null;
+    /** Present iff !isDecoupled. Allowed values: 1 = numerisch, 2 = alfanumerisch */
+    public ?int $erlaubtesFormat = null;
+    public string $textZurBelegungDesRueckgabewertes;
+    /** Allowed values: 1 through 256 */
+    public int $maximaleLaengeDesRueckgabewertes;
+    public bool $mehrfachTanErlaubt;
     /**
      * In case of multi-TAN (see {@link $mehrfachTanErlaubt}), this specifies whether all TANs must be entered in the
      * same dialog and at the same time, or not.
@@ -47,37 +44,31 @@ class VerfahrensparameterZweiSchrittVerfahrenV7 extends BaseDeg implements TanMo
      * 2 TAN zeitversetzt / dialogübergreifend erlaubt
      * 3 beide Verfahren unterstützt
      * 4 nicht zutreffend
-     * @var int
      */
-    public $tanZeitUndDialogbezug;
-    /** @var bool */
-    public $auftragsstornoErlaubt;
-    /** @var int Allowed values: 0 (cannot), 2 (must) */
-    public $smsAbbuchungskontoErforderlich;
-    /** @var int Allowed values: 0 (cannot), 2 (must) */
-    public $auftraggeberkontoErforderlich;
-    /** @var bool */
-    public $challengeKlasseErforderlich;
-    /** @var bool */
-    public $challengeStrukturiert;
-    /** @var string Allowed values: 00 (cleartext PIN, no TAN), 01 (Schablone 01, encrypted PIN), 02 (reserved) */
-    public $initialisierungsmodus;
-    /** @var int Allowed values: 0 (cannot), 2 (must) */
-    public $bezeichnungDesTanMediumsErforderlich;
-    /** @var bool */
-    public $antwortHhdUcErforderlich;
-    /** @var int|null */
-    public $anzahlUnterstuetzterAktiverTanMedien;
-    /** @var int|null Present iff isDecoupled. 0 means infinity. */
-    public $maximaleAnzahlStatusabfragen;
-    /** @var int|null Present iff isDecoupled. In seconds. */
-    public $wartezeitVorErsterStatusabfrage;
-    /** @var int|null Present iff isDecoupled. In seconds. */
-    public $wartezeitVorNaechsterStatusabfrage;
-    /** @var bool|null Maybe present if isDecoupled. */
-    public $manuelleBestaetigungMoeglich;
-    /** @var bool|null Maybe present if isDecoupled. */
-    public $automatisierteStatusabfragenErlaubt;
+    public int $tanZeitUndDialogbezug;
+    public bool $auftragsstornoErlaubt;
+    /** Allowed values: 0 (cannot), 2 (must) */
+    public int $smsAbbuchungskontoErforderlich;
+    /** Allowed values: 0 (cannot), 2 (must) */
+    public int $auftraggeberkontoErforderlich;
+    public bool $challengeKlasseErforderlich;
+    public bool $challengeStrukturiert;
+    /** Allowed values: 00 (cleartext PIN, no TAN), 01 (Schablone 01, encrypted PIN), 02 (reserved) */
+    public string $initialisierungsmodus;
+    /** Allowed values: 0 (cannot), 2 (must) */
+    public int $bezeichnungDesTanMediumsErforderlich;
+    public bool $antwortHhdUcErforderlich;
+    public ?int $anzahlUnterstuetzterAktiverTanMedien = null;
+    /** Present iff isDecoupled. 0 means infinity. */
+    public ?int $maximaleAnzahlStatusabfragen = null;
+    /** Present iff isDecoupled. In seconds. */
+    public ?int $wartezeitVorErsterStatusabfrage = null;
+    /** Present iff isDecoupled. In seconds. */
+    public ?int $wartezeitVorNaechsterStatusabfrage = null;
+    /** Maybe present if isDecoupled. */
+    public ?bool $manuelleBestaetigungMoeglich = null;
+    /** Maybe present if isDecoupled. */
+    public ?bool $automatisierteStatusabfragenErlaubt = null;
 
     /** {@inheritdoc} */
     public function getId(): int

--- a/lib/Fhp/Segment/WPD/HIWPDSv5.php
+++ b/lib/Fhp/Segment/WPD/HIWPDSv5.php
@@ -13,8 +13,7 @@ use Fhp\Segment\BaseGeschaeftsvorfallparameterOld;
  */
 class HIWPDSv5 extends BaseGeschaeftsvorfallparameterOld implements HIWPDS
 {
-    /** @var ParameterDepotaufstellungV2 */
-    public $parameter;
+    public ParameterDepotaufstellungV2 $parameter;
 
     public function getParameter(): ParameterDepotaufstellung
     {

--- a/lib/Fhp/Segment/WPD/HIWPDv5.php
+++ b/lib/Fhp/Segment/WPD/HIWPDv5.php
@@ -14,8 +14,8 @@ use Fhp\Syntax\Bin;
  */
 class HIWPDv5 extends BaseSegment implements HIWPD
 {
-    /** @var Bin Uses SWIFT format MT353, version SRG 1998 */
-    public $depotaufstellung;
+    /** Uses SWIFT format MT353, version SRG 1998 */
+    public Bin $depotaufstellung;
 
     public function getDepotaufstellung(): Bin
     {

--- a/lib/Fhp/Segment/WPD/HKWPDv5.php
+++ b/lib/Fhp/Segment/WPD/HKWPDv5.php
@@ -14,17 +14,11 @@ use Fhp\Segment\Paginateable;
  */
 class HKWPDv5 extends BaseSegment implements Paginateable
 {
-    /** @var \Fhp\Segment\Common\KtvV3 */
-    public $depot;
-
-    /** @var string|null */
-    public $waehrungDerDepotaufstellung;
-
-    /** @var \Fhp\Segment\Common\Kursqualitaet|null */
-    public $kursqualitaet;
-
-    /** @var int|null Only allowed if {@link ParameterDepotaufstellungV2::$eingabeAnzahlEintraegeErlaubt} says so. */
-    public $maximaleAnzahlEintraege;
+    public \Fhp\Segment\Common\KtvV3 $depot;
+    public ?string $waehrungDerDepotaufstellung = null;
+    public ?\Fhp\Segment\Common\Kursqualitaet $kursqualitaet = null;
+    /** Only allowed if {@link ParameterDepotaufstellungV2::$eingabeAnzahlEintraegeErlaubt} says so. */
+    public ?int $maximaleAnzahlEintraege = null;
 
     public static function create(\Fhp\Segment\Common\KtvV3 $ktv): HKWPDv5
     {

--- a/lib/Fhp/Segment/WPD/ParameterDepotaufstellungV2.php
+++ b/lib/Fhp/Segment/WPD/ParameterDepotaufstellungV2.php
@@ -11,14 +11,9 @@ use Fhp\Segment\BaseDeg;
  */
 class ParameterDepotaufstellungV2 extends BaseDeg implements ParameterDepotaufstellung
 {
-    /** @var bool */
-    public $eingabeAnzahlEintraegeErlaubt;
-
-    /** @var bool */
-    public $waehrungDepotaufstellungWaehlbar;
-
-    /** @var bool */
-    public $kursqualitaetWaehlbar;
+    public bool $eingabeAnzahlEintraegeErlaubt;
+    public bool $waehrungDepotaufstellungWaehlbar;
+    public bool $kursqualitaetWaehlbar;
 
     public function getEingabeAnzahlEintraegeErlaubt(): bool
     {

--- a/lib/Fhp/Syntax/Bin.php
+++ b/lib/Fhp/Syntax/Bin.php
@@ -4,10 +4,7 @@ namespace Fhp\Syntax;
 
 class Bin
 {
-    /**
-     * @var string
-     */
-    protected $string;
+    protected string $string;
 
     public function __construct(string $string)
     {
@@ -19,7 +16,7 @@ class Bin
      *
      * @return $this
      */
-    public function setData(string $data)
+    public function setData(string $data): static
     {
         $this->string = $data;
 

--- a/lib/Fhp/Syntax/Parser.php
+++ b/lib/Fhp/Syntax/Parser.php
@@ -8,17 +8,6 @@ use Fhp\Segment\BaseSegment;
 use Fhp\Segment\ElementDescriptor;
 use Fhp\Segment\Segmentkopf;
 
-// Polyfill for PHP < 7.3
-if (!function_exists('array_key_last') && !function_exists('Fhp\\Syntax\\array_key_last')) {
-    function array_key_last($array)
-    {
-        if (!is_array($array) || empty($array)) {
-            return null;
-        }
-        return array_keys($array)[count($array) - 1];
-    }
-}
-
 /**
  * Parses the FinTS wire format (aka. syntax) into Messages, Segments, Data Element Groups (DEG) and Data Elements (DE).
  *

--- a/lib/Fhp/Syntax/Serializer.php
+++ b/lib/Fhp/Syntax/Serializer.php
@@ -9,17 +9,6 @@ use Fhp\Segment\BaseSegment;
 use Fhp\Segment\DegDescriptor;
 use Fhp\Segment\SegmentDescriptor;
 
-// Polyfill for PHP < 7.3
-if (!function_exists('array_key_last') && !function_exists('Fhp\\Syntax\\array_key_last')) {
-    function array_key_last($array)
-    {
-        if (!is_array($array) || empty($array)) {
-            return null;
-        }
-        return array_keys($array)[count($array) - 1];
-    }
-}
-
 abstract class Serializer
 {
     /**

--- a/lib/Tests/Fhp/FinTsTestCase.php
+++ b/lib/Tests/Fhp/FinTsTestCase.php
@@ -76,7 +76,7 @@ abstract class FinTsTestCase extends TestCase
             list($expectedRequest, $mockResponse) = array_shift($this->expectedMessages);
 
             // Check that the request matches the expectation.
-            if (strlen($expectedRequest) > 0 && strpos($expectedRequest, 'HNHBK') !== 0) {
+            if (strlen($expectedRequest) > 0 && !str_starts_with($expectedRequest, 'HNHBK')) {
                 // The expected request is just the inner part, so we need to unwrap the actual request. This is done in
                 // in a quick and hacky way, which slices everything from HNSHK's terminating delimiter to the start of
                 // HNSHA.
@@ -86,7 +86,7 @@ abstract class FinTsTestCase extends TestCase
             $this->assertEquals($expectedRequest, $request);
 
             // Send the mock response.
-            if (strpos($mockResponse, 'HNHBK') !== 0) {
+            if (!str_starts_with($mockResponse, 'HNHBK')) {
                 // The mock response is just the inner part, so we need to wrap it in a fake envelope.
                 $mockPrefix = 'HNHBK:1:3+';
                 // Note: The 4242 is the message number. It's garbage and a constant, but the SUT does not verify it.


### PR DESCRIPTION
This is dependent on #403. It's also a potentially breaking change, so I propose we roll this into a new major together with that other PR, and test it before release (can we do a pre-release, release-candiate or so?).

-----

This PR modernizes the code by replacing fields types in phpdoc (`/** @var int */ private foo;`) with native PHP properties (`private int foo`). This is less verbose to read, better supported by IDEs, and actually type-checked by PHP. However, this could lead to new failures in multiple ways:
1. The runtime enforcement could lead to new failures due to type mismatches that were previously hidden/ignored, but are real issues that need fixing.
2. The use of PHP properties means that PHP won't implicitly initialize the fields with `null` anymore. Instead, reading such properties before writing to them leads to an error. For nullable fields, this PR therefore adds an `= null` initializer, but other fields might still be affected. There's also at least one case where the FinTS specification declares a field as mandatory, but in practice many banks leave it out, so we need to make it nullable in order not to get (new) errors.

The latter point in particular requires some extensive testing in practice before releasing this. I'm happy to deploy a pre-release to my server for a few months, and perhaps a few other people could do the same.

------

This PR is best reviewed in pieces:

* The first couple commits (that don't have "Move..." in their description) prepare the library for handling segment classes with property types. In particular, the `BaseDescriptor` now reads phpdoc when it's present, but falls back to properties if there's no phpdoc, and only complains if neither of them is present.
* The "Move ..." commits are split into a few core and common classes and then the bulk is in the "most segment classes" commit. Each of them does the following:
    * Put the phpdoc-declared type into a property type, with IDE automation.
    * Add `= null` for nullable fields.
    * Remove the phpdoc type when it's redundant (replacing `\@var (string|int|bool)(\|null)? ` with the empty string, and some more manual cleanup). Array field types in particular are _not_ redundant, because the native `array` type can't specify the type of the array elements (yet).
    * Remove the entire phpdoc commenet if it ended up empty.
    * Remove blank lines if there are no phpdoc comments remaining.
    * Some minor cleanups alongside these changes in the same classes, like adding return types.