### PR TITLE
Unterstützung für Echtzeitüberweisung

### DIFF
--- a/lib/Fhp/Action/SendSEPARealtimeTransfer.php
+++ b/lib/Fhp/Action/SendSEPARealtimeTransfer.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Fhp\Action;
+
+use Fhp\BaseAction;
+use Fhp\Model\SEPAAccount;
+use Fhp\Protocol\BPD;
+use Fhp\Protocol\Message;
+use Fhp\Protocol\UnexpectedResponseException;
+use Fhp\Protocol\UPD;
+use Fhp\Segment\Common\Kti;
+use Fhp\Segment\HIRMS\Rueckmeldung;
+use Fhp\Segment\HIRMS\Rueckmeldungscode;
+use Fhp\Segment\IPZ\HIIPZSv1;
+use Fhp\Segment\IPZ\HIIPZSv2;
+use Fhp\Segment\IPZ\HKIPZv2;
+use Fhp\Segment\SPA\HISPAS;
+use Fhp\Syntax\Bin;
+use Fhp\UnsupportedException;
+
+/**
+ * Initiates an outgoing realtime transfer in SEPA format (PAIN XML).
+ */
+class SendSEPARealtimeTransfer extends BaseAction
+{
+    /** @var SEPAAccount */
+    private $account;
+    /** @var string */
+    private $painMessage;
+    /** @var string */
+    private $xmlSchema;
+
+    private bool $allowConversionToSEPATransfer = true;
+
+    /**
+     * @param SEPAAccount $account The account from which the transfer will be sent.
+     * @param string $painMessage An XML-formatted ISO 20022 message. You may want to use github.com/nemiah/phpSepaXml
+     *     to create this.
+     * @param bool $allowConversionToSEPATransfer If instant payment ist not possible, allow the bank to send as a regular transfer instead
+     * @return SendSEPARealtimeTransfer A new action for executing this the given PAIN message.
+     */
+    public static function create(SEPAAccount $account, string $painMessage, bool $allowConversionToSEPATransfer = true): SendSEPARealtimeTransfer
+    {
+        if (preg_match('/xmlns="(.*?)"/', $painMessage, $match) === false) {
+            throw new \InvalidArgumentException('xmlns not found in the PAIN message');
+        }
+        $result = new SendSEPARealtimeTransfer();
+        $result->account = $account;
+        $result->painMessage = $painMessage;
+        $result->xmlSchema = $match[1];
+        $result->allowConversionToSEPATransfer = $allowConversionToSEPATransfer;
+        return $result;
+    }
+
+    /** {@inheritdoc} */
+    protected function createRequest(BPD $bpd, ?UPD $upd)
+    {
+        /** @var HIIPZSv1|HIIPZSv2 $hiipzs */
+        $hiipzs = $bpd->requireLatestSupportedParameters('HIIPZS');
+
+        /** @var HISPAS $hispas */
+        $hispas = $bpd->requireLatestSupportedParameters('HISPAS');
+        $supportedSchemas = $hispas->getParameter()->getUnterstuetzteSepaDatenformate();
+        if (!in_array($this->xmlSchema, $supportedSchemas)) {
+            throw new UnsupportedException("The bank does not support the XML schema $this->xmlSchema, but only "
+                . implode(', ', $supportedSchemas));
+        }
+
+        /** @var HKIPZv1|HKIPZv2 $hkipz */
+        $hkipz = $hiipzs->createRequestSegment();
+        $hkipz->kontoverbindungInternational = Kti::fromAccount($this->account);
+        $hkipz->sepaDescriptor = $this->xmlSchema;
+        $hkipz->sepaPainMessage = new Bin($this->painMessage);
+        if ($hiipzs instanceof HIIPZSv2) {
+            $hkipz->umwandlungNachSEPAUeberweisungZulaessig = $hiipzs->parameter->umwandlungNachSEPAUeberweisungZulaessigErlaubt && $this->allowConversionToSEPATransfer;
+        }
+        return $hkipz;
+    }
+
+    /** {@inheritdoc} */
+    public function processResponse(Message $response)
+    {
+        parent::processResponse($response);
+
+        // Was the instant payment converted to a regular transfer?
+        $info = $response->findRueckmeldungen(3270);
+        if (count($info) > 0) {
+            $this->successMessage = implode("\n", array_map(function (Rueckmeldung $rueckmeldung) {
+                return $rueckmeldung->rueckmeldungstext;
+            }, $info));
+            return;
+        }
+
+        if ($response->findRueckmeldung(Rueckmeldungscode::ENTGEGENGENOMMEN) === null &&
+            $response->findRueckmeldung(Rueckmeldungscode::AUSGEFUEHRT) === null) {
+            throw new UnexpectedResponseException('Bank did not confirm SEPATransfer execution');
+        }
+    }
+}

--- a/lib/Fhp/Segment/IPZ/HIIPZSv1.php
+++ b/lib/Fhp/Segment/IPZ/HIIPZSv1.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Fhp\Segment\IPZ;
+
+use Fhp\Segment\BaseGeschaeftsvorfallparameter;
+use Fhp\Segment\BaseSegment;
+
+/**
+ * Segment: SEPA-Instant Payment Zahlung (Version 1)
+ *
+ * @link https://www.hbci-zka.de/dokumente/spezifikation_deutsch/fintsv3/FinTS_3.0_Messages_Geschaeftsvorfaelle_2022-04-15_final_version.pdf
+ * Section: C.10.2.9.1.1 c)
+ */
+
+class HIIPZSv1 extends BaseGeschaeftsvorfallparameter
+{
+    public ParameterSEPAInstantPaymentZahlungV1 $parameter;
+
+    public function createRequestSegment(): BaseSegment
+    {
+        return HKIPZv1::createEmpty();
+    }
+}

--- a/lib/Fhp/Segment/IPZ/HIIPZSv2.php
+++ b/lib/Fhp/Segment/IPZ/HIIPZSv2.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Fhp\Segment\IPZ;
+
+use Fhp\lib\Fhp\Segment\IPZ\ParameterSEPAInstantPaymentZahlungV2;
+use Fhp\Segment\BaseGeschaeftsvorfallparameter;
+use Fhp\Segment\BaseSegment;
+
+/**
+ * Segment: SEPA-Instant Payment Zahlung (Version 2)
+ *
+ * @link https://www.hbci-zka.de/dokumente/spezifikation_deutsch/fintsv3/FinTS_3.0_Messages_Geschaeftsvorfaelle_2022-04-15_final_version.pdf
+ * Section: C.10.2.9.1.2 c)
+ */
+
+class HIIPZSv2 extends BaseGeschaeftsvorfallparameter
+{
+    public ParameterSEPAInstantPaymentZahlungV2 $parameter;
+
+    public function createRequestSegment(): BaseSegment
+    {
+        return HKIPZv2::createEmpty();
+    }
+}

--- a/lib/Fhp/Segment/IPZ/HIIPZv1.php
+++ b/lib/Fhp/Segment/IPZ/HIIPZv1.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Fhp\Segment\IPZ;
+
+use Fhp\Segment\BaseSegment;
+
+/**
+ * Segment: SEPA-Instant Payment Zahlung (Version 1)
+ *
+ * @link https://www.hbci-zka.de/dokumente/spezifikation_deutsch/fintsv3/FinTS_3.0_Messages_Geschaeftsvorfaelle_2022-04-15_final_version.pdf
+ * Section: C.10.2.9.1.1 b)
+ */
+class HIIPZv1 extends BaseSegment
+{
+    public string $auftragsidentifikation;
+
+    /**
+     * SEPA C-Code („C“ for Cancellation)
+     * Possible values
+     * 3: Delete
+     * 4: Recall
+     */
+    public ?int $sepaCCode = null;
+
+    /*
+     * Possible values
+     * 1: in Terminierung
+     * 2: abgelehnt von erster Inkassostelle
+     * 3: in Bearbeitung
+     * 4: Creditoren-seitig verarbeitet, Buchung veranlasst
+     * 5: R-Transaktion wurde veranlasst
+     * 6: Auftrag fehlgeschagen
+     * 7: Auftrag ausgeführt; Geld für den Zahlungsempfänger verfügbar
+     * 8: Abgelehnt durch Zahlungsdienstleister des Zahlers
+     * 9: Abgelehnt durch Zahlungsdienstleister des Zahlungsempfängers
+     */
+    public ?int $statusSepaAuftrag = null;
+}

--- a/lib/Fhp/Segment/IPZ/HIIPZv2.php
+++ b/lib/Fhp/Segment/IPZ/HIIPZv2.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Fhp\Segment\IPZ;
+
+/**
+ * Segment: SEPA-Instant Payment Zahlung (Version 2)
+ *
+ * @link https://www.hbci-zka.de/dokumente/spezifikation_deutsch/fintsv3/FinTS_3.0_Messages_Geschaeftsvorfaelle_2022-04-15_final_version.pdf
+ * Section: C.10.2.9.1.2 b)
+ */
+class HIIPZv2 extends HIIPZv1
+{
+}

--- a/lib/Fhp/Segment/IPZ/HKIPZv1.php
+++ b/lib/Fhp/Segment/IPZ/HKIPZv1.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Fhp\Segment\IPZ;
+
+use Fhp\Segment\CCS\HKCCSv1;
+
+/**
+ * Segment: SEPA-Instant Payment Zahlung (Version 1)
+ *
+ * @link https://www.hbci-zka.de/dokumente/spezifikation_deutsch/fintsv3/FinTS_3.0_Messages_Geschaeftsvorfaelle_2022-04-15_final_version.pdf
+ * Section: C.10.2.9.1.1 a)
+ */
+class HKIPZv1 extends HKCCSv1
+{
+
+}

--- a/lib/Fhp/Segment/IPZ/HKIPZv2.php
+++ b/lib/Fhp/Segment/IPZ/HKIPZv2.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Fhp\Segment\IPZ;
+
+/**
+ * Segment: SEPA-Instant Payment Zahlung (Version 2)
+ *
+ * @link https://www.hbci-zka.de/dokumente/spezifikation_deutsch/fintsv3/FinTS_3.0_Messages_Geschaeftsvorfaelle_2022-04-15_final_version.pdf
+ * Section: C.10.2.9.1.2 a)
+ */
+class HKIPZv2 extends HKIPZv1
+{
+    public bool $umwandlungNachSEPAUeberweisungZulaessig;
+}

--- a/lib/Fhp/Segment/IPZ/ParameterSEPAInstantPaymentZahlungV1.php
+++ b/lib/Fhp/Segment/IPZ/ParameterSEPAInstantPaymentZahlungV1.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Fhp\Segment\IPZ;
+
+use Fhp\Segment\BaseDeg;
+
+/**
+ * Parameter SEPA-Instant Payment Zahlung (Version 1)
+ *
+ * @link https://www.hbci-zka.de/dokumente/spezifikation_deutsch/fintsv3/FinTS_3.0_Messages_Geschaeftsvorfaelle_2022-04-15_final_version.pdf
+ * Section D
+ */
+class ParameterSEPAInstantPaymentZahlungV1 extends BaseDeg
+{
+    /** Max Length: 4096 */
+    public ?string $zulaessigePurposecodes = null;
+
+    /** @var string[]|null @Max(9) Max length: 256 */
+    public ?array $unterstuetzteSEPADatenformate = null;
+}

--- a/lib/Fhp/Segment/IPZ/ParameterSEPAInstantPaymentZahlungV2.php
+++ b/lib/Fhp/Segment/IPZ/ParameterSEPAInstantPaymentZahlungV2.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Fhp\lib\Fhp\Segment\IPZ;
+
+use Fhp\Segment\BaseDeg;
+
+/**
+ * Parameter SEPA-Instant Payment Zahlung (Version 2)
+ *
+ * @link https://www.hbci-zka.de/dokumente/spezifikation_deutsch/fintsv3/FinTS_3.0_Messages_Geschaeftsvorfaelle_2022-04-15_final_version.pdf
+ * Section D
+ */
+class ParameterSEPAInstantPaymentZahlungV2 extends BaseDeg
+{
+    public bool $umwandlungNachSEPAUeberweisungZulaessigErlaubt;
+
+    /** Max Length: 4096 */
+    public ?string $zulaessigePurposecodes = null;
+
+    /** @var string[]|null @Max(9) Max length: 256 */
+    public ?array $unterstuetzteSEPADatenformate = null;
+}


### PR DESCRIPTION
Ich konnte nur Segment Version 1 testen, aber der einzige Unterschied zu Version 2 ist die Möglichkeit der Bank zu erlauben die Echtzeit Überweisung automatisch in eine "normale" Überweisung umzuwandeln, wenn die Zielbank keine Echtzeit Überweisung unterstützt.

closes #438 