### PR TITLE
Unterstützung für "Segmentversion 3"

### DIFF
--- a/lib/Fhp/Action/GetSEPAAccounts.php
+++ b/lib/Fhp/Action/GetSEPAAccounts.php
@@ -13,6 +13,7 @@ use Fhp\Segment\HIRMS\Rueckmeldungscode;
 use Fhp\Segment\SPA\HISPA;
 use Fhp\Segment\SPA\HKSPAv1;
 use Fhp\Segment\SPA\HKSPAv2;
+use Fhp\Segment\SPA\HKSPAv3;
 use Fhp\UnsupportedException;
 
 /**
@@ -56,6 +57,8 @@ class GetSEPAAccounts extends PaginateableAction
                 return HKSPAv1::createEmpty();
             case 2:
                 return HKSPAv2::createEmpty();
+            case 3:
+                return HKSPAv3::createEmpty();
             default:
                 throw new UnsupportedException('Unsupported HKSPA version: ' . $hispas->getVersion());
         }

--- a/lib/Fhp/Segment/SPA/HISPASv3.php
+++ b/lib/Fhp/Segment/SPA/HISPASv3.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Fhp\Segment\SPA;
+
+/**
+ * Segment: SEPA-Kontoverbindung anfordern, Parameter (Version 3)
+ *
+ * @link https://www.hbci-zka.de/dokumente/spezifikation_deutsch/fintsv3/FinTS_3.0_Messages_Geschaeftsvorfaelle_2015-08-07_final_version.pdf
+ * Section C.10.1.5)
+ */
+class HISPASv3 extends HISPASv2
+{
+}

--- a/lib/Fhp/Segment/SPA/HISPAv3.php
+++ b/lib/Fhp/Segment/SPA/HISPAv3.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Fhp\Segment\SPA;
+
+/**
+ * Segment: SEPA-Kontoverbindung rückmelden (Version 3)
+ * Bezugssegment: HKSPA
+ *
+ * @link https://www.hbci-zka.de/dokumente/spezifikation_deutsch/fintsv3/FinTS_3.0_Messages_Geschaeftsvorfaelle_2015-08-07_final_version.pdf
+ * Section C.10.1.5)
+ */
+class HISPAv3 extends HISPAv2
+{
+}

--- a/lib/Fhp/Segment/SPA/HKSPAv3.php
+++ b/lib/Fhp/Segment/SPA/HKSPAv3.php
@@ -1,0 +1,14 @@
+<?php
+/** @noinspection PhpUnused */
+
+namespace Fhp\Segment\SPA;
+
+/**
+ * Segment: SEPA-Kontoverbindung anfordern (Version 3)
+ *
+ * @link https://www.hbci-zka.de/dokumente/spezifikation_deutsch/fintsv3/FinTS_3.0_Messages_Geschaeftsvorfaelle_2015-08-07_final_version.pdf
+ * Section C.10.1.5)
+ */
+class HKSPAv3 extends HKSPAv2
+{
+}

--- a/lib/Fhp/Segment/SPA/ParameterSepaKontoverbindungAnfordernV3.php
+++ b/lib/Fhp/Segment/SPA/ParameterSepaKontoverbindungAnfordernV3.php
@@ -1,0 +1,25 @@
+<?php
+/** @noinspection PhpUnused */
+
+namespace Fhp\Segment\SPA;
+
+use Fhp\Segment\BaseDeg;
+
+/**
+ * Data Element Group: Parameter SEPA-Kontoverbindung anfordern (Version 3)
+ *
+ * @link https://www.hbci-zka.de/dokumente/spezifikation_deutsch/fintsv3/FinTS_3.0_Messages_Geschaeftsvorfaelle_2015-08-07_final_version.pdf
+ * Section: D (letter P)
+ */
+class ParameterSepaKontoverbindungAnfordernV3 extends BaseDeg implements ParameterSepaKontoverbindungAnfordern
+{
+    use GetUnterstuetzteSepaDatenformateTrait;
+
+    public bool $einzelkontenabrufErlaubt;
+    public bool $nationaleKontoverbindungErlaubt;
+    public bool $strukturierterVerwendungszweckErlaubt;
+    public bool $eingabeAnzahlEintraegeErlaubt;
+    public int $anzahlReservierterVerwendungszweckstellen;
+    /** @var string[] @Max(99) Max length each: 256 */
+    public array $unterstuetzteSepaDatenformate;
+}


### PR DESCRIPTION
Das ist der Patch von @NabilHanna aus https://github.com/nemiah/phpFinTS/issues/391. Zusätzlich hat mir @ampaze noch erklärt wie man `ParameterSepaKontoverbindungAnfordernV3` anpasst.

Damit funktioniert bei mir die Abfrage von Kontostand und Transaktionshistorie mit Finanzen.net Zero/Baader Bank.