### PR TITLE
Fixes sending large SEPA XMLs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,36 @@
+# .github/workflows/tests.yml
+name: tests
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  phpunit:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        php: [ '8.0', '8.1', '8.2', '8.3', '8.4' ]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: mbstring
+
+      - name: Validate composer.json
+        run: composer validate --strict
+
+      - name: Install dependencies
+        run: composer install --no-interaction --prefer-dist --no-progress
+
+      - name: Run PHPUnit
+        run: ./vendor/bin/phpunit

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,9 +26,6 @@ jobs:
           php-version: ${{ matrix.php }}
           extensions: mbstring
 
-      - name: Validate composer.json
-        run: composer validate --strict
-
       - name: Install dependencies
         run: composer install --no-interaction --prefer-dist --no-progress
 

--- a/lib/Fhp/Action/SendSEPADirectDebit.php
+++ b/lib/Fhp/Action/SendSEPADirectDebit.php
@@ -55,11 +55,11 @@ class SendSEPADirectDebit extends BaseAction
         $nbOfTxs = substr_count($painMessage, '<DrctDbtTxInf>');
         $ctrlSum = null;
 
-        if (preg_match('@<GrpHdr>.*<CtrlSum>(?<ctrlsum>[.0-9]+)</CtrlSum>.*</GrpHdr>@s', $painMessage, $matches) === 1) {
+        if (preg_match('@<GrpHdr>.*?<CtrlSum>(?<ctrlsum>[0-9.]+)</CtrlSum>.*?</GrpHdr>@s', $painMessage, $matches) === 1) {
             $ctrlSum = $matches['ctrlsum'];
         }
 
-        if (preg_match('@<PmtTpInf>.*<LclInstrm>.*<Cd>(?<coretype>CORE|COR1|B2B)</Cd>.*</LclInstrm>.*</PmtTpInf>@s', $painMessage, $matches) === 1) {
+        if (preg_match('@<PmtTpInf>.*?<LclInstrm>.*?<Cd>(?<coretype>CORE|COR1|B2B)</Cd>.*?</LclInstrm>.*?</PmtTpInf>@s', $painMessage, $matches) === 1) {
             $coreType = $matches['coretype'];
         } else {
             throw new \InvalidArgumentException('The type CORE/COR1/B2B is missing in PAIN message');

--- a/lib/Tests/Fhp/Unit/SendSEPADirectDebitTest.php
+++ b/lib/Tests/Fhp/Unit/SendSEPADirectDebitTest.php
@@ -15,7 +15,8 @@ class SendSEPADirectDebitTest extends FinTsTestCase
 
         $painString = file_get_contents(__DIR__ . '/../../resources/pain.008.002.02.xml');
 
-        //this will throw an error
-        SendSEPADirectDebit::create($account, $painString);
+        $sepa = SendSEPADirectDebit::create($account, $painString);
+
+        $this->assertInstanceOf(SendSEPADirectDebit::class, $sepa);
     }
 }

--- a/lib/Tests/Fhp/Unit/SendSEPADirectDebitTest.php
+++ b/lib/Tests/Fhp/Unit/SendSEPADirectDebitTest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Tests\Fhp\Unit;
+
+
+use Fhp\Action\SendSEPADirectDebit;
+use Fhp\Model\SEPAAccount;
+use Tests\Fhp\FinTsTestCase;
+
+class SendSEPADirectDebitTest extends FinTsTestCase
+{
+    public function testCanSendLargeFiles()
+    {
+        $account = new SEPAAccount();
+
+        $painString = file_get_contents(__DIR__ . '/../../resources/pain.008.002.02.xml');
+
+        //this will throw an error
+        SendSEPADirectDebit::create($account, $painString);
+    }
+}

--- a/lib/Tests/resources/pain.008.002.02.xml
+++ b/lib/Tests/resources/pain.008.002.02.xml
@@ -1,0 +1,1477 @@
+<?xml version='1.0' encoding='utf-8'?>
+<Document
+        xmlns="urn:iso:std:iso:20022:tech:xsd:pain.008.002.02">
+    <CstmrDrctDbtInitn>
+        <GrpHdr>
+            <MsgId>FAKEPAIN397948648101</MsgId>
+            <CreDtTm>2025-08-26T21:03:32Z</CreDtTm>
+            <NbOfTxs>300</NbOfTxs>
+            <CtrlSum>14380.00</CtrlSum>
+            <InitgPty>
+                <Nm text="Example Sports Club e.V." />
+            </InitgPty>
+        </GrpHdr>
+        <PmtInf>
+            <PmtInfId>PMT001</PmtInfId>
+            <PmtMtd>DD</PmtMtd>
+            <BtchBookg>true</BtchBookg>
+            <NbOfTxs>1</NbOfTxs>
+            <CtrlSum>50.00</CtrlSum>
+            <PmtTpInf>
+                <SvcLvl><Cd>SEPA</Cd></SvcLvl>
+                <LclInstrm><Cd>CORE</Cd></LclInstrm>
+                <SeqTp>FRST</SeqTp>
+            </PmtTpInf>
+            <ReqdColltnDt>2025-08-30</ReqdColltnDt>
+            <Cdtr>
+                <Nm>Example Sports Club e.V.</Nm>
+            </Cdtr>
+            <CdtrAcct>
+                <Id><IBAN>DE11123456789012345678</IBAN></Id>
+            </CdtrAcct>
+            <CdtrAgt><FinInstnId><BIC>FAKEDEFFXXX</BIC></FinInstnId></CdtrAgt>
+            <CdtrSchmeId>
+                <Id><PrvtId><Othr><Id>DE99ZZZ00000000001</Id><SchmeNm><Prtry>SEPA</Prtry></SchmeNm></Othr></PrvtId></Id>
+            </CdtrSchmeId>
+            <DrctDbtTxInf>
+                <PmtId><EndToEndId>INV001</EndToEndId></PmtId>
+                <InstdAmt Ccy="EUR">50.00</InstdAmt>
+                <DrctDbtTx>
+                    <MndtRltdInf><MndtId>MANDATE001</MndtId><DtOfSgntr>2025-08-01</DtOfSgntr></MndtRltdInf>
+                </DrctDbtTx>
+                <DbtrAgt><FinInstnId><BIC>FAKEDEPPXXX</BIC></FinInstnId></DbtrAgt>
+                <Dbtr><Nm>Max Mustermann</Nm></Dbtr>
+                <DbtrAcct><Id><IBAN>DE44123456789012345678</IBAN></Id></DbtrAcct>
+                <RmtInf><Ustrd>Membership Fee August</Ustrd></RmtInf>
+            </DrctDbtTxInf>
+        </PmtInf>
+        <PmtInf>
+            <PmtInfId>PMT002</PmtInfId>
+            <PmtMtd>DD</PmtMtd>
+            <BtchBookg>true</BtchBookg>
+            <NbOfTxs>1</NbOfTxs>
+            <CtrlSum>75.00</CtrlSum>
+            <PmtTpInf>
+                <SvcLvl><Cd>SEPA</Cd></SvcLvl>
+                <LclInstrm><Cd>CORE</Cd></LclInstrm>
+                <SeqTp>RCUR</SeqTp>
+            </PmtTpInf>
+            <ReqdColltnDt>2025-08-30</ReqdColltnDt>
+            <Cdtr><Nm>Example Sports Club e.V.</Nm></Cdtr>
+            <CdtrAcct><Id><IBAN>DE11123456789012345678</IBAN></Id></CdtrAcct>
+            <CdtrAgt><FinInstnId><BIC>FAKEDEFFXXX</BIC></FinInstnId></CdtrAgt>
+            <DrctDbtTxInf>
+                <PmtId><EndToEndId>INV002</EndToEndId></PmtId>
+                <InstdAmt Ccy="EUR">75.00</InstdAmt>
+                <DrctDbtTx>
+                    <MndtRltdInf><MndtId>MANDATE002</MndtId><DtOfSgntr>2024-09-15</DtOfSgntr></MndtRltdInf>
+                </DrctDbtTx>
+                <DbtrAgt><FinInstnId><BIC>FAKEXYZZXXX</BIC></FinInstnId></DbtrAgt>
+                <Dbtr><Nm>Jane Doe</Nm></Dbtr>
+                <DbtrAcct><Id><IBAN>DE55123456789012345678</IBAN></Id></DbtrAcct>
+                <RmtInf><Ustrd>Quarterly Training Fee</Ustrd></RmtInf>
+            </DrctDbtTxInf>
+        </PmtInf>
+        <PmtInf>
+            <PmtInfId>PMT001</PmtInfId>
+            <PmtMtd>DD</PmtMtd>
+            <BtchBookg>true</BtchBookg>
+            <NbOfTxs>1</NbOfTxs>
+            <CtrlSum>50.00</CtrlSum>
+            <PmtTpInf>
+                <SvcLvl><Cd>SEPA</Cd></SvcLvl>
+                <LclInstrm><Cd>CORE</Cd></LclInstrm>
+                <SeqTp>FRST</SeqTp>
+            </PmtTpInf>
+            <ReqdColltnDt>2025-08-30</ReqdColltnDt>
+            <Cdtr>
+                <Nm>Example Sports Club e.V.</Nm>
+            </Cdtr>
+            <CdtrAcct>
+                <Id><IBAN>DE11123456789012345678</IBAN></Id>
+            </CdtrAcct>
+            <CdtrAgt><FinInstnId><BIC>FAKEDEFFXXX</BIC></FinInstnId></CdtrAgt>
+            <CdtrSchmeId>
+                <Id><PrvtId><Othr><Id>DE99ZZZ00000000001</Id><SchmeNm><Prtry>SEPA</Prtry></SchmeNm></Othr></PrvtId></Id>
+            </CdtrSchmeId>
+            <DrctDbtTxInf>
+                <PmtId><EndToEndId>INV001</EndToEndId></PmtId>
+                <InstdAmt Ccy="EUR">50.00</InstdAmt>
+                <DrctDbtTx>
+                    <MndtRltdInf><MndtId>MANDATE001</MndtId><DtOfSgntr>2025-08-01</DtOfSgntr></MndtRltdInf>
+                </DrctDbtTx>
+                <DbtrAgt><FinInstnId><BIC>FAKEDEPPXXX</BIC></FinInstnId></DbtrAgt>
+                <Dbtr><Nm>Max Mustermann</Nm></Dbtr>
+                <DbtrAcct><Id><IBAN>DE44123456789012345678</IBAN></Id></DbtrAcct>
+                <RmtInf><Ustrd>Membership Fee August</Ustrd></RmtInf>
+            </DrctDbtTxInf>
+        </PmtInf>
+        <PmtInf>
+            <PmtInfId>PMT002</PmtInfId>
+            <PmtMtd>DD</PmtMtd>
+            <BtchBookg>true</BtchBookg>
+            <NbOfTxs>1</NbOfTxs>
+            <CtrlSum>75.00</CtrlSum>
+            <PmtTpInf>
+                <SvcLvl><Cd>SEPA</Cd></SvcLvl>
+                <LclInstrm><Cd>CORE</Cd></LclInstrm>
+                <SeqTp>RCUR</SeqTp>
+            </PmtTpInf>
+            <ReqdColltnDt>2025-08-30</ReqdColltnDt>
+            <Cdtr><Nm>Example Sports Club e.V.</Nm></Cdtr>
+            <CdtrAcct><Id><IBAN>DE11123456789012345678</IBAN></Id></CdtrAcct>
+            <CdtrAgt><FinInstnId><BIC>FAKEDEFFXXX</BIC></FinInstnId></CdtrAgt>
+            <DrctDbtTxInf>
+                <PmtId><EndToEndId>INV002</EndToEndId></PmtId>
+                <InstdAmt Ccy="EUR">75.00</InstdAmt>
+                <DrctDbtTx>
+                    <MndtRltdInf><MndtId>MANDATE002</MndtId><DtOfSgntr>2024-09-15</DtOfSgntr></MndtRltdInf>
+                </DrctDbtTx>
+                <DbtrAgt><FinInstnId><BIC>FAKEXYZZXXX</BIC></FinInstnId></DbtrAgt>
+                <Dbtr><Nm>Jane Doe</Nm></Dbtr>
+                <DbtrAcct><Id><IBAN>DE55123456789012345678</IBAN></Id></DbtrAcct>
+                <RmtInf><Ustrd>Quarterly Training Fee</Ustrd></RmtInf>
+            </DrctDbtTxInf>
+        </PmtInf>
+        <PmtInf>
+            <PmtInfId>PMT001</PmtInfId>
+            <PmtMtd>DD</PmtMtd>
+            <BtchBookg>true</BtchBookg>
+            <NbOfTxs>1</NbOfTxs>
+            <CtrlSum>50.00</CtrlSum>
+            <PmtTpInf>
+                <SvcLvl><Cd>SEPA</Cd></SvcLvl>
+                <LclInstrm><Cd>CORE</Cd></LclInstrm>
+                <SeqTp>FRST</SeqTp>
+            </PmtTpInf>
+            <ReqdColltnDt>2025-08-30</ReqdColltnDt>
+            <Cdtr>
+                <Nm>Example Sports Club e.V.</Nm>
+            </Cdtr>
+            <CdtrAcct>
+                <Id><IBAN>DE11123456789012345678</IBAN></Id>
+            </CdtrAcct>
+            <CdtrAgt><FinInstnId><BIC>FAKEDEFFXXX</BIC></FinInstnId></CdtrAgt>
+            <CdtrSchmeId>
+                <Id><PrvtId><Othr><Id>DE99ZZZ00000000001</Id><SchmeNm><Prtry>SEPA</Prtry></SchmeNm></Othr></PrvtId></Id>
+            </CdtrSchmeId>
+            <DrctDbtTxInf>
+                <PmtId><EndToEndId>INV001</EndToEndId></PmtId>
+                <InstdAmt Ccy="EUR">50.00</InstdAmt>
+                <DrctDbtTx>
+                    <MndtRltdInf><MndtId>MANDATE001</MndtId><DtOfSgntr>2025-08-01</DtOfSgntr></MndtRltdInf>
+                </DrctDbtTx>
+                <DbtrAgt><FinInstnId><BIC>FAKEDEPPXXX</BIC></FinInstnId></DbtrAgt>
+                <Dbtr><Nm>Max Mustermann</Nm></Dbtr>
+                <DbtrAcct><Id><IBAN>DE44123456789012345678</IBAN></Id></DbtrAcct>
+                <RmtInf><Ustrd>Membership Fee August</Ustrd></RmtInf>
+            </DrctDbtTxInf>
+        </PmtInf>
+        <PmtInf>
+            <PmtInfId>PMT002</PmtInfId>
+            <PmtMtd>DD</PmtMtd>
+            <BtchBookg>true</BtchBookg>
+            <NbOfTxs>1</NbOfTxs>
+            <CtrlSum>75.00</CtrlSum>
+            <PmtTpInf>
+                <SvcLvl><Cd>SEPA</Cd></SvcLvl>
+                <LclInstrm><Cd>CORE</Cd></LclInstrm>
+                <SeqTp>RCUR</SeqTp>
+            </PmtTpInf>
+            <ReqdColltnDt>2025-08-30</ReqdColltnDt>
+            <Cdtr><Nm>Example Sports Club e.V.</Nm></Cdtr>
+            <CdtrAcct><Id><IBAN>DE11123456789012345678</IBAN></Id></CdtrAcct>
+            <CdtrAgt><FinInstnId><BIC>FAKEDEFFXXX</BIC></FinInstnId></CdtrAgt>
+            <DrctDbtTxInf>
+                <PmtId><EndToEndId>INV002</EndToEndId></PmtId>
+                <InstdAmt Ccy="EUR">75.00</InstdAmt>
+                <DrctDbtTx>
+                    <MndtRltdInf><MndtId>MANDATE002</MndtId><DtOfSgntr>2024-09-15</DtOfSgntr></MndtRltdInf>
+                </DrctDbtTx>
+                <DbtrAgt><FinInstnId><BIC>FAKEXYZZXXX</BIC></FinInstnId></DbtrAgt>
+                <Dbtr><Nm>Jane Doe</Nm></Dbtr>
+                <DbtrAcct><Id><IBAN>DE55123456789012345678</IBAN></Id></DbtrAcct>
+                <RmtInf><Ustrd>Quarterly Training Fee</Ustrd></RmtInf>
+            </DrctDbtTxInf>
+        </PmtInf>
+        <PmtInf>
+            <PmtInfId>PMT001</PmtInfId>
+            <PmtMtd>DD</PmtMtd>
+            <BtchBookg>true</BtchBookg>
+            <NbOfTxs>1</NbOfTxs>
+            <CtrlSum>50.00</CtrlSum>
+            <PmtTpInf>
+                <SvcLvl><Cd>SEPA</Cd></SvcLvl>
+                <LclInstrm><Cd>CORE</Cd></LclInstrm>
+                <SeqTp>FRST</SeqTp>
+            </PmtTpInf>
+            <ReqdColltnDt>2025-08-30</ReqdColltnDt>
+            <Cdtr>
+                <Nm>Example Sports Club e.V.</Nm>
+            </Cdtr>
+            <CdtrAcct>
+                <Id><IBAN>DE11123456789012345678</IBAN></Id>
+            </CdtrAcct>
+            <CdtrAgt><FinInstnId><BIC>FAKEDEFFXXX</BIC></FinInstnId></CdtrAgt>
+            <CdtrSchmeId>
+                <Id><PrvtId><Othr><Id>DE99ZZZ00000000001</Id><SchmeNm><Prtry>SEPA</Prtry></SchmeNm></Othr></PrvtId></Id>
+            </CdtrSchmeId>
+            <DrctDbtTxInf>
+                <PmtId><EndToEndId>INV001</EndToEndId></PmtId>
+                <InstdAmt Ccy="EUR">50.00</InstdAmt>
+                <DrctDbtTx>
+                    <MndtRltdInf><MndtId>MANDATE001</MndtId><DtOfSgntr>2025-08-01</DtOfSgntr></MndtRltdInf>
+                </DrctDbtTx>
+                <DbtrAgt><FinInstnId><BIC>FAKEDEPPXXX</BIC></FinInstnId></DbtrAgt>
+                <Dbtr><Nm>Max Mustermann</Nm></Dbtr>
+                <DbtrAcct><Id><IBAN>DE44123456789012345678</IBAN></Id></DbtrAcct>
+                <RmtInf><Ustrd>Membership Fee August</Ustrd></RmtInf>
+            </DrctDbtTxInf>
+        </PmtInf>
+        <PmtInf>
+            <PmtInfId>PMT002</PmtInfId>
+            <PmtMtd>DD</PmtMtd>
+            <BtchBookg>true</BtchBookg>
+            <NbOfTxs>1</NbOfTxs>
+            <CtrlSum>75.00</CtrlSum>
+            <PmtTpInf>
+                <SvcLvl><Cd>SEPA</Cd></SvcLvl>
+                <LclInstrm><Cd>CORE</Cd></LclInstrm>
+                <SeqTp>RCUR</SeqTp>
+            </PmtTpInf>
+            <ReqdColltnDt>2025-08-30</ReqdColltnDt>
+            <Cdtr><Nm>Example Sports Club e.V.</Nm></Cdtr>
+            <CdtrAcct><Id><IBAN>DE11123456789012345678</IBAN></Id></CdtrAcct>
+            <CdtrAgt><FinInstnId><BIC>FAKEDEFFXXX</BIC></FinInstnId></CdtrAgt>
+            <DrctDbtTxInf>
+                <PmtId><EndToEndId>INV002</EndToEndId></PmtId>
+                <InstdAmt Ccy="EUR">75.00</InstdAmt>
+                <DrctDbtTx>
+                    <MndtRltdInf><MndtId>MANDATE002</MndtId><DtOfSgntr>2024-09-15</DtOfSgntr></MndtRltdInf>
+                </DrctDbtTx>
+                <DbtrAgt><FinInstnId><BIC>FAKEXYZZXXX</BIC></FinInstnId></DbtrAgt>
+                <Dbtr><Nm>Jane Doe</Nm></Dbtr>
+                <DbtrAcct><Id><IBAN>DE55123456789012345678</IBAN></Id></DbtrAcct>
+                <RmtInf><Ustrd>Quarterly Training Fee</Ustrd></RmtInf>
+            </DrctDbtTxInf>
+        </PmtInf>
+        <PmtInf>
+            <PmtInfId>PMT001</PmtInfId>
+            <PmtMtd>DD</PmtMtd>
+            <BtchBookg>true</BtchBookg>
+            <NbOfTxs>1</NbOfTxs>
+            <CtrlSum>50.00</CtrlSum>
+            <PmtTpInf>
+                <SvcLvl><Cd>SEPA</Cd></SvcLvl>
+                <LclInstrm><Cd>CORE</Cd></LclInstrm>
+                <SeqTp>FRST</SeqTp>
+            </PmtTpInf>
+            <ReqdColltnDt>2025-08-30</ReqdColltnDt>
+            <Cdtr>
+                <Nm>Example Sports Club e.V.</Nm>
+            </Cdtr>
+            <CdtrAcct>
+                <Id><IBAN>DE11123456789012345678</IBAN></Id>
+            </CdtrAcct>
+            <CdtrAgt><FinInstnId><BIC>FAKEDEFFXXX</BIC></FinInstnId></CdtrAgt>
+            <CdtrSchmeId>
+                <Id><PrvtId><Othr><Id>DE99ZZZ00000000001</Id><SchmeNm><Prtry>SEPA</Prtry></SchmeNm></Othr></PrvtId></Id>
+            </CdtrSchmeId>
+            <DrctDbtTxInf>
+                <PmtId><EndToEndId>INV001</EndToEndId></PmtId>
+                <InstdAmt Ccy="EUR">50.00</InstdAmt>
+                <DrctDbtTx>
+                    <MndtRltdInf><MndtId>MANDATE001</MndtId><DtOfSgntr>2025-08-01</DtOfSgntr></MndtRltdInf>
+                </DrctDbtTx>
+                <DbtrAgt><FinInstnId><BIC>FAKEDEPPXXX</BIC></FinInstnId></DbtrAgt>
+                <Dbtr><Nm>Max Mustermann</Nm></Dbtr>
+                <DbtrAcct><Id><IBAN>DE44123456789012345678</IBAN></Id></DbtrAcct>
+                <RmtInf><Ustrd>Membership Fee August</Ustrd></RmtInf>
+            </DrctDbtTxInf>
+        </PmtInf>
+        <PmtInf>
+            <PmtInfId>PMT002</PmtInfId>
+            <PmtMtd>DD</PmtMtd>
+            <BtchBookg>true</BtchBookg>
+            <NbOfTxs>1</NbOfTxs>
+            <CtrlSum>75.00</CtrlSum>
+            <PmtTpInf>
+                <SvcLvl><Cd>SEPA</Cd></SvcLvl>
+                <LclInstrm><Cd>CORE</Cd></LclInstrm>
+                <SeqTp>RCUR</SeqTp>
+            </PmtTpInf>
+            <ReqdColltnDt>2025-08-30</ReqdColltnDt>
+            <Cdtr><Nm>Example Sports Club e.V.</Nm></Cdtr>
+            <CdtrAcct><Id><IBAN>DE11123456789012345678</IBAN></Id></CdtrAcct>
+            <CdtrAgt><FinInstnId><BIC>FAKEDEFFXXX</BIC></FinInstnId></CdtrAgt>
+            <DrctDbtTxInf>
+                <PmtId><EndToEndId>INV002</EndToEndId></PmtId>
+                <InstdAmt Ccy="EUR">75.00</InstdAmt>
+                <DrctDbtTx>
+                    <MndtRltdInf><MndtId>MANDATE002</MndtId><DtOfSgntr>2024-09-15</DtOfSgntr></MndtRltdInf>
+                </DrctDbtTx>
+                <DbtrAgt><FinInstnId><BIC>FAKEXYZZXXX</BIC></FinInstnId></DbtrAgt>
+                <Dbtr><Nm>Jane Doe</Nm></Dbtr>
+                <DbtrAcct><Id><IBAN>DE55123456789012345678</IBAN></Id></DbtrAcct>
+                <RmtInf><Ustrd>Quarterly Training Fee</Ustrd></RmtInf>
+            </DrctDbtTxInf>
+        </PmtInf>
+        <PmtInf>
+            <PmtInfId>PMT001</PmtInfId>
+            <PmtMtd>DD</PmtMtd>
+            <BtchBookg>true</BtchBookg>
+            <NbOfTxs>1</NbOfTxs>
+            <CtrlSum>50.00</CtrlSum>
+            <PmtTpInf>
+                <SvcLvl><Cd>SEPA</Cd></SvcLvl>
+                <LclInstrm><Cd>CORE</Cd></LclInstrm>
+                <SeqTp>FRST</SeqTp>
+            </PmtTpInf>
+            <ReqdColltnDt>2025-08-30</ReqdColltnDt>
+            <Cdtr>
+                <Nm>Example Sports Club e.V.</Nm>
+            </Cdtr>
+            <CdtrAcct>
+                <Id><IBAN>DE11123456789012345678</IBAN></Id>
+            </CdtrAcct>
+            <CdtrAgt><FinInstnId><BIC>FAKEDEFFXXX</BIC></FinInstnId></CdtrAgt>
+            <CdtrSchmeId>
+                <Id><PrvtId><Othr><Id>DE99ZZZ00000000001</Id><SchmeNm><Prtry>SEPA</Prtry></SchmeNm></Othr></PrvtId></Id>
+            </CdtrSchmeId>
+            <DrctDbtTxInf>
+                <PmtId><EndToEndId>INV001</EndToEndId></PmtId>
+                <InstdAmt Ccy="EUR">50.00</InstdAmt>
+                <DrctDbtTx>
+                    <MndtRltdInf><MndtId>MANDATE001</MndtId><DtOfSgntr>2025-08-01</DtOfSgntr></MndtRltdInf>
+                </DrctDbtTx>
+                <DbtrAgt><FinInstnId><BIC>FAKEDEPPXXX</BIC></FinInstnId></DbtrAgt>
+                <Dbtr><Nm>Max Mustermann</Nm></Dbtr>
+                <DbtrAcct><Id><IBAN>DE44123456789012345678</IBAN></Id></DbtrAcct>
+                <RmtInf><Ustrd>Membership Fee August</Ustrd></RmtInf>
+            </DrctDbtTxInf>
+        </PmtInf>
+        <PmtInf>
+            <PmtInfId>PMT002</PmtInfId>
+            <PmtMtd>DD</PmtMtd>
+            <BtchBookg>true</BtchBookg>
+            <NbOfTxs>1</NbOfTxs>
+            <CtrlSum>75.00</CtrlSum>
+            <PmtTpInf>
+                <SvcLvl><Cd>SEPA</Cd></SvcLvl>
+                <LclInstrm><Cd>CORE</Cd></LclInstrm>
+                <SeqTp>RCUR</SeqTp>
+            </PmtTpInf>
+            <ReqdColltnDt>2025-08-30</ReqdColltnDt>
+            <Cdtr><Nm>Example Sports Club e.V.</Nm></Cdtr>
+            <CdtrAcct><Id><IBAN>DE11123456789012345678</IBAN></Id></CdtrAcct>
+            <CdtrAgt><FinInstnId><BIC>FAKEDEFFXXX</BIC></FinInstnId></CdtrAgt>
+            <DrctDbtTxInf>
+                <PmtId><EndToEndId>INV002</EndToEndId></PmtId>
+                <InstdAmt Ccy="EUR">75.00</InstdAmt>
+                <DrctDbtTx>
+                    <MndtRltdInf><MndtId>MANDATE002</MndtId><DtOfSgntr>2024-09-15</DtOfSgntr></MndtRltdInf>
+                </DrctDbtTx>
+                <DbtrAgt><FinInstnId><BIC>FAKEXYZZXXX</BIC></FinInstnId></DbtrAgt>
+                <Dbtr><Nm>Jane Doe</Nm></Dbtr>
+                <DbtrAcct><Id><IBAN>DE55123456789012345678</IBAN></Id></DbtrAcct>
+                <RmtInf><Ustrd>Quarterly Training Fee</Ustrd></RmtInf>
+            </DrctDbtTxInf>
+        </PmtInf>
+        <PmtInf>
+            <PmtInfId>PMT001</PmtInfId>
+            <PmtMtd>DD</PmtMtd>
+            <BtchBookg>true</BtchBookg>
+            <NbOfTxs>1</NbOfTxs>
+            <CtrlSum>50.00</CtrlSum>
+            <PmtTpInf>
+                <SvcLvl><Cd>SEPA</Cd></SvcLvl>
+                <LclInstrm><Cd>CORE</Cd></LclInstrm>
+                <SeqTp>FRST</SeqTp>
+            </PmtTpInf>
+            <ReqdColltnDt>2025-08-30</ReqdColltnDt>
+            <Cdtr>
+                <Nm>Example Sports Club e.V.</Nm>
+            </Cdtr>
+            <CdtrAcct>
+                <Id><IBAN>DE11123456789012345678</IBAN></Id>
+            </CdtrAcct>
+            <CdtrAgt><FinInstnId><BIC>FAKEDEFFXXX</BIC></FinInstnId></CdtrAgt>
+            <CdtrSchmeId>
+                <Id><PrvtId><Othr><Id>DE99ZZZ00000000001</Id><SchmeNm><Prtry>SEPA</Prtry></SchmeNm></Othr></PrvtId></Id>
+            </CdtrSchmeId>
+            <DrctDbtTxInf>
+                <PmtId><EndToEndId>INV001</EndToEndId></PmtId>
+                <InstdAmt Ccy="EUR">50.00</InstdAmt>
+                <DrctDbtTx>
+                    <MndtRltdInf><MndtId>MANDATE001</MndtId><DtOfSgntr>2025-08-01</DtOfSgntr></MndtRltdInf>
+                </DrctDbtTx>
+                <DbtrAgt><FinInstnId><BIC>FAKEDEPPXXX</BIC></FinInstnId></DbtrAgt>
+                <Dbtr><Nm>Max Mustermann</Nm></Dbtr>
+                <DbtrAcct><Id><IBAN>DE44123456789012345678</IBAN></Id></DbtrAcct>
+                <RmtInf><Ustrd>Membership Fee August</Ustrd></RmtInf>
+            </DrctDbtTxInf>
+        </PmtInf>
+        <PmtInf>
+            <PmtInfId>PMT002</PmtInfId>
+            <PmtMtd>DD</PmtMtd>
+            <BtchBookg>true</BtchBookg>
+            <NbOfTxs>1</NbOfTxs>
+            <CtrlSum>75.00</CtrlSum>
+            <PmtTpInf>
+                <SvcLvl><Cd>SEPA</Cd></SvcLvl>
+                <LclInstrm><Cd>CORE</Cd></LclInstrm>
+                <SeqTp>RCUR</SeqTp>
+            </PmtTpInf>
+            <ReqdColltnDt>2025-08-30</ReqdColltnDt>
+            <Cdtr><Nm>Example Sports Club e.V.</Nm></Cdtr>
+            <CdtrAcct><Id><IBAN>DE11123456789012345678</IBAN></Id></CdtrAcct>
+            <CdtrAgt><FinInstnId><BIC>FAKEDEFFXXX</BIC></FinInstnId></CdtrAgt>
+            <DrctDbtTxInf>
+                <PmtId><EndToEndId>INV002</EndToEndId></PmtId>
+                <InstdAmt Ccy="EUR">75.00</InstdAmt>
+                <DrctDbtTx>
+                    <MndtRltdInf><MndtId>MANDATE002</MndtId><DtOfSgntr>2024-09-15</DtOfSgntr></MndtRltdInf>
+                </DrctDbtTx>
+                <DbtrAgt><FinInstnId><BIC>FAKEXYZZXXX</BIC></FinInstnId></DbtrAgt>
+                <Dbtr><Nm>Jane Doe</Nm></Dbtr>
+                <DbtrAcct><Id><IBAN>DE55123456789012345678</IBAN></Id></DbtrAcct>
+                <RmtInf><Ustrd>Quarterly Training Fee</Ustrd></RmtInf>
+            </DrctDbtTxInf>
+        </PmtInf>
+        <PmtInf>
+            <PmtInfId>PMT001</PmtInfId>
+            <PmtMtd>DD</PmtMtd>
+            <BtchBookg>true</BtchBookg>
+            <NbOfTxs>1</NbOfTxs>
+            <CtrlSum>50.00</CtrlSum>
+            <PmtTpInf>
+                <SvcLvl><Cd>SEPA</Cd></SvcLvl>
+                <LclInstrm><Cd>CORE</Cd></LclInstrm>
+                <SeqTp>FRST</SeqTp>
+            </PmtTpInf>
+            <ReqdColltnDt>2025-08-30</ReqdColltnDt>
+            <Cdtr>
+                <Nm>Example Sports Club e.V.</Nm>
+            </Cdtr>
+            <CdtrAcct>
+                <Id><IBAN>DE11123456789012345678</IBAN></Id>
+            </CdtrAcct>
+            <CdtrAgt><FinInstnId><BIC>FAKEDEFFXXX</BIC></FinInstnId></CdtrAgt>
+            <CdtrSchmeId>
+                <Id><PrvtId><Othr><Id>DE99ZZZ00000000001</Id><SchmeNm><Prtry>SEPA</Prtry></SchmeNm></Othr></PrvtId></Id>
+            </CdtrSchmeId>
+            <DrctDbtTxInf>
+                <PmtId><EndToEndId>INV001</EndToEndId></PmtId>
+                <InstdAmt Ccy="EUR">50.00</InstdAmt>
+                <DrctDbtTx>
+                    <MndtRltdInf><MndtId>MANDATE001</MndtId><DtOfSgntr>2025-08-01</DtOfSgntr></MndtRltdInf>
+                </DrctDbtTx>
+                <DbtrAgt><FinInstnId><BIC>FAKEDEPPXXX</BIC></FinInstnId></DbtrAgt>
+                <Dbtr><Nm>Max Mustermann</Nm></Dbtr>
+                <DbtrAcct><Id><IBAN>DE44123456789012345678</IBAN></Id></DbtrAcct>
+                <RmtInf><Ustrd>Membership Fee August</Ustrd></RmtInf>
+            </DrctDbtTxInf>
+        </PmtInf>
+        <PmtInf>
+            <PmtInfId>PMT002</PmtInfId>
+            <PmtMtd>DD</PmtMtd>
+            <BtchBookg>true</BtchBookg>
+            <NbOfTxs>1</NbOfTxs>
+            <CtrlSum>75.00</CtrlSum>
+            <PmtTpInf>
+                <SvcLvl><Cd>SEPA</Cd></SvcLvl>
+                <LclInstrm><Cd>CORE</Cd></LclInstrm>
+                <SeqTp>RCUR</SeqTp>
+            </PmtTpInf>
+            <ReqdColltnDt>2025-08-30</ReqdColltnDt>
+            <Cdtr><Nm>Example Sports Club e.V.</Nm></Cdtr>
+            <CdtrAcct><Id><IBAN>DE11123456789012345678</IBAN></Id></CdtrAcct>
+            <CdtrAgt><FinInstnId><BIC>FAKEDEFFXXX</BIC></FinInstnId></CdtrAgt>
+            <DrctDbtTxInf>
+                <PmtId><EndToEndId>INV002</EndToEndId></PmtId>
+                <InstdAmt Ccy="EUR">75.00</InstdAmt>
+                <DrctDbtTx>
+                    <MndtRltdInf><MndtId>MANDATE002</MndtId><DtOfSgntr>2024-09-15</DtOfSgntr></MndtRltdInf>
+                </DrctDbtTx>
+                <DbtrAgt><FinInstnId><BIC>FAKEXYZZXXX</BIC></FinInstnId></DbtrAgt>
+                <Dbtr><Nm>Jane Doe</Nm></Dbtr>
+                <DbtrAcct><Id><IBAN>DE55123456789012345678</IBAN></Id></DbtrAcct>
+                <RmtInf><Ustrd>Quarterly Training Fee</Ustrd></RmtInf>
+            </DrctDbtTxInf>
+        </PmtInf>
+        <PmtInf>
+            <PmtInfId>PMT001</PmtInfId>
+            <PmtMtd>DD</PmtMtd>
+            <BtchBookg>true</BtchBookg>
+            <NbOfTxs>1</NbOfTxs>
+            <CtrlSum>50.00</CtrlSum>
+            <PmtTpInf>
+                <SvcLvl><Cd>SEPA</Cd></SvcLvl>
+                <LclInstrm><Cd>CORE</Cd></LclInstrm>
+                <SeqTp>FRST</SeqTp>
+            </PmtTpInf>
+            <ReqdColltnDt>2025-08-30</ReqdColltnDt>
+            <Cdtr>
+                <Nm>Example Sports Club e.V.</Nm>
+            </Cdtr>
+            <CdtrAcct>
+                <Id><IBAN>DE11123456789012345678</IBAN></Id>
+            </CdtrAcct>
+            <CdtrAgt><FinInstnId><BIC>FAKEDEFFXXX</BIC></FinInstnId></CdtrAgt>
+            <CdtrSchmeId>
+                <Id><PrvtId><Othr><Id>DE99ZZZ00000000001</Id><SchmeNm><Prtry>SEPA</Prtry></SchmeNm></Othr></PrvtId></Id>
+            </CdtrSchmeId>
+            <DrctDbtTxInf>
+                <PmtId><EndToEndId>INV001</EndToEndId></PmtId>
+                <InstdAmt Ccy="EUR">50.00</InstdAmt>
+                <DrctDbtTx>
+                    <MndtRltdInf><MndtId>MANDATE001</MndtId><DtOfSgntr>2025-08-01</DtOfSgntr></MndtRltdInf>
+                </DrctDbtTx>
+                <DbtrAgt><FinInstnId><BIC>FAKEDEPPXXX</BIC></FinInstnId></DbtrAgt>
+                <Dbtr><Nm>Max Mustermann</Nm></Dbtr>
+                <DbtrAcct><Id><IBAN>DE44123456789012345678</IBAN></Id></DbtrAcct>
+                <RmtInf><Ustrd>Membership Fee August</Ustrd></RmtInf>
+            </DrctDbtTxInf>
+        </PmtInf>
+        <PmtInf>
+            <PmtInfId>PMT002</PmtInfId>
+            <PmtMtd>DD</PmtMtd>
+            <BtchBookg>true</BtchBookg>
+            <NbOfTxs>1</NbOfTxs>
+            <CtrlSum>75.00</CtrlSum>
+            <PmtTpInf>
+                <SvcLvl><Cd>SEPA</Cd></SvcLvl>
+                <LclInstrm><Cd>CORE</Cd></LclInstrm>
+                <SeqTp>RCUR</SeqTp>
+            </PmtTpInf>
+            <ReqdColltnDt>2025-08-30</ReqdColltnDt>
+            <Cdtr><Nm>Example Sports Club e.V.</Nm></Cdtr>
+            <CdtrAcct><Id><IBAN>DE11123456789012345678</IBAN></Id></CdtrAcct>
+            <CdtrAgt><FinInstnId><BIC>FAKEDEFFXXX</BIC></FinInstnId></CdtrAgt>
+            <DrctDbtTxInf>
+                <PmtId><EndToEndId>INV002</EndToEndId></PmtId>
+                <InstdAmt Ccy="EUR">75.00</InstdAmt>
+                <DrctDbtTx>
+                    <MndtRltdInf><MndtId>MANDATE002</MndtId><DtOfSgntr>2024-09-15</DtOfSgntr></MndtRltdInf>
+                </DrctDbtTx>
+                <DbtrAgt><FinInstnId><BIC>FAKEXYZZXXX</BIC></FinInstnId></DbtrAgt>
+                <Dbtr><Nm>Jane Doe</Nm></Dbtr>
+                <DbtrAcct><Id><IBAN>DE55123456789012345678</IBAN></Id></DbtrAcct>
+                <RmtInf><Ustrd>Quarterly Training Fee</Ustrd></RmtInf>
+            </DrctDbtTxInf>
+        </PmtInf>
+        <PmtInf>
+            <PmtInfId>PMT001</PmtInfId>
+            <PmtMtd>DD</PmtMtd>
+            <BtchBookg>true</BtchBookg>
+            <NbOfTxs>1</NbOfTxs>
+            <CtrlSum>50.00</CtrlSum>
+            <PmtTpInf>
+                <SvcLvl><Cd>SEPA</Cd></SvcLvl>
+                <LclInstrm><Cd>CORE</Cd></LclInstrm>
+                <SeqTp>FRST</SeqTp>
+            </PmtTpInf>
+            <ReqdColltnDt>2025-08-30</ReqdColltnDt>
+            <Cdtr>
+                <Nm>Example Sports Club e.V.</Nm>
+            </Cdtr>
+            <CdtrAcct>
+                <Id><IBAN>DE11123456789012345678</IBAN></Id>
+            </CdtrAcct>
+            <CdtrAgt><FinInstnId><BIC>FAKEDEFFXXX</BIC></FinInstnId></CdtrAgt>
+            <CdtrSchmeId>
+                <Id><PrvtId><Othr><Id>DE99ZZZ00000000001</Id><SchmeNm><Prtry>SEPA</Prtry></SchmeNm></Othr></PrvtId></Id>
+            </CdtrSchmeId>
+            <DrctDbtTxInf>
+                <PmtId><EndToEndId>INV001</EndToEndId></PmtId>
+                <InstdAmt Ccy="EUR">50.00</InstdAmt>
+                <DrctDbtTx>
+                    <MndtRltdInf><MndtId>MANDATE001</MndtId><DtOfSgntr>2025-08-01</DtOfSgntr></MndtRltdInf>
+                </DrctDbtTx>
+                <DbtrAgt><FinInstnId><BIC>FAKEDEPPXXX</BIC></FinInstnId></DbtrAgt>
+                <Dbtr><Nm>Max Mustermann</Nm></Dbtr>
+                <DbtrAcct><Id><IBAN>DE44123456789012345678</IBAN></Id></DbtrAcct>
+                <RmtInf><Ustrd>Membership Fee August</Ustrd></RmtInf>
+            </DrctDbtTxInf>
+        </PmtInf>
+        <PmtInf>
+            <PmtInfId>PMT002</PmtInfId>
+            <PmtMtd>DD</PmtMtd>
+            <BtchBookg>true</BtchBookg>
+            <NbOfTxs>1</NbOfTxs>
+            <CtrlSum>75.00</CtrlSum>
+            <PmtTpInf>
+                <SvcLvl><Cd>SEPA</Cd></SvcLvl>
+                <LclInstrm><Cd>CORE</Cd></LclInstrm>
+                <SeqTp>RCUR</SeqTp>
+            </PmtTpInf>
+            <ReqdColltnDt>2025-08-30</ReqdColltnDt>
+            <Cdtr><Nm>Example Sports Club e.V.</Nm></Cdtr>
+            <CdtrAcct><Id><IBAN>DE11123456789012345678</IBAN></Id></CdtrAcct>
+            <CdtrAgt><FinInstnId><BIC>FAKEDEFFXXX</BIC></FinInstnId></CdtrAgt>
+            <DrctDbtTxInf>
+                <PmtId><EndToEndId>INV002</EndToEndId></PmtId>
+                <InstdAmt Ccy="EUR">75.00</InstdAmt>
+                <DrctDbtTx>
+                    <MndtRltdInf><MndtId>MANDATE002</MndtId><DtOfSgntr>2024-09-15</DtOfSgntr></MndtRltdInf>
+                </DrctDbtTx>
+                <DbtrAgt><FinInstnId><BIC>FAKEXYZZXXX</BIC></FinInstnId></DbtrAgt>
+                <Dbtr><Nm>Jane Doe</Nm></Dbtr>
+                <DbtrAcct><Id><IBAN>DE55123456789012345678</IBAN></Id></DbtrAcct>
+                <RmtInf><Ustrd>Quarterly Training Fee</Ustrd></RmtInf>
+            </DrctDbtTxInf>
+        </PmtInf><PmtInf>
+        <PmtInfId>PMT001</PmtInfId>
+        <PmtMtd>DD</PmtMtd>
+        <BtchBookg>true</BtchBookg>
+        <NbOfTxs>1</NbOfTxs>
+        <CtrlSum>50.00</CtrlSum>
+        <PmtTpInf>
+            <SvcLvl><Cd>SEPA</Cd></SvcLvl>
+            <LclInstrm><Cd>CORE</Cd></LclInstrm>
+            <SeqTp>FRST</SeqTp>
+        </PmtTpInf>
+        <ReqdColltnDt>2025-08-30</ReqdColltnDt>
+        <Cdtr>
+            <Nm>Example Sports Club e.V.</Nm>
+        </Cdtr>
+        <CdtrAcct>
+            <Id><IBAN>DE11123456789012345678</IBAN></Id>
+        </CdtrAcct>
+        <CdtrAgt><FinInstnId><BIC>FAKEDEFFXXX</BIC></FinInstnId></CdtrAgt>
+        <CdtrSchmeId>
+            <Id><PrvtId><Othr><Id>DE99ZZZ00000000001</Id><SchmeNm><Prtry>SEPA</Prtry></SchmeNm></Othr></PrvtId></Id>
+        </CdtrSchmeId>
+        <DrctDbtTxInf>
+            <PmtId><EndToEndId>INV001</EndToEndId></PmtId>
+            <InstdAmt Ccy="EUR">50.00</InstdAmt>
+            <DrctDbtTx>
+                <MndtRltdInf><MndtId>MANDATE001</MndtId><DtOfSgntr>2025-08-01</DtOfSgntr></MndtRltdInf>
+            </DrctDbtTx>
+            <DbtrAgt><FinInstnId><BIC>FAKEDEPPXXX</BIC></FinInstnId></DbtrAgt>
+            <Dbtr><Nm>Max Mustermann</Nm></Dbtr>
+            <DbtrAcct><Id><IBAN>DE44123456789012345678</IBAN></Id></DbtrAcct>
+            <RmtInf><Ustrd>Membership Fee August</Ustrd></RmtInf>
+        </DrctDbtTxInf>
+    </PmtInf>
+        <PmtInf>
+            <PmtInfId>PMT002</PmtInfId>
+            <PmtMtd>DD</PmtMtd>
+            <BtchBookg>true</BtchBookg>
+            <NbOfTxs>1</NbOfTxs>
+            <CtrlSum>75.00</CtrlSum>
+            <PmtTpInf>
+                <SvcLvl><Cd>SEPA</Cd></SvcLvl>
+                <LclInstrm><Cd>CORE</Cd></LclInstrm>
+                <SeqTp>RCUR</SeqTp>
+            </PmtTpInf>
+            <ReqdColltnDt>2025-08-30</ReqdColltnDt>
+            <Cdtr><Nm>Example Sports Club e.V.</Nm></Cdtr>
+            <CdtrAcct><Id><IBAN>DE11123456789012345678</IBAN></Id></CdtrAcct>
+            <CdtrAgt><FinInstnId><BIC>FAKEDEFFXXX</BIC></FinInstnId></CdtrAgt>
+            <DrctDbtTxInf>
+                <PmtId><EndToEndId>INV002</EndToEndId></PmtId>
+                <InstdAmt Ccy="EUR">75.00</InstdAmt>
+                <DrctDbtTx>
+                    <MndtRltdInf><MndtId>MANDATE002</MndtId><DtOfSgntr>2024-09-15</DtOfSgntr></MndtRltdInf>
+                </DrctDbtTx>
+                <DbtrAgt><FinInstnId><BIC>FAKEXYZZXXX</BIC></FinInstnId></DbtrAgt>
+                <Dbtr><Nm>Jane Doe</Nm></Dbtr>
+                <DbtrAcct><Id><IBAN>DE55123456789012345678</IBAN></Id></DbtrAcct>
+                <RmtInf><Ustrd>Quarterly Training Fee</Ustrd></RmtInf>
+            </DrctDbtTxInf>
+        </PmtInf><PmtInf>
+        <PmtInfId>PMT001</PmtInfId>
+        <PmtMtd>DD</PmtMtd>
+        <BtchBookg>true</BtchBookg>
+        <NbOfTxs>1</NbOfTxs>
+        <CtrlSum>50.00</CtrlSum>
+        <PmtTpInf>
+            <SvcLvl><Cd>SEPA</Cd></SvcLvl>
+            <LclInstrm><Cd>CORE</Cd></LclInstrm>
+            <SeqTp>FRST</SeqTp>
+        </PmtTpInf>
+        <ReqdColltnDt>2025-08-30</ReqdColltnDt>
+        <Cdtr>
+            <Nm>Example Sports Club e.V.</Nm>
+        </Cdtr>
+        <CdtrAcct>
+            <Id><IBAN>DE11123456789012345678</IBAN></Id>
+        </CdtrAcct>
+        <CdtrAgt><FinInstnId><BIC>FAKEDEFFXXX</BIC></FinInstnId></CdtrAgt>
+        <CdtrSchmeId>
+            <Id><PrvtId><Othr><Id>DE99ZZZ00000000001</Id><SchmeNm><Prtry>SEPA</Prtry></SchmeNm></Othr></PrvtId></Id>
+        </CdtrSchmeId>
+        <DrctDbtTxInf>
+            <PmtId><EndToEndId>INV001</EndToEndId></PmtId>
+            <InstdAmt Ccy="EUR">50.00</InstdAmt>
+            <DrctDbtTx>
+                <MndtRltdInf><MndtId>MANDATE001</MndtId><DtOfSgntr>2025-08-01</DtOfSgntr></MndtRltdInf>
+            </DrctDbtTx>
+            <DbtrAgt><FinInstnId><BIC>FAKEDEPPXXX</BIC></FinInstnId></DbtrAgt>
+            <Dbtr><Nm>Max Mustermann</Nm></Dbtr>
+            <DbtrAcct><Id><IBAN>DE44123456789012345678</IBAN></Id></DbtrAcct>
+            <RmtInf><Ustrd>Membership Fee August</Ustrd></RmtInf>
+        </DrctDbtTxInf>
+    </PmtInf>
+        <PmtInf>
+            <PmtInfId>PMT002</PmtInfId>
+            <PmtMtd>DD</PmtMtd>
+            <BtchBookg>true</BtchBookg>
+            <NbOfTxs>1</NbOfTxs>
+            <CtrlSum>75.00</CtrlSum>
+            <PmtTpInf>
+                <SvcLvl><Cd>SEPA</Cd></SvcLvl>
+                <LclInstrm><Cd>CORE</Cd></LclInstrm>
+                <SeqTp>RCUR</SeqTp>
+            </PmtTpInf>
+            <ReqdColltnDt>2025-08-30</ReqdColltnDt>
+            <Cdtr><Nm>Example Sports Club e.V.</Nm></Cdtr>
+            <CdtrAcct><Id><IBAN>DE11123456789012345678</IBAN></Id></CdtrAcct>
+            <CdtrAgt><FinInstnId><BIC>FAKEDEFFXXX</BIC></FinInstnId></CdtrAgt>
+            <DrctDbtTxInf>
+                <PmtId><EndToEndId>INV002</EndToEndId></PmtId>
+                <InstdAmt Ccy="EUR">75.00</InstdAmt>
+                <DrctDbtTx>
+                    <MndtRltdInf><MndtId>MANDATE002</MndtId><DtOfSgntr>2024-09-15</DtOfSgntr></MndtRltdInf>
+                </DrctDbtTx>
+                <DbtrAgt><FinInstnId><BIC>FAKEXYZZXXX</BIC></FinInstnId></DbtrAgt>
+                <Dbtr><Nm>Jane Doe</Nm></Dbtr>
+                <DbtrAcct><Id><IBAN>DE55123456789012345678</IBAN></Id></DbtrAcct>
+                <RmtInf><Ustrd>Quarterly Training Fee</Ustrd></RmtInf>
+            </DrctDbtTxInf>
+        </PmtInf>
+        <PmtInf>
+            <PmtInfId>PMT001</PmtInfId>
+            <PmtMtd>DD</PmtMtd>
+            <BtchBookg>true</BtchBookg>
+            <NbOfTxs>1</NbOfTxs>
+            <CtrlSum>50.00</CtrlSum>
+            <PmtTpInf>
+                <SvcLvl><Cd>SEPA</Cd></SvcLvl>
+                <LclInstrm><Cd>CORE</Cd></LclInstrm>
+                <SeqTp>FRST</SeqTp>
+            </PmtTpInf>
+            <ReqdColltnDt>2025-08-30</ReqdColltnDt>
+            <Cdtr>
+                <Nm>Example Sports Club e.V.</Nm>
+            </Cdtr>
+            <CdtrAcct>
+                <Id><IBAN>DE11123456789012345678</IBAN></Id>
+            </CdtrAcct>
+            <CdtrAgt><FinInstnId><BIC>FAKEDEFFXXX</BIC></FinInstnId></CdtrAgt>
+            <CdtrSchmeId>
+                <Id><PrvtId><Othr><Id>DE99ZZZ00000000001</Id><SchmeNm><Prtry>SEPA</Prtry></SchmeNm></Othr></PrvtId></Id>
+            </CdtrSchmeId>
+            <DrctDbtTxInf>
+                <PmtId><EndToEndId>INV001</EndToEndId></PmtId>
+                <InstdAmt Ccy="EUR">50.00</InstdAmt>
+                <DrctDbtTx>
+                    <MndtRltdInf><MndtId>MANDATE001</MndtId><DtOfSgntr>2025-08-01</DtOfSgntr></MndtRltdInf>
+                </DrctDbtTx>
+                <DbtrAgt><FinInstnId><BIC>FAKEDEPPXXX</BIC></FinInstnId></DbtrAgt>
+                <Dbtr><Nm>Max Mustermann</Nm></Dbtr>
+                <DbtrAcct><Id><IBAN>DE44123456789012345678</IBAN></Id></DbtrAcct>
+                <RmtInf><Ustrd>Membership Fee August</Ustrd></RmtInf>
+            </DrctDbtTxInf>
+        </PmtInf>
+        <PmtInf>
+            <PmtInfId>PMT002</PmtInfId>
+            <PmtMtd>DD</PmtMtd>
+            <BtchBookg>true</BtchBookg>
+            <NbOfTxs>1</NbOfTxs>
+            <CtrlSum>75.00</CtrlSum>
+            <PmtTpInf>
+                <SvcLvl><Cd>SEPA</Cd></SvcLvl>
+                <LclInstrm><Cd>CORE</Cd></LclInstrm>
+                <SeqTp>RCUR</SeqTp>
+            </PmtTpInf>
+            <ReqdColltnDt>2025-08-30</ReqdColltnDt>
+            <Cdtr><Nm>Example Sports Club e.V.</Nm></Cdtr>
+            <CdtrAcct><Id><IBAN>DE11123456789012345678</IBAN></Id></CdtrAcct>
+            <CdtrAgt><FinInstnId><BIC>FAKEDEFFXXX</BIC></FinInstnId></CdtrAgt>
+            <DrctDbtTxInf>
+                <PmtId><EndToEndId>INV002</EndToEndId></PmtId>
+                <InstdAmt Ccy="EUR">75.00</InstdAmt>
+                <DrctDbtTx>
+                    <MndtRltdInf><MndtId>MANDATE002</MndtId><DtOfSgntr>2024-09-15</DtOfSgntr></MndtRltdInf>
+                </DrctDbtTx>
+                <DbtrAgt><FinInstnId><BIC>FAKEXYZZXXX</BIC></FinInstnId></DbtrAgt>
+                <Dbtr><Nm>Jane Doe</Nm></Dbtr>
+                <DbtrAcct><Id><IBAN>DE55123456789012345678</IBAN></Id></DbtrAcct>
+                <RmtInf><Ustrd>Quarterly Training Fee</Ustrd></RmtInf>
+            </DrctDbtTxInf>
+        </PmtInf>
+        <PmtInf>
+            <PmtInfId>PMT001</PmtInfId>
+            <PmtMtd>DD</PmtMtd>
+            <BtchBookg>true</BtchBookg>
+            <NbOfTxs>1</NbOfTxs>
+            <CtrlSum>50.00</CtrlSum>
+            <PmtTpInf>
+                <SvcLvl><Cd>SEPA</Cd></SvcLvl>
+                <LclInstrm><Cd>CORE</Cd></LclInstrm>
+                <SeqTp>FRST</SeqTp>
+            </PmtTpInf>
+            <ReqdColltnDt>2025-08-30</ReqdColltnDt>
+            <Cdtr>
+                <Nm>Example Sports Club e.V.</Nm>
+            </Cdtr>
+            <CdtrAcct>
+                <Id><IBAN>DE11123456789012345678</IBAN></Id>
+            </CdtrAcct>
+            <CdtrAgt><FinInstnId><BIC>FAKEDEFFXXX</BIC></FinInstnId></CdtrAgt>
+            <CdtrSchmeId>
+                <Id><PrvtId><Othr><Id>DE99ZZZ00000000001</Id><SchmeNm><Prtry>SEPA</Prtry></SchmeNm></Othr></PrvtId></Id>
+            </CdtrSchmeId>
+            <DrctDbtTxInf>
+                <PmtId><EndToEndId>INV001</EndToEndId></PmtId>
+                <InstdAmt Ccy="EUR">50.00</InstdAmt>
+                <DrctDbtTx>
+                    <MndtRltdInf><MndtId>MANDATE001</MndtId><DtOfSgntr>2025-08-01</DtOfSgntr></MndtRltdInf>
+                </DrctDbtTx>
+                <DbtrAgt><FinInstnId><BIC>FAKEDEPPXXX</BIC></FinInstnId></DbtrAgt>
+                <Dbtr><Nm>Max Mustermann</Nm></Dbtr>
+                <DbtrAcct><Id><IBAN>DE44123456789012345678</IBAN></Id></DbtrAcct>
+                <RmtInf><Ustrd>Membership Fee August</Ustrd></RmtInf>
+            </DrctDbtTxInf>
+        </PmtInf>
+        <PmtInf>
+            <PmtInfId>PMT002</PmtInfId>
+            <PmtMtd>DD</PmtMtd>
+            <BtchBookg>true</BtchBookg>
+            <NbOfTxs>1</NbOfTxs>
+            <CtrlSum>75.00</CtrlSum>
+            <PmtTpInf>
+                <SvcLvl><Cd>SEPA</Cd></SvcLvl>
+                <LclInstrm><Cd>CORE</Cd></LclInstrm>
+                <SeqTp>RCUR</SeqTp>
+            </PmtTpInf>
+            <ReqdColltnDt>2025-08-30</ReqdColltnDt>
+            <Cdtr><Nm>Example Sports Club e.V.</Nm></Cdtr>
+            <CdtrAcct><Id><IBAN>DE11123456789012345678</IBAN></Id></CdtrAcct>
+            <CdtrAgt><FinInstnId><BIC>FAKEDEFFXXX</BIC></FinInstnId></CdtrAgt>
+            <DrctDbtTxInf>
+                <PmtId><EndToEndId>INV002</EndToEndId></PmtId>
+                <InstdAmt Ccy="EUR">75.00</InstdAmt>
+                <DrctDbtTx>
+                    <MndtRltdInf><MndtId>MANDATE002</MndtId><DtOfSgntr>2024-09-15</DtOfSgntr></MndtRltdInf>
+                </DrctDbtTx>
+                <DbtrAgt><FinInstnId><BIC>FAKEXYZZXXX</BIC></FinInstnId></DbtrAgt>
+                <Dbtr><Nm>Jane Doe</Nm></Dbtr>
+                <DbtrAcct><Id><IBAN>DE55123456789012345678</IBAN></Id></DbtrAcct>
+                <RmtInf><Ustrd>Quarterly Training Fee</Ustrd></RmtInf>
+            </DrctDbtTxInf>
+        </PmtInf>
+        <PmtInf>
+            <PmtInfId>PMT001</PmtInfId>
+            <PmtMtd>DD</PmtMtd>
+            <BtchBookg>true</BtchBookg>
+            <NbOfTxs>1</NbOfTxs>
+            <CtrlSum>50.00</CtrlSum>
+            <PmtTpInf>
+                <SvcLvl><Cd>SEPA</Cd></SvcLvl>
+                <LclInstrm><Cd>CORE</Cd></LclInstrm>
+                <SeqTp>FRST</SeqTp>
+            </PmtTpInf>
+            <ReqdColltnDt>2025-08-30</ReqdColltnDt>
+            <Cdtr>
+                <Nm>Example Sports Club e.V.</Nm>
+            </Cdtr>
+            <CdtrAcct>
+                <Id><IBAN>DE11123456789012345678</IBAN></Id>
+            </CdtrAcct>
+            <CdtrAgt><FinInstnId><BIC>FAKEDEFFXXX</BIC></FinInstnId></CdtrAgt>
+            <CdtrSchmeId>
+                <Id><PrvtId><Othr><Id>DE99ZZZ00000000001</Id><SchmeNm><Prtry>SEPA</Prtry></SchmeNm></Othr></PrvtId></Id>
+            </CdtrSchmeId>
+            <DrctDbtTxInf>
+                <PmtId><EndToEndId>INV001</EndToEndId></PmtId>
+                <InstdAmt Ccy="EUR">50.00</InstdAmt>
+                <DrctDbtTx>
+                    <MndtRltdInf><MndtId>MANDATE001</MndtId><DtOfSgntr>2025-08-01</DtOfSgntr></MndtRltdInf>
+                </DrctDbtTx>
+                <DbtrAgt><FinInstnId><BIC>FAKEDEPPXXX</BIC></FinInstnId></DbtrAgt>
+                <Dbtr><Nm>Max Mustermann</Nm></Dbtr>
+                <DbtrAcct><Id><IBAN>DE44123456789012345678</IBAN></Id></DbtrAcct>
+                <RmtInf><Ustrd>Membership Fee August</Ustrd></RmtInf>
+            </DrctDbtTxInf>
+        </PmtInf>
+        <PmtInf>
+            <PmtInfId>PMT002</PmtInfId>
+            <PmtMtd>DD</PmtMtd>
+            <BtchBookg>true</BtchBookg>
+            <NbOfTxs>1</NbOfTxs>
+            <CtrlSum>75.00</CtrlSum>
+            <PmtTpInf>
+                <SvcLvl><Cd>SEPA</Cd></SvcLvl>
+                <LclInstrm><Cd>CORE</Cd></LclInstrm>
+                <SeqTp>RCUR</SeqTp>
+            </PmtTpInf>
+            <ReqdColltnDt>2025-08-30</ReqdColltnDt>
+            <Cdtr><Nm>Example Sports Club e.V.</Nm></Cdtr>
+            <CdtrAcct><Id><IBAN>DE11123456789012345678</IBAN></Id></CdtrAcct>
+            <CdtrAgt><FinInstnId><BIC>FAKEDEFFXXX</BIC></FinInstnId></CdtrAgt>
+            <DrctDbtTxInf>
+                <PmtId><EndToEndId>INV002</EndToEndId></PmtId>
+                <InstdAmt Ccy="EUR">75.00</InstdAmt>
+                <DrctDbtTx>
+                    <MndtRltdInf><MndtId>MANDATE002</MndtId><DtOfSgntr>2024-09-15</DtOfSgntr></MndtRltdInf>
+                </DrctDbtTx>
+                <DbtrAgt><FinInstnId><BIC>FAKEXYZZXXX</BIC></FinInstnId></DbtrAgt>
+                <Dbtr><Nm>Jane Doe</Nm></Dbtr>
+                <DbtrAcct><Id><IBAN>DE55123456789012345678</IBAN></Id></DbtrAcct>
+                <RmtInf><Ustrd>Quarterly Training Fee</Ustrd></RmtInf>
+            </DrctDbtTxInf>
+        </PmtInf>
+        <PmtInf>
+            <PmtInfId>PMT001</PmtInfId>
+            <PmtMtd>DD</PmtMtd>
+            <BtchBookg>true</BtchBookg>
+            <NbOfTxs>1</NbOfTxs>
+            <CtrlSum>50.00</CtrlSum>
+            <PmtTpInf>
+                <SvcLvl><Cd>SEPA</Cd></SvcLvl>
+                <LclInstrm><Cd>CORE</Cd></LclInstrm>
+                <SeqTp>FRST</SeqTp>
+            </PmtTpInf>
+            <ReqdColltnDt>2025-08-30</ReqdColltnDt>
+            <Cdtr>
+                <Nm>Example Sports Club e.V.</Nm>
+            </Cdtr>
+            <CdtrAcct>
+                <Id><IBAN>DE11123456789012345678</IBAN></Id>
+            </CdtrAcct>
+            <CdtrAgt><FinInstnId><BIC>FAKEDEFFXXX</BIC></FinInstnId></CdtrAgt>
+            <CdtrSchmeId>
+                <Id><PrvtId><Othr><Id>DE99ZZZ00000000001</Id><SchmeNm><Prtry>SEPA</Prtry></SchmeNm></Othr></PrvtId></Id>
+            </CdtrSchmeId>
+            <DrctDbtTxInf>
+                <PmtId><EndToEndId>INV001</EndToEndId></PmtId>
+                <InstdAmt Ccy="EUR">50.00</InstdAmt>
+                <DrctDbtTx>
+                    <MndtRltdInf><MndtId>MANDATE001</MndtId><DtOfSgntr>2025-08-01</DtOfSgntr></MndtRltdInf>
+                </DrctDbtTx>
+                <DbtrAgt><FinInstnId><BIC>FAKEDEPPXXX</BIC></FinInstnId></DbtrAgt>
+                <Dbtr><Nm>Max Mustermann</Nm></Dbtr>
+                <DbtrAcct><Id><IBAN>DE44123456789012345678</IBAN></Id></DbtrAcct>
+                <RmtInf><Ustrd>Membership Fee August</Ustrd></RmtInf>
+            </DrctDbtTxInf>
+        </PmtInf>
+        <PmtInf>
+            <PmtInfId>PMT002</PmtInfId>
+            <PmtMtd>DD</PmtMtd>
+            <BtchBookg>true</BtchBookg>
+            <NbOfTxs>1</NbOfTxs>
+            <CtrlSum>75.00</CtrlSum>
+            <PmtTpInf>
+                <SvcLvl><Cd>SEPA</Cd></SvcLvl>
+                <LclInstrm><Cd>CORE</Cd></LclInstrm>
+                <SeqTp>RCUR</SeqTp>
+            </PmtTpInf>
+            <ReqdColltnDt>2025-08-30</ReqdColltnDt>
+            <Cdtr><Nm>Example Sports Club e.V.</Nm></Cdtr>
+            <CdtrAcct><Id><IBAN>DE11123456789012345678</IBAN></Id></CdtrAcct>
+            <CdtrAgt><FinInstnId><BIC>FAKEDEFFXXX</BIC></FinInstnId></CdtrAgt>
+            <DrctDbtTxInf>
+                <PmtId><EndToEndId>INV002</EndToEndId></PmtId>
+                <InstdAmt Ccy="EUR">75.00</InstdAmt>
+                <DrctDbtTx>
+                    <MndtRltdInf><MndtId>MANDATE002</MndtId><DtOfSgntr>2024-09-15</DtOfSgntr></MndtRltdInf>
+                </DrctDbtTx>
+                <DbtrAgt><FinInstnId><BIC>FAKEXYZZXXX</BIC></FinInstnId></DbtrAgt>
+                <Dbtr><Nm>Jane Doe</Nm></Dbtr>
+                <DbtrAcct><Id><IBAN>DE55123456789012345678</IBAN></Id></DbtrAcct>
+                <RmtInf><Ustrd>Quarterly Training Fee</Ustrd></RmtInf>
+            </DrctDbtTxInf>
+        </PmtInf>
+        <PmtInf>
+            <PmtInfId>PMT001</PmtInfId>
+            <PmtMtd>DD</PmtMtd>
+            <BtchBookg>true</BtchBookg>
+            <NbOfTxs>1</NbOfTxs>
+            <CtrlSum>50.00</CtrlSum>
+            <PmtTpInf>
+                <SvcLvl><Cd>SEPA</Cd></SvcLvl>
+                <LclInstrm><Cd>CORE</Cd></LclInstrm>
+                <SeqTp>FRST</SeqTp>
+            </PmtTpInf>
+            <ReqdColltnDt>2025-08-30</ReqdColltnDt>
+            <Cdtr>
+                <Nm>Example Sports Club e.V.</Nm>
+            </Cdtr>
+            <CdtrAcct>
+                <Id><IBAN>DE11123456789012345678</IBAN></Id>
+            </CdtrAcct>
+            <CdtrAgt><FinInstnId><BIC>FAKEDEFFXXX</BIC></FinInstnId></CdtrAgt>
+            <CdtrSchmeId>
+                <Id><PrvtId><Othr><Id>DE99ZZZ00000000001</Id><SchmeNm><Prtry>SEPA</Prtry></SchmeNm></Othr></PrvtId></Id>
+            </CdtrSchmeId>
+            <DrctDbtTxInf>
+                <PmtId><EndToEndId>INV001</EndToEndId></PmtId>
+                <InstdAmt Ccy="EUR">50.00</InstdAmt>
+                <DrctDbtTx>
+                    <MndtRltdInf><MndtId>MANDATE001</MndtId><DtOfSgntr>2025-08-01</DtOfSgntr></MndtRltdInf>
+                </DrctDbtTx>
+                <DbtrAgt><FinInstnId><BIC>FAKEDEPPXXX</BIC></FinInstnId></DbtrAgt>
+                <Dbtr><Nm>Max Mustermann</Nm></Dbtr>
+                <DbtrAcct><Id><IBAN>DE44123456789012345678</IBAN></Id></DbtrAcct>
+                <RmtInf><Ustrd>Membership Fee August</Ustrd></RmtInf>
+            </DrctDbtTxInf>
+        </PmtInf>
+        <PmtInf>
+            <PmtInfId>PMT002</PmtInfId>
+            <PmtMtd>DD</PmtMtd>
+            <BtchBookg>true</BtchBookg>
+            <NbOfTxs>1</NbOfTxs>
+            <CtrlSum>75.00</CtrlSum>
+            <PmtTpInf>
+                <SvcLvl><Cd>SEPA</Cd></SvcLvl>
+                <LclInstrm><Cd>CORE</Cd></LclInstrm>
+                <SeqTp>RCUR</SeqTp>
+            </PmtTpInf>
+            <ReqdColltnDt>2025-08-30</ReqdColltnDt>
+            <Cdtr><Nm>Example Sports Club e.V.</Nm></Cdtr>
+            <CdtrAcct><Id><IBAN>DE11123456789012345678</IBAN></Id></CdtrAcct>
+            <CdtrAgt><FinInstnId><BIC>FAKEDEFFXXX</BIC></FinInstnId></CdtrAgt>
+            <DrctDbtTxInf>
+                <PmtId><EndToEndId>INV002</EndToEndId></PmtId>
+                <InstdAmt Ccy="EUR">75.00</InstdAmt>
+                <DrctDbtTx>
+                    <MndtRltdInf><MndtId>MANDATE002</MndtId><DtOfSgntr>2024-09-15</DtOfSgntr></MndtRltdInf>
+                </DrctDbtTx>
+                <DbtrAgt><FinInstnId><BIC>FAKEXYZZXXX</BIC></FinInstnId></DbtrAgt>
+                <Dbtr><Nm>Jane Doe</Nm></Dbtr>
+                <DbtrAcct><Id><IBAN>DE55123456789012345678</IBAN></Id></DbtrAcct>
+                <RmtInf><Ustrd>Quarterly Training Fee</Ustrd></RmtInf>
+            </DrctDbtTxInf>
+        </PmtInf>
+        <PmtInf>
+            <PmtInfId>PMT001</PmtInfId>
+            <PmtMtd>DD</PmtMtd>
+            <BtchBookg>true</BtchBookg>
+            <NbOfTxs>1</NbOfTxs>
+            <CtrlSum>50.00</CtrlSum>
+            <PmtTpInf>
+                <SvcLvl><Cd>SEPA</Cd></SvcLvl>
+                <LclInstrm><Cd>CORE</Cd></LclInstrm>
+                <SeqTp>FRST</SeqTp>
+            </PmtTpInf>
+            <ReqdColltnDt>2025-08-30</ReqdColltnDt>
+            <Cdtr>
+                <Nm>Example Sports Club e.V.</Nm>
+            </Cdtr>
+            <CdtrAcct>
+                <Id><IBAN>DE11123456789012345678</IBAN></Id>
+            </CdtrAcct>
+            <CdtrAgt><FinInstnId><BIC>FAKEDEFFXXX</BIC></FinInstnId></CdtrAgt>
+            <CdtrSchmeId>
+                <Id><PrvtId><Othr><Id>DE99ZZZ00000000001</Id><SchmeNm><Prtry>SEPA</Prtry></SchmeNm></Othr></PrvtId></Id>
+            </CdtrSchmeId>
+            <DrctDbtTxInf>
+                <PmtId><EndToEndId>INV001</EndToEndId></PmtId>
+                <InstdAmt Ccy="EUR">50.00</InstdAmt>
+                <DrctDbtTx>
+                    <MndtRltdInf><MndtId>MANDATE001</MndtId><DtOfSgntr>2025-08-01</DtOfSgntr></MndtRltdInf>
+                </DrctDbtTx>
+                <DbtrAgt><FinInstnId><BIC>FAKEDEPPXXX</BIC></FinInstnId></DbtrAgt>
+                <Dbtr><Nm>Max Mustermann</Nm></Dbtr>
+                <DbtrAcct><Id><IBAN>DE44123456789012345678</IBAN></Id></DbtrAcct>
+                <RmtInf><Ustrd>Membership Fee August</Ustrd></RmtInf>
+            </DrctDbtTxInf>
+        </PmtInf>
+        <PmtInf>
+            <PmtInfId>PMT002</PmtInfId>
+            <PmtMtd>DD</PmtMtd>
+            <BtchBookg>true</BtchBookg>
+            <NbOfTxs>1</NbOfTxs>
+            <CtrlSum>75.00</CtrlSum>
+            <PmtTpInf>
+                <SvcLvl><Cd>SEPA</Cd></SvcLvl>
+                <LclInstrm><Cd>CORE</Cd></LclInstrm>
+                <SeqTp>RCUR</SeqTp>
+            </PmtTpInf>
+            <ReqdColltnDt>2025-08-30</ReqdColltnDt>
+            <Cdtr><Nm>Example Sports Club e.V.</Nm></Cdtr>
+            <CdtrAcct><Id><IBAN>DE11123456789012345678</IBAN></Id></CdtrAcct>
+            <CdtrAgt><FinInstnId><BIC>FAKEDEFFXXX</BIC></FinInstnId></CdtrAgt>
+            <DrctDbtTxInf>
+                <PmtId><EndToEndId>INV002</EndToEndId></PmtId>
+                <InstdAmt Ccy="EUR">75.00</InstdAmt>
+                <DrctDbtTx>
+                    <MndtRltdInf><MndtId>MANDATE002</MndtId><DtOfSgntr>2024-09-15</DtOfSgntr></MndtRltdInf>
+                </DrctDbtTx>
+                <DbtrAgt><FinInstnId><BIC>FAKEXYZZXXX</BIC></FinInstnId></DbtrAgt>
+                <Dbtr><Nm>Jane Doe</Nm></Dbtr>
+                <DbtrAcct><Id><IBAN>DE55123456789012345678</IBAN></Id></DbtrAcct>
+                <RmtInf><Ustrd>Quarterly Training Fee</Ustrd></RmtInf>
+            </DrctDbtTxInf>
+        </PmtInf>
+        <PmtInf>
+            <PmtInfId>PMT001</PmtInfId>
+            <PmtMtd>DD</PmtMtd>
+            <BtchBookg>true</BtchBookg>
+            <NbOfTxs>1</NbOfTxs>
+            <CtrlSum>50.00</CtrlSum>
+            <PmtTpInf>
+                <SvcLvl><Cd>SEPA</Cd></SvcLvl>
+                <LclInstrm><Cd>CORE</Cd></LclInstrm>
+                <SeqTp>FRST</SeqTp>
+            </PmtTpInf>
+            <ReqdColltnDt>2025-08-30</ReqdColltnDt>
+            <Cdtr>
+                <Nm>Example Sports Club e.V.</Nm>
+            </Cdtr>
+            <CdtrAcct>
+                <Id><IBAN>DE11123456789012345678</IBAN></Id>
+            </CdtrAcct>
+            <CdtrAgt><FinInstnId><BIC>FAKEDEFFXXX</BIC></FinInstnId></CdtrAgt>
+            <CdtrSchmeId>
+                <Id><PrvtId><Othr><Id>DE99ZZZ00000000001</Id><SchmeNm><Prtry>SEPA</Prtry></SchmeNm></Othr></PrvtId></Id>
+            </CdtrSchmeId>
+            <DrctDbtTxInf>
+                <PmtId><EndToEndId>INV001</EndToEndId></PmtId>
+                <InstdAmt Ccy="EUR">50.00</InstdAmt>
+                <DrctDbtTx>
+                    <MndtRltdInf><MndtId>MANDATE001</MndtId><DtOfSgntr>2025-08-01</DtOfSgntr></MndtRltdInf>
+                </DrctDbtTx>
+                <DbtrAgt><FinInstnId><BIC>FAKEDEPPXXX</BIC></FinInstnId></DbtrAgt>
+                <Dbtr><Nm>Max Mustermann</Nm></Dbtr>
+                <DbtrAcct><Id><IBAN>DE44123456789012345678</IBAN></Id></DbtrAcct>
+                <RmtInf><Ustrd>Membership Fee August</Ustrd></RmtInf>
+            </DrctDbtTxInf>
+        </PmtInf>
+        <PmtInf>
+            <PmtInfId>PMT002</PmtInfId>
+            <PmtMtd>DD</PmtMtd>
+            <BtchBookg>true</BtchBookg>
+            <NbOfTxs>1</NbOfTxs>
+            <CtrlSum>75.00</CtrlSum>
+            <PmtTpInf>
+                <SvcLvl><Cd>SEPA</Cd></SvcLvl>
+                <LclInstrm><Cd>CORE</Cd></LclInstrm>
+                <SeqTp>RCUR</SeqTp>
+            </PmtTpInf>
+            <ReqdColltnDt>2025-08-30</ReqdColltnDt>
+            <Cdtr><Nm>Example Sports Club e.V.</Nm></Cdtr>
+            <CdtrAcct><Id><IBAN>DE11123456789012345678</IBAN></Id></CdtrAcct>
+            <CdtrAgt><FinInstnId><BIC>FAKEDEFFXXX</BIC></FinInstnId></CdtrAgt>
+            <DrctDbtTxInf>
+                <PmtId><EndToEndId>INV002</EndToEndId></PmtId>
+                <InstdAmt Ccy="EUR">75.00</InstdAmt>
+                <DrctDbtTx>
+                    <MndtRltdInf><MndtId>MANDATE002</MndtId><DtOfSgntr>2024-09-15</DtOfSgntr></MndtRltdInf>
+                </DrctDbtTx>
+                <DbtrAgt><FinInstnId><BIC>FAKEXYZZXXX</BIC></FinInstnId></DbtrAgt>
+                <Dbtr><Nm>Jane Doe</Nm></Dbtr>
+                <DbtrAcct><Id><IBAN>DE55123456789012345678</IBAN></Id></DbtrAcct>
+                <RmtInf><Ustrd>Quarterly Training Fee</Ustrd></RmtInf>
+            </DrctDbtTxInf>
+        </PmtInf>
+        <PmtInf>
+            <PmtInfId>PMT001</PmtInfId>
+            <PmtMtd>DD</PmtMtd>
+            <BtchBookg>true</BtchBookg>
+            <NbOfTxs>1</NbOfTxs>
+            <CtrlSum>50.00</CtrlSum>
+            <PmtTpInf>
+                <SvcLvl><Cd>SEPA</Cd></SvcLvl>
+                <LclInstrm><Cd>CORE</Cd></LclInstrm>
+                <SeqTp>FRST</SeqTp>
+            </PmtTpInf>
+            <ReqdColltnDt>2025-08-30</ReqdColltnDt>
+            <Cdtr>
+                <Nm>Example Sports Club e.V.</Nm>
+            </Cdtr>
+            <CdtrAcct>
+                <Id><IBAN>DE11123456789012345678</IBAN></Id>
+            </CdtrAcct>
+            <CdtrAgt><FinInstnId><BIC>FAKEDEFFXXX</BIC></FinInstnId></CdtrAgt>
+            <CdtrSchmeId>
+                <Id><PrvtId><Othr><Id>DE99ZZZ00000000001</Id><SchmeNm><Prtry>SEPA</Prtry></SchmeNm></Othr></PrvtId></Id>
+            </CdtrSchmeId>
+            <DrctDbtTxInf>
+                <PmtId><EndToEndId>INV001</EndToEndId></PmtId>
+                <InstdAmt Ccy="EUR">50.00</InstdAmt>
+                <DrctDbtTx>
+                    <MndtRltdInf><MndtId>MANDATE001</MndtId><DtOfSgntr>2025-08-01</DtOfSgntr></MndtRltdInf>
+                </DrctDbtTx>
+                <DbtrAgt><FinInstnId><BIC>FAKEDEPPXXX</BIC></FinInstnId></DbtrAgt>
+                <Dbtr><Nm>Max Mustermann</Nm></Dbtr>
+                <DbtrAcct><Id><IBAN>DE44123456789012345678</IBAN></Id></DbtrAcct>
+                <RmtInf><Ustrd>Membership Fee August</Ustrd></RmtInf>
+            </DrctDbtTxInf>
+        </PmtInf>
+        <PmtInf>
+            <PmtInfId>PMT002</PmtInfId>
+            <PmtMtd>DD</PmtMtd>
+            <BtchBookg>true</BtchBookg>
+            <NbOfTxs>1</NbOfTxs>
+            <CtrlSum>75.00</CtrlSum>
+            <PmtTpInf>
+                <SvcLvl><Cd>SEPA</Cd></SvcLvl>
+                <LclInstrm><Cd>CORE</Cd></LclInstrm>
+                <SeqTp>RCUR</SeqTp>
+            </PmtTpInf>
+            <ReqdColltnDt>2025-08-30</ReqdColltnDt>
+            <Cdtr><Nm>Example Sports Club e.V.</Nm></Cdtr>
+            <CdtrAcct><Id><IBAN>DE11123456789012345678</IBAN></Id></CdtrAcct>
+            <CdtrAgt><FinInstnId><BIC>FAKEDEFFXXX</BIC></FinInstnId></CdtrAgt>
+            <DrctDbtTxInf>
+                <PmtId><EndToEndId>INV002</EndToEndId></PmtId>
+                <InstdAmt Ccy="EUR">75.00</InstdAmt>
+                <DrctDbtTx>
+                    <MndtRltdInf><MndtId>MANDATE002</MndtId><DtOfSgntr>2024-09-15</DtOfSgntr></MndtRltdInf>
+                </DrctDbtTx>
+                <DbtrAgt><FinInstnId><BIC>FAKEXYZZXXX</BIC></FinInstnId></DbtrAgt>
+                <Dbtr><Nm>Jane Doe</Nm></Dbtr>
+                <DbtrAcct><Id><IBAN>DE55123456789012345678</IBAN></Id></DbtrAcct>
+                <RmtInf><Ustrd>Quarterly Training Fee</Ustrd></RmtInf>
+            </DrctDbtTxInf>
+        </PmtInf>
+        <PmtInf>
+            <PmtInfId>PMT001</PmtInfId>
+            <PmtMtd>DD</PmtMtd>
+            <BtchBookg>true</BtchBookg>
+            <NbOfTxs>1</NbOfTxs>
+            <CtrlSum>50.00</CtrlSum>
+            <PmtTpInf>
+                <SvcLvl><Cd>SEPA</Cd></SvcLvl>
+                <LclInstrm><Cd>CORE</Cd></LclInstrm>
+                <SeqTp>FRST</SeqTp>
+            </PmtTpInf>
+            <ReqdColltnDt>2025-08-30</ReqdColltnDt>
+            <Cdtr>
+                <Nm>Example Sports Club e.V.</Nm>
+            </Cdtr>
+            <CdtrAcct>
+                <Id><IBAN>DE11123456789012345678</IBAN></Id>
+            </CdtrAcct>
+            <CdtrAgt><FinInstnId><BIC>FAKEDEFFXXX</BIC></FinInstnId></CdtrAgt>
+            <CdtrSchmeId>
+                <Id><PrvtId><Othr><Id>DE99ZZZ00000000001</Id><SchmeNm><Prtry>SEPA</Prtry></SchmeNm></Othr></PrvtId></Id>
+            </CdtrSchmeId>
+            <DrctDbtTxInf>
+                <PmtId><EndToEndId>INV001</EndToEndId></PmtId>
+                <InstdAmt Ccy="EUR">50.00</InstdAmt>
+                <DrctDbtTx>
+                    <MndtRltdInf><MndtId>MANDATE001</MndtId><DtOfSgntr>2025-08-01</DtOfSgntr></MndtRltdInf>
+                </DrctDbtTx>
+                <DbtrAgt><FinInstnId><BIC>FAKEDEPPXXX</BIC></FinInstnId></DbtrAgt>
+                <Dbtr><Nm>Max Mustermann</Nm></Dbtr>
+                <DbtrAcct><Id><IBAN>DE44123456789012345678</IBAN></Id></DbtrAcct>
+                <RmtInf><Ustrd>Membership Fee August</Ustrd></RmtInf>
+            </DrctDbtTxInf>
+        </PmtInf>
+        <PmtInf>
+            <PmtInfId>PMT002</PmtInfId>
+            <PmtMtd>DD</PmtMtd>
+            <BtchBookg>true</BtchBookg>
+            <NbOfTxs>1</NbOfTxs>
+            <CtrlSum>75.00</CtrlSum>
+            <PmtTpInf>
+                <SvcLvl><Cd>SEPA</Cd></SvcLvl>
+                <LclInstrm><Cd>CORE</Cd></LclInstrm>
+                <SeqTp>RCUR</SeqTp>
+            </PmtTpInf>
+            <ReqdColltnDt>2025-08-30</ReqdColltnDt>
+            <Cdtr><Nm>Example Sports Club e.V.</Nm></Cdtr>
+            <CdtrAcct><Id><IBAN>DE11123456789012345678</IBAN></Id></CdtrAcct>
+            <CdtrAgt><FinInstnId><BIC>FAKEDEFFXXX</BIC></FinInstnId></CdtrAgt>
+            <DrctDbtTxInf>
+                <PmtId><EndToEndId>INV002</EndToEndId></PmtId>
+                <InstdAmt Ccy="EUR">75.00</InstdAmt>
+                <DrctDbtTx>
+                    <MndtRltdInf><MndtId>MANDATE002</MndtId><DtOfSgntr>2024-09-15</DtOfSgntr></MndtRltdInf>
+                </DrctDbtTx>
+                <DbtrAgt><FinInstnId><BIC>FAKEXYZZXXX</BIC></FinInstnId></DbtrAgt>
+                <Dbtr><Nm>Jane Doe</Nm></Dbtr>
+                <DbtrAcct><Id><IBAN>DE55123456789012345678</IBAN></Id></DbtrAcct>
+                <RmtInf><Ustrd>Quarterly Training Fee</Ustrd></RmtInf>
+            </DrctDbtTxInf>
+        </PmtInf>
+        <PmtInf>
+            <PmtInfId>PMT001</PmtInfId>
+            <PmtMtd>DD</PmtMtd>
+            <BtchBookg>true</BtchBookg>
+            <NbOfTxs>1</NbOfTxs>
+            <CtrlSum>50.00</CtrlSum>
+            <PmtTpInf>
+                <SvcLvl><Cd>SEPA</Cd></SvcLvl>
+                <LclInstrm><Cd>CORE</Cd></LclInstrm>
+                <SeqTp>FRST</SeqTp>
+            </PmtTpInf>
+            <ReqdColltnDt>2025-08-30</ReqdColltnDt>
+            <Cdtr>
+                <Nm>Example Sports Club e.V.</Nm>
+            </Cdtr>
+            <CdtrAcct>
+                <Id><IBAN>DE11123456789012345678</IBAN></Id>
+            </CdtrAcct>
+            <CdtrAgt><FinInstnId><BIC>FAKEDEFFXXX</BIC></FinInstnId></CdtrAgt>
+            <CdtrSchmeId>
+                <Id><PrvtId><Othr><Id>DE99ZZZ00000000001</Id><SchmeNm><Prtry>SEPA</Prtry></SchmeNm></Othr></PrvtId></Id>
+            </CdtrSchmeId>
+            <DrctDbtTxInf>
+                <PmtId><EndToEndId>INV001</EndToEndId></PmtId>
+                <InstdAmt Ccy="EUR">50.00</InstdAmt>
+                <DrctDbtTx>
+                    <MndtRltdInf><MndtId>MANDATE001</MndtId><DtOfSgntr>2025-08-01</DtOfSgntr></MndtRltdInf>
+                </DrctDbtTx>
+                <DbtrAgt><FinInstnId><BIC>FAKEDEPPXXX</BIC></FinInstnId></DbtrAgt>
+                <Dbtr><Nm>Max Mustermann</Nm></Dbtr>
+                <DbtrAcct><Id><IBAN>DE44123456789012345678</IBAN></Id></DbtrAcct>
+                <RmtInf><Ustrd>Membership Fee August</Ustrd></RmtInf>
+            </DrctDbtTxInf>
+        </PmtInf>
+        <PmtInf>
+            <PmtInfId>PMT002</PmtInfId>
+            <PmtMtd>DD</PmtMtd>
+            <BtchBookg>true</BtchBookg>
+            <NbOfTxs>1</NbOfTxs>
+            <CtrlSum>75.00</CtrlSum>
+            <PmtTpInf>
+                <SvcLvl><Cd>SEPA</Cd></SvcLvl>
+                <LclInstrm><Cd>CORE</Cd></LclInstrm>
+                <SeqTp>RCUR</SeqTp>
+            </PmtTpInf>
+            <ReqdColltnDt>2025-08-30</ReqdColltnDt>
+            <Cdtr><Nm>Example Sports Club e.V.</Nm></Cdtr>
+            <CdtrAcct><Id><IBAN>DE11123456789012345678</IBAN></Id></CdtrAcct>
+            <CdtrAgt><FinInstnId><BIC>FAKEDEFFXXX</BIC></FinInstnId></CdtrAgt>
+            <DrctDbtTxInf>
+                <PmtId><EndToEndId>INV002</EndToEndId></PmtId>
+                <InstdAmt Ccy="EUR">75.00</InstdAmt>
+                <DrctDbtTx>
+                    <MndtRltdInf><MndtId>MANDATE002</MndtId><DtOfSgntr>2024-09-15</DtOfSgntr></MndtRltdInf>
+                </DrctDbtTx>
+                <DbtrAgt><FinInstnId><BIC>FAKEXYZZXXX</BIC></FinInstnId></DbtrAgt>
+                <Dbtr><Nm>Jane Doe</Nm></Dbtr>
+                <DbtrAcct><Id><IBAN>DE55123456789012345678</IBAN></Id></DbtrAcct>
+                <RmtInf><Ustrd>Quarterly Training Fee</Ustrd></RmtInf>
+            </DrctDbtTxInf>
+        </PmtInf>
+        <PmtInf>
+            <PmtInfId>PMT001</PmtInfId>
+            <PmtMtd>DD</PmtMtd>
+            <BtchBookg>true</BtchBookg>
+            <NbOfTxs>1</NbOfTxs>
+            <CtrlSum>50.00</CtrlSum>
+            <PmtTpInf>
+                <SvcLvl><Cd>SEPA</Cd></SvcLvl>
+                <LclInstrm><Cd>CORE</Cd></LclInstrm>
+                <SeqTp>FRST</SeqTp>
+            </PmtTpInf>
+            <ReqdColltnDt>2025-08-30</ReqdColltnDt>
+            <Cdtr>
+                <Nm>Example Sports Club e.V.</Nm>
+            </Cdtr>
+            <CdtrAcct>
+                <Id><IBAN>DE11123456789012345678</IBAN></Id>
+            </CdtrAcct>
+            <CdtrAgt><FinInstnId><BIC>FAKEDEFFXXX</BIC></FinInstnId></CdtrAgt>
+            <CdtrSchmeId>
+                <Id><PrvtId><Othr><Id>DE99ZZZ00000000001</Id><SchmeNm><Prtry>SEPA</Prtry></SchmeNm></Othr></PrvtId></Id>
+            </CdtrSchmeId>
+            <DrctDbtTxInf>
+                <PmtId><EndToEndId>INV001</EndToEndId></PmtId>
+                <InstdAmt Ccy="EUR">50.00</InstdAmt>
+                <DrctDbtTx>
+                    <MndtRltdInf><MndtId>MANDATE001</MndtId><DtOfSgntr>2025-08-01</DtOfSgntr></MndtRltdInf>
+                </DrctDbtTx>
+                <DbtrAgt><FinInstnId><BIC>FAKEDEPPXXX</BIC></FinInstnId></DbtrAgt>
+                <Dbtr><Nm>Max Mustermann</Nm></Dbtr>
+                <DbtrAcct><Id><IBAN>DE44123456789012345678</IBAN></Id></DbtrAcct>
+                <RmtInf><Ustrd>Membership Fee August</Ustrd></RmtInf>
+            </DrctDbtTxInf>
+        </PmtInf>
+        <PmtInf>
+            <PmtInfId>PMT002</PmtInfId>
+            <PmtMtd>DD</PmtMtd>
+            <BtchBookg>true</BtchBookg>
+            <NbOfTxs>1</NbOfTxs>
+            <CtrlSum>75.00</CtrlSum>
+            <PmtTpInf>
+                <SvcLvl><Cd>SEPA</Cd></SvcLvl>
+                <LclInstrm><Cd>CORE</Cd></LclInstrm>
+                <SeqTp>RCUR</SeqTp>
+            </PmtTpInf>
+            <ReqdColltnDt>2025-08-30</ReqdColltnDt>
+            <Cdtr><Nm>Example Sports Club e.V.</Nm></Cdtr>
+            <CdtrAcct><Id><IBAN>DE11123456789012345678</IBAN></Id></CdtrAcct>
+            <CdtrAgt><FinInstnId><BIC>FAKEDEFFXXX</BIC></FinInstnId></CdtrAgt>
+            <DrctDbtTxInf>
+                <PmtId><EndToEndId>INV002</EndToEndId></PmtId>
+                <InstdAmt Ccy="EUR">75.00</InstdAmt>
+                <DrctDbtTx>
+                    <MndtRltdInf><MndtId>MANDATE002</MndtId><DtOfSgntr>2024-09-15</DtOfSgntr></MndtRltdInf>
+                </DrctDbtTx>
+                <DbtrAgt><FinInstnId><BIC>FAKEXYZZXXX</BIC></FinInstnId></DbtrAgt>
+                <Dbtr><Nm>Jane Doe</Nm></Dbtr>
+                <DbtrAcct><Id><IBAN>DE55123456789012345678</IBAN></Id></DbtrAcct>
+                <RmtInf><Ustrd>Quarterly Training Fee</Ustrd></RmtInf>
+            </DrctDbtTxInf>
+        </PmtInf>
+        <PmtInf>
+            <PmtInfId>PMT001</PmtInfId>
+            <PmtMtd>DD</PmtMtd>
+            <BtchBookg>true</BtchBookg>
+            <NbOfTxs>1</NbOfTxs>
+            <CtrlSum>50.00</CtrlSum>
+            <PmtTpInf>
+                <SvcLvl><Cd>SEPA</Cd></SvcLvl>
+                <LclInstrm><Cd>CORE</Cd></LclInstrm>
+                <SeqTp>FRST</SeqTp>
+            </PmtTpInf>
+            <ReqdColltnDt>2025-08-30</ReqdColltnDt>
+            <Cdtr>
+                <Nm>Example Sports Club e.V.</Nm>
+            </Cdtr>
+            <CdtrAcct>
+                <Id><IBAN>DE11123456789012345678</IBAN></Id>
+            </CdtrAcct>
+            <CdtrAgt><FinInstnId><BIC>FAKEDEFFXXX</BIC></FinInstnId></CdtrAgt>
+            <CdtrSchmeId>
+                <Id><PrvtId><Othr><Id>DE99ZZZ00000000001</Id><SchmeNm><Prtry>SEPA</Prtry></SchmeNm></Othr></PrvtId></Id>
+            </CdtrSchmeId>
+            <DrctDbtTxInf>
+                <PmtId><EndToEndId>INV001</EndToEndId></PmtId>
+                <InstdAmt Ccy="EUR">50.00</InstdAmt>
+                <DrctDbtTx>
+                    <MndtRltdInf><MndtId>MANDATE001</MndtId><DtOfSgntr>2025-08-01</DtOfSgntr></MndtRltdInf>
+                </DrctDbtTx>
+                <DbtrAgt><FinInstnId><BIC>FAKEDEPPXXX</BIC></FinInstnId></DbtrAgt>
+                <Dbtr><Nm>Max Mustermann</Nm></Dbtr>
+                <DbtrAcct><Id><IBAN>DE44123456789012345678</IBAN></Id></DbtrAcct>
+                <RmtInf><Ustrd>Membership Fee August</Ustrd></RmtInf>
+            </DrctDbtTxInf>
+        </PmtInf>
+        <PmtInf>
+            <PmtInfId>PMT002</PmtInfId>
+            <PmtMtd>DD</PmtMtd>
+            <BtchBookg>true</BtchBookg>
+            <NbOfTxs>1</NbOfTxs>
+            <CtrlSum>75.00</CtrlSum>
+            <PmtTpInf>
+                <SvcLvl><Cd>SEPA</Cd></SvcLvl>
+                <LclInstrm><Cd>CORE</Cd></LclInstrm>
+                <SeqTp>RCUR</SeqTp>
+            </PmtTpInf>
+            <ReqdColltnDt>2025-08-30</ReqdColltnDt>
+            <Cdtr><Nm>Example Sports Club e.V.</Nm></Cdtr>
+            <CdtrAcct><Id><IBAN>DE11123456789012345678</IBAN></Id></CdtrAcct>
+            <CdtrAgt><FinInstnId><BIC>FAKEDEFFXXX</BIC></FinInstnId></CdtrAgt>
+            <DrctDbtTxInf>
+                <PmtId><EndToEndId>INV002</EndToEndId></PmtId>
+                <InstdAmt Ccy="EUR">75.00</InstdAmt>
+                <DrctDbtTx>
+                    <MndtRltdInf><MndtId>MANDATE002</MndtId><DtOfSgntr>2024-09-15</DtOfSgntr></MndtRltdInf>
+                </DrctDbtTx>
+                <DbtrAgt><FinInstnId><BIC>FAKEXYZZXXX</BIC></FinInstnId></DbtrAgt>
+                <Dbtr><Nm>Jane Doe</Nm></Dbtr>
+                <DbtrAcct><Id><IBAN>DE55123456789012345678</IBAN></Id></DbtrAcct>
+                <RmtInf><Ustrd>Quarterly Training Fee</Ustrd></RmtInf>
+            </DrctDbtTxInf>
+        </PmtInf>
+    </CstmrDrctDbtInitn>
+</Document>


### PR DESCRIPTION
Fixes https://github.com/nemiah/phpFinTS/issues/490

this PR adds lazy quantifiers to the regex validating CtrlSum and others in SendSEPADirectDebit.
- The first commit has a failing test (I didn't know the package didn't have a CI pipeline) 
- The second commit creates a CI pipeline
- The third commit adds a code fix - and test passes.
