### PR TITLE
Use the UnterstuetzteSEPADatenformateTrait in all Actions to avoid xml namespace missmatches

### DIFF
--- a/lib/Fhp/Action/SendSEPADirectDebit.php
+++ b/lib/Fhp/Action/SendSEPADirectDebit.php
@@ -138,14 +138,14 @@ class SendSEPADirectDebit extends BaseAction
 
         if ($hidxes->getVersion() === 2) {
             /** @var HIDMESv2|HIDSESv2 $hidxes */
-            $supportedPainNamespaces = $hidxes->getParameter()->unterstuetzteSEPADatenformate;
+            $supportedPainNamespaces = $hidxes->getParameter()->getUnterstuetzteSEPADatenformate();
         }
 
         // If there are no SEPA formats available in the HIDXES Parameters, we look to the general formats
         if (!is_array($supportedPainNamespaces) || count($supportedPainNamespaces) === 0) {
             /** @var HISPAS $hispas */
             $hispas = $bpd->requireLatestSupportedParameters('HISPAS');
-            $supportedPainNamespaces = $hispas->getParameter()->getUnterstuetzteSepaDatenformate();
+            $supportedPainNamespaces = $hispas->getParameter()->getUnterstuetzteSEPADatenformate();
         }
 
         // Sometimes the Bank reports supported schemas with a "_GBIC_X" postfix.

--- a/lib/Fhp/Action/SendSEPARealtimeTransfer.php
+++ b/lib/Fhp/Action/SendSEPARealtimeTransfer.php
@@ -58,13 +58,13 @@ class SendSEPARealtimeTransfer extends BaseAction
         /** @var HIIPZSv1|HIIPZSv2 $hiipzs */
         $hiipzs = $bpd->requireLatestSupportedParameters('HIIPZS');
 
-        $supportedSchemas = $hiipzs->parameter->unterstuetzteSEPADatenformate;
+        $supportedSchemas = $hiipzs->parameter->getUnterstuetzteSEPADatenformate();
 
         // If there are no SEPA formats available in the HIIPZS Parameters, we look to the general formats
         if (is_null($supportedSchemas)) {
             /** @var HISPAS $hispas */
             $hispas = $bpd->requireLatestSupportedParameters('HISPAS');
-            $supportedSchemas = $hispas->getParameter()->getUnterstuetzteSepaDatenformate();
+            $supportedSchemas = $hispas->getParameter()->getUnterstuetzteSEPADatenformate();
         }
 
         // Sometimes the Bank reports supported schemas with a "_GBIC_X" postfix.

--- a/lib/Fhp/Action/SendSEPATransfer.php
+++ b/lib/Fhp/Action/SendSEPATransfer.php
@@ -87,8 +87,8 @@ class SendSEPATransfer extends BaseAction
         }
 
         /** @var HISPAS $hispas */
-        $parameters = $bpd->requireLatestSupportedParameters('HISPAS');
-        $supportedSchemas = $parameters->getParameter()->getUnterstuetzteSepaDatenformate();
+        $hispas = $bpd->requireLatestSupportedParameters('HISPAS');
+        $supportedSchemas = $hispas->getParameter()->getUnterstuetzteSEPADatenformate();
 
         // Sometimes the Bank reports supported schemas with a "_GBIC_X" postfix.
         // GIBC_X stands for German Banking Industry Committee and a version counter.

--- a/lib/Fhp/Segment/BME/ParameterTerminierteSEPAFirmenSammellastschriftEinreichenV2.php
+++ b/lib/Fhp/Segment/BME/ParameterTerminierteSEPAFirmenSammellastschriftEinreichenV2.php
@@ -3,9 +3,13 @@
 namespace Fhp\Segment\BME;
 
 use Fhp\Segment\BSE\ParameterTerminierteSEPAFirmenLastschriftEinreichenV2;
+use Fhp\Segment\UnterstuetzteSEPADatenformate;
+use Fhp\Segment\UnterstuetzteSEPADatenformateTrait;
 
-class ParameterTerminierteSEPAFirmenSammellastschriftEinreichenV2 extends ParameterTerminierteSEPAFirmenLastschriftEinreichenV2
+class ParameterTerminierteSEPAFirmenSammellastschriftEinreichenV2 extends ParameterTerminierteSEPAFirmenLastschriftEinreichenV2 implements UnterstuetzteSEPADatenformate
 {
+    use UnterstuetzteSEPADatenformateTrait;
+
     public int $maximaleAnzahlDirectDebitTransferTransactionInformation;
     public bool $summenfeldBenoetigt;
     public bool $einzelbuchungErlaubt;

--- a/lib/Fhp/Segment/BSE/ParameterTerminierteSEPAFirmenEinzellastschriftEinreichenV2.php
+++ b/lib/Fhp/Segment/BSE/ParameterTerminierteSEPAFirmenEinzellastschriftEinreichenV2.php
@@ -2,8 +2,13 @@
 
 namespace Fhp\Segment\BSE;
 
-class ParameterTerminierteSEPAFirmenEinzellastschriftEinreichenV2 extends ParameterTerminierteSEPAFirmenLastschriftEinreichenV2
+use Fhp\Segment\UnterstuetzteSEPADatenformate;
+use Fhp\Segment\UnterstuetzteSEPADatenformateTrait;
+
+class ParameterTerminierteSEPAFirmenEinzellastschriftEinreichenV2 extends ParameterTerminierteSEPAFirmenLastschriftEinreichenV2 implements UnterstuetzteSEPADatenformate
 {
+    use UnterstuetzteSEPADatenformateTrait;
+
     /** Max Length: 4096 */
     public ?string $zulaessigePurposecodes = null;
 

--- a/lib/Fhp/Segment/DME/ParameterTerminierteSEPASammellastschriftEinreichenV2.php
+++ b/lib/Fhp/Segment/DME/ParameterTerminierteSEPASammellastschriftEinreichenV2.php
@@ -3,9 +3,13 @@
 namespace Fhp\Segment\DME;
 
 use Fhp\Segment\DSE\ParameterTerminierteSEPALastschriftEinreichenV2;
+use Fhp\Segment\UnterstuetzteSEPADatenformate;
+use Fhp\Segment\UnterstuetzteSEPADatenformateTrait;
 
-class ParameterTerminierteSEPASammellastschriftEinreichenV2 extends ParameterTerminierteSEPALastschriftEinreichenV2
+class ParameterTerminierteSEPASammellastschriftEinreichenV2 extends ParameterTerminierteSEPALastschriftEinreichenV2 implements UnterstuetzteSEPADatenformate
 {
+    use UnterstuetzteSEPADatenformateTrait;
+
     public int $maximaleAnzahlDirectDebitTransferTransactionInformation;
     public bool $summenfeldBenoetigt;
     public bool $einzelbuchungErlaubt;

--- a/lib/Fhp/Segment/DSE/HIDSESv1.php
+++ b/lib/Fhp/Segment/DSE/HIDSESv1.php
@@ -15,7 +15,7 @@ class HIDSESv1 extends BaseGeschaeftsvorfallparameter implements HIDXES
 {
     public ParameterTerminierteSEPAEinzellastschriftEinreichenV1 $parameter;
 
-    public function getParameter(): SEPADirectDebitMinimalLeadTimeProvider
+    public function getParameter(): ParameterTerminierteSEPAEinzellastschriftEinreichenV1
     {
         return $this->parameter;
     }

--- a/lib/Fhp/Segment/DSE/HIDSESv2.php
+++ b/lib/Fhp/Segment/DSE/HIDSESv2.php
@@ -15,7 +15,7 @@ class HIDSESv2 extends BaseGeschaeftsvorfallparameter implements HIDXES
 {
     public ParameterTerminierteSEPAEinzellastschriftEinreichenV2 $parameter;
 
-    public function getParameter(): SEPADirectDebitMinimalLeadTimeProvider
+    public function getParameter(): ParameterTerminierteSEPAEinzellastschriftEinreichenV2
     {
         return $this->parameter;
     }

--- a/lib/Fhp/Segment/DSE/ParameterTerminierteSEPAEinzellastschriftEinreichenV2.php
+++ b/lib/Fhp/Segment/DSE/ParameterTerminierteSEPAEinzellastschriftEinreichenV2.php
@@ -2,8 +2,13 @@
 
 namespace Fhp\Segment\DSE;
 
-class ParameterTerminierteSEPAEinzellastschriftEinreichenV2 extends ParameterTerminierteSEPALastschriftEinreichenV2
+use Fhp\Segment\UnterstuetzteSEPADatenformate;
+use Fhp\Segment\UnterstuetzteSEPADatenformateTrait;
+
+class ParameterTerminierteSEPAEinzellastschriftEinreichenV2 extends ParameterTerminierteSEPALastschriftEinreichenV2 implements UnterstuetzteSEPADatenformate
 {
+    use UnterstuetzteSEPADatenformateTrait;
+
     /** Max Length: 4096 */
     public ?string $zulaessigePurposecodes = null;
 

--- a/lib/Fhp/Segment/IPZ/ParameterSEPAInstantPaymentZahlungV1.php
+++ b/lib/Fhp/Segment/IPZ/ParameterSEPAInstantPaymentZahlungV1.php
@@ -3,6 +3,8 @@
 namespace Fhp\Segment\IPZ;
 
 use Fhp\Segment\BaseDeg;
+use Fhp\Segment\UnterstuetzteSEPADatenformate;
+use Fhp\Segment\UnterstuetzteSEPADatenformateTrait;
 
 /**
  * Parameter SEPA-Instant Payment Zahlung (Version 1)
@@ -10,8 +12,10 @@ use Fhp\Segment\BaseDeg;
  * @link https://www.hbci-zka.de/dokumente/spezifikation_deutsch/fintsv3/FinTS_3.0_Messages_Geschaeftsvorfaelle_2022-04-15_final_version.pdf
  * Section D
  */
-class ParameterSEPAInstantPaymentZahlungV1 extends BaseDeg
+class ParameterSEPAInstantPaymentZahlungV1 extends BaseDeg implements UnterstuetzteSEPADatenformate
 {
+    use UnterstuetzteSEPADatenformateTrait;
+
     /** Max Length: 4096 */
     public ?string $zulaessigePurposecodes = null;
 

--- a/lib/Fhp/Segment/IPZ/ParameterSEPAInstantPaymentZahlungV2.php
+++ b/lib/Fhp/Segment/IPZ/ParameterSEPAInstantPaymentZahlungV2.php
@@ -3,6 +3,8 @@
 namespace Fhp\lib\Fhp\Segment\IPZ;
 
 use Fhp\Segment\BaseDeg;
+use Fhp\Segment\UnterstuetzteSEPADatenformate;
+use Fhp\Segment\UnterstuetzteSEPADatenformateTrait;
 
 /**
  * Parameter SEPA-Instant Payment Zahlung (Version 2)
@@ -10,8 +12,10 @@ use Fhp\Segment\BaseDeg;
  * @link https://www.hbci-zka.de/dokumente/spezifikation_deutsch/fintsv3/FinTS_3.0_Messages_Geschaeftsvorfaelle_2022-04-15_final_version.pdf
  * Section D
  */
-class ParameterSEPAInstantPaymentZahlungV2 extends BaseDeg
+class ParameterSEPAInstantPaymentZahlungV2 extends BaseDeg implements UnterstuetzteSEPADatenformate
 {
+    use UnterstuetzteSEPADatenformateTrait;
+
     public bool $umwandlungNachSEPAUeberweisungZulaessigErlaubt;
 
     /** Max Length: 4096 */

--- a/lib/Fhp/Segment/SPA/ParameterSepaKontoverbindungAnfordern.php
+++ b/lib/Fhp/Segment/SPA/ParameterSepaKontoverbindungAnfordern.php
@@ -3,11 +3,12 @@
 
 namespace Fhp\Segment\SPA;
 
+use Fhp\Segment\UnterstuetzteSEPADatenformate;
+
 /**
  * Data Element Group: Parameter SEPA-Kontoverbindung anfordern
  */
-interface ParameterSepaKontoverbindungAnfordern
+interface ParameterSepaKontoverbindungAnfordern extends UnterstuetzteSEPADatenformate
 {
-    /** @return string[] */
-    public function getUnterstuetzteSepaDatenformate(): array;
+
 }

--- a/lib/Fhp/Segment/SPA/ParameterSepaKontoverbindungAnfordernV1.php
+++ b/lib/Fhp/Segment/SPA/ParameterSepaKontoverbindungAnfordernV1.php
@@ -4,6 +4,7 @@
 namespace Fhp\Segment\SPA;
 
 use Fhp\Segment\BaseDeg;
+use Fhp\Segment\UnterstuetzteSEPADatenformateTrait;
 
 /**
  * Data Element Group: Parameter SEPA-Kontoverbindung anfordern (Version 1)
@@ -13,7 +14,7 @@ use Fhp\Segment\BaseDeg;
  */
 class ParameterSepaKontoverbindungAnfordernV1 extends BaseDeg implements ParameterSepaKontoverbindungAnfordern
 {
-    use GetUnterstuetzteSepaDatenformateTrait;
+    use UnterstuetzteSEPADatenformateTrait;
 
     public bool $einzelkontenabrufErlaubt;
     public bool $nationaleKontoverbindungErlaubt;

--- a/lib/Fhp/Segment/SPA/ParameterSepaKontoverbindungAnfordernV2.php
+++ b/lib/Fhp/Segment/SPA/ParameterSepaKontoverbindungAnfordernV2.php
@@ -4,6 +4,7 @@
 namespace Fhp\Segment\SPA;
 
 use Fhp\Segment\BaseDeg;
+use Fhp\Segment\UnterstuetzteSEPADatenformateTrait;
 
 /**
  * Data Element Group: Parameter SEPA-Kontoverbindung anfordern (Version 2)
@@ -13,7 +14,7 @@ use Fhp\Segment\BaseDeg;
  */
 class ParameterSepaKontoverbindungAnfordernV2 extends BaseDeg implements ParameterSepaKontoverbindungAnfordern
 {
-    use GetUnterstuetzteSepaDatenformateTrait;
+    use UnterstuetzteSEPADatenformateTrait;
 
     public bool $einzelkontenabrufErlaubt;
     public bool $nationaleKontoverbindungErlaubt;

--- a/lib/Fhp/Segment/SPA/ParameterSepaKontoverbindungAnfordernV3.php
+++ b/lib/Fhp/Segment/SPA/ParameterSepaKontoverbindungAnfordernV3.php
@@ -4,6 +4,7 @@
 namespace Fhp\Segment\SPA;
 
 use Fhp\Segment\BaseDeg;
+use Fhp\Segment\UnterstuetzteSEPADatenformateTrait;
 
 /**
  * Data Element Group: Parameter SEPA-Kontoverbindung anfordern (Version 3)
@@ -13,7 +14,7 @@ use Fhp\Segment\BaseDeg;
  */
 class ParameterSepaKontoverbindungAnfordernV3 extends BaseDeg implements ParameterSepaKontoverbindungAnfordern
 {
-    use GetUnterstuetzteSepaDatenformateTrait;
+    use UnterstuetzteSEPADatenformateTrait;
 
     public bool $einzelkontenabrufErlaubt;
     public bool $nationaleKontoverbindungErlaubt;

--- a/lib/Fhp/Segment/UnterstuetzteSEPADatenformate.php
+++ b/lib/Fhp/Segment/UnterstuetzteSEPADatenformate.php
@@ -1,0 +1,10 @@
+<?php
+/** @noinspection PhpUnused */
+
+namespace Fhp\Segment;
+
+interface UnterstuetzteSEPADatenformate
+{
+    /** @return string[] */
+    public function getUnterstuetzteSEPADatenformate(): array;
+}

--- a/lib/Fhp/Segment/UnterstuetzteSEPADatenformateTrait.php
+++ b/lib/Fhp/Segment/UnterstuetzteSEPADatenformateTrait.php
@@ -1,15 +1,15 @@
 <?php
 
-namespace Fhp\Segment\SPA;
+namespace Fhp\Segment;
 
 /**
  * @link https://www.hbci-zka.de/dokumente/spezifikation_deutsch/fintsv3/FinTS_3.0_Messages_Geschaeftsvorfaelle_2015-08-07_final_version.pdf
  * Section: D ("Unterstützte SEPA-Datenformate")
  */
-trait GetUnterstuetzteSepaDatenformateTrait
+trait UnterstuetzteSEPADatenformateTrait
 {
     /** @return string[] */
-    public function getUnterstuetzteSepaDatenformate(): array
+    public function getUnterstuetzteSEPADatenformate(): array
     {
         // Something like "sepade.pain.00x.001.0y.xsd" is allowed here, which is not a valid SEPA XML URN / Namespace
         return array_map(function ($sepaUrn) {
@@ -18,6 +18,6 @@ trait GetUnterstuetzteSepaDatenformateTrait
                 'sepade:' => 'urn:iso:std:iso:20022:tech:xsd:',
                 '.xsd' => '',
             ]);
-        }, $this->unterstuetzteSepaDatenformate);
+        }, $this->unterstuetzteSepaDatenformate ?? $this->unterstuetzteSEPADatenformate ?? []);
     }
 }


### PR DESCRIPTION
Banks can report sepa xml namespaces as filenames like sepade:xsd*.xsd instead of urn:iso:std:iso:20022:tech:xsd:* this uses the existing trait that converts these namespaces in all actions that check xml namespaces.