### PR TITLE
Create Login Action in separate function call

### DIFF
--- a/lib/Fhp/FinTs.php
+++ b/lib/Fhp/FinTs.php
@@ -242,6 +242,16 @@ class FinTs
         $this->options->timeoutResponse = $responseTimeout;
     }
 
+    public function createLoginAction(): DialogInitialization
+    {
+        $this->requireTanMode();
+        $this->ensureSynchronized();
+        $this->messageNumber = 1;
+        
+        return new DialogInitialization($this->options, $this->requireCredentials(), $this->getSelectedTanMode(),
+            $this->selectedTanMedium, $this->kundensystemId);
+    }
+
     /**
      * Executes a strongly authenticated login action and returns it. With some banks, this requires a TAN.
      * @return DialogInitialization A {@link BaseAction} for the outcome of the login. You should check whether a TAN is
@@ -254,12 +264,10 @@ class FinTs
      */
     public function login(): DialogInitialization
     {
-        $this->requireTanMode();
-        $this->ensureSynchronized();
-        $this->messageNumber = 1;
-        $login = new DialogInitialization($this->options, $this->requireCredentials(), $this->getSelectedTanMode(),
-            $this->selectedTanMedium, $this->kundensystemId);
+        $login = $this->createLoginAction();
+        
         $this->execute($login);
+        
         return $login;
     }
 


### PR DESCRIPTION
The Example:
In the `Samples/browser.php` example the flow is shared between front and backend code and have the assumption that a tan is only required once during login.

If a tan is required the flow of actions is stopped and restarted where we left.

Our Goal here is a flow that fits all actions:
We want update a SEPA Account:
1. Login
2. GetBalance
3. GetNewTransaction
4. Logout/Close Connection

We assume that each step can require a tanRequest flow, so the process can stop on each step and have to restart with a tan (coupled or decoupled). We want to treat every situation the same:
1. POST Request `/account/refresh` to start the Process
2. Handle Exception: `tan is needed`, show user interaction for all tan requests a like
3. Continue with POST Request `/account/refresh`

Our Implementation
```php
// $action is the action from the last call which needed a tan, or the action from the current step:
   $action = session()->pull('fints.action', $bank_connection->fints->createLoginAction());
// if the $action is from the last call and needs a tan and is not from this step:
// skip this step and continue with the next step
    if (! $action instanceof DialogInitialization) {
        return;
    }
// execute the action for the first time or try again with a tan
    $bank_connection->execute($action, $tan = request()->input('tan'));
// if the action needs a tan, fire an expcetion and show the tanRequest to the user
    if ($action->needsTan()) {
        $this->handleTanRequiredException($action);
    }
```

This is our idea of an implementation of the stop/restart mechanism the tanRequest needs.




