### PR TITLE
fix usage of kundensystemId

### DIFF
--- a/lib/Fhp/FinTs.php
+++ b/lib/Fhp/FinTs.php
@@ -589,6 +589,8 @@ class FinTs
         }
         $this->selectedTanMode = $tanMode instanceof TanMode ? $tanMode->getId() : $tanMode;
         $this->selectedTanMedium = $tanMedium instanceof TanMedium ? $tanMedium->getName() : $tanMedium;
+		
+		$this->kundensystemId = $this->options->kundensystemId;
     }
 
     /**

--- a/lib/Fhp/Options/FinTsOptions.php
+++ b/lib/Fhp/Options/FinTsOptions.php
@@ -46,6 +46,14 @@ class FinTsOptions
     public $timeoutResponse = 30;
 
     /**
+	 * The Kundensystem-Id as returned by the bank and persisted by the application code
+	 * Prevents having to re-authenticate every time on login
+	 * Use DialogInitialization::getKundensystemId() on the return-object of FinTs::login(), to get the new one
+	 * @var string
+	 */
+	public $kundensystemId;
+	
+    /**
      * @throws \InvalidArgumentException If the options are invalid.
      */
     public function validate()


### PR DESCRIPTION
kundensystemId can now be set on FinTsOptions and will be used on next login to prevent having to re-authenticate:

```
$options->url = $url;
$options->bankCode = $blz;
…
$options->kundensystemId = $kundensystemId; //get $kundensystemId by calling DialogInitialization::getKundensystemId() on the return-object of FinTs::login()
```