### PR TITLE
HICME and HICSE segments are not Geschaeftsvorfaelle (unlike HICxES)

### DIFF
--- a/lib/Fhp/Segment/CME/HICMEv1.php
+++ b/lib/Fhp/Segment/CME/HICMEv1.php
@@ -10,7 +10,7 @@ use Fhp\Segment\BaseGeschaeftsvorfallparameter;
  * @link https://www.hbci-zka.de/dokumente/spezifikation_deutsch/fintsv3/FinTS_3.0_Messages_Geschaeftsvorfaelle_2015-08-07_final_version.pdf
  * Section: C.10.2.1 c)
  */
-class HICMEv1 extends BaseGeschaeftsvorfallparameter
+class HICMEv1 extends BaseSegment
 {
     public string $auftragsidentifikation;
 }

--- a/lib/Fhp/Segment/CSE/HICSEv1.php
+++ b/lib/Fhp/Segment/CSE/HICSEv1.php
@@ -10,7 +10,7 @@ use Fhp\Segment\BaseGeschaeftsvorfallparameter;
  * @link https://www.hbci-zka.de/dokumente/spezifikation_deutsch/fintsv3/FinTS_3.0_Messages_Geschaeftsvorfaelle_2015-08-07_final_version.pdf
  * Section: C.10.2.1 c)
  */
-class HICSEv1 extends BaseGeschaeftsvorfallparameter
+class HICSEv1 extends BaseSegment
 {
     public string $auftragsidentifikation;
 }


### PR DESCRIPTION
This fixes an error with scheduled SEPA transfers.
The HICSE/HICME segment response from the bank was parsed incorrectly, throwing an InvalidResponseException ('Invalid Response from serverInvalid int: <string>') after the Bank accepted the transfer.
This occured because the HICSEv1/HICMEv1 classes inherited additional integer properties from BaseGeschaeftsvorfallparameter, which the parser is looking for in vain while reading the one string parameter of HICME.

In contrast, the HICMESv1 and HICSESv1 segments are correctly inherited from BaseGeschaeftsvorfallparameter.