### PR TITLE
Allow minor version update on composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,9 +17,9 @@
     "ext-mbstring": "*"
   },
   "require-dev": {
-    "phpunit/phpunit": "9.5.*",
-    "php-mock/php-mock-phpunit": "2.6.*",
-    "friendsofphp/php-cs-fixer": "3.*"
+    "phpunit/phpunit": "^9.5",
+    "php-mock/php-mock-phpunit": "^2.6",
+    "friendsofphp/php-cs-fixer": "^3.0"
   },
   "suggest": {
     "monolog/monolog": "Allow sending log messages to a variety of different handlers",


### PR DESCRIPTION
We're locking few libraries in a minor version - allowing only patches. 
It's safe to allow minor versions updates.