### PR TITLE
Reset DialogInitialization state when decoupled submission is still pending on login

### DIFF
--- a/lib/Fhp/FinTs.php
+++ b/lib/Fhp/FinTs.php
@@ -489,6 +489,10 @@ class FinTs
                 throw new UnexpectedResponseException('Got neither 3956 nor HITAN with tanProzess=2');
             }
             $action->setTanRequest($hitanProcessS);
+            if ($action instanceof DialogInitialization) {
+                $this->dialogId = null;
+                $action->setMessageNumber($this->messageNumber);
+            }
         }
         return $isSuccess;
     }


### PR DESCRIPTION
Fixes #439, maybe. If it doesn't fix it, let's discard this pull request.