### PR TITLE
Better schema check

### DIFF
--- a/lib/Fhp/Action/SendSEPADirectDebit.php
+++ b/lib/Fhp/Action/SendSEPADirectDebit.php
@@ -151,13 +151,13 @@ class SendSEPADirectDebit extends BaseAction
         // Sometimes the Bank reports supported schemas with a "_GBIC_X" postfix.
         // GIBC_X stands for German Banking Industry Committee and a version counter.
         $xmlSchema = $this->painNamespace;
-        $matchingSchemas = array_filter($supportedPainNamespaces, function($key) use ($xmlSchema) {
+        $matchingSchemas = array_filter($supportedPainNamespaces, function($value) use ($xmlSchema) {
             // For example urn:iso:std:iso:20022:tech:xsd:pain.008.001.08 from the xml matches
             // urn:iso:std:iso:20022:tech:xsd:pain.008.001.08_GBIC_4
-            return strpos($key, $xmlSchema) === 0;
-        }, ARRAY_FILTER_USE_KEY);
+            return str_starts_with($value, $xmlSchema);
+        });
 
-        if (count($matchingSchemas) > 0) {
+        if (count($matchingSchemas) === 0) {
             throw new UnsupportedException("The bank does not support the XML schema $this->painNamespace, but only "
                 . implode(', ', $supportedPainNamespaces));
         }

--- a/lib/Fhp/Action/SendSEPARealtimeTransfer.php
+++ b/lib/Fhp/Action/SendSEPARealtimeTransfer.php
@@ -70,13 +70,13 @@ class SendSEPARealtimeTransfer extends BaseAction
         // Sometimes the Bank reports supported schemas with a "_GBIC_X" postfix.
         // GIBC_X stands for German Banking Industry Committee and a version counter.
         $xmlSchema = $this->xmlSchema;
-        $matchingSchemas = array_filter($supportedSchemas, function($key) use ($xmlSchema) {
+        $matchingSchemas = array_filter($supportedSchemas, function($value) use ($xmlSchema) {
             // For example urn:iso:std:iso:20022:tech:xsd:pain.001.001.09 from the xml matches
             // urn:iso:std:iso:20022:tech:xsd:pain.001.001.09_GBIC_4
-            return strpos($key, $xmlSchema) === 0;
-        }, ARRAY_FILTER_USE_KEY);
+            return str_starts_with($value, $xmlSchema);
+        });
 
-        if (count($matchingSchemas) > 0) {
+        if (count($matchingSchemas) === 0) {
             throw new UnsupportedException("The bank does not support the XML schema $this->xmlSchema, but only "
                 . implode(', ', $supportedSchemas));
         }

--- a/lib/Fhp/Action/SendSEPATransfer.php
+++ b/lib/Fhp/Action/SendSEPATransfer.php
@@ -93,13 +93,13 @@ class SendSEPATransfer extends BaseAction
         // Sometimes the Bank reports supported schemas with a "_GBIC_X" postfix.
         // GIBC_X stands for German Banking Industry Committee and a version counter.
         $xmlSchema = $this->xmlSchema;
-        $matchingSchemas = array_filter($supportedSchemas, function($key) use ($xmlSchema) {
+        $matchingSchemas = array_filter($supportedSchemas, function($value) use ($xmlSchema) {
             // For example urn:iso:std:iso:20022:tech:xsd:pain.001.001.09 from the xml matches
             // urn:iso:std:iso:20022:tech:xsd:pain.001.001.09_GBIC_4
-            return strpos($key, $xmlSchema) === 0;
-        }, ARRAY_FILTER_USE_KEY);
+            return str_starts_with($value, $xmlSchema);
+        });
 
-        if (count($matchingSchemas) > 0) {
+        if (count($matchingSchemas) === 0) {
             throw new UnsupportedException("The bank does not support the XML schema $this->xmlSchema, but only "
                 . implode(', ', $supportedSchemas));
         }


### PR DESCRIPTION
This add support for `pain.001.001.09` for transfers, and also ignores the GBIC_X postfix in the xml namespaces the bank reports supporting.

refs #493 