### PR TITLE
Tolerate null values passed to Kti::create()

### DIFF
--- a/lib/Fhp/Segment/Common/Kti.php
+++ b/lib/Fhp/Segment/Common/Kti.php
@@ -43,7 +43,7 @@ class Kti extends BaseDeg implements AccountInfo
         }
     }
 
-    public static function create(string $iban, string $bic): Kti
+    public static function create(?string $iban, ?string $bic): Kti
     {
         $result = new Kti();
         $result->iban = $iban;


### PR DESCRIPTION
The fields are actually nullable and in ::fromAccount() we might receive nulls.

Fixes #405 