### PR TITLE
Remove @inheritdoc annotations

### DIFF
--- a/lib/Fhp/Action/GetBalance.php
+++ b/lib/Fhp/Action/GetBalance.php
@@ -96,7 +96,6 @@ class GetBalance extends PaginateableAction
         return $this->response;
     }
 
-    /** {@inheritdoc} */
     protected function createRequest(BPD $bpd, ?UPD $upd)
     {
         /** @var BaseSegment $hisals */
@@ -115,7 +114,6 @@ class GetBalance extends PaginateableAction
         }
     }
 
-    /** {@inheritdoc} */
     public function processResponse(Message $response)
     {
         parent::processResponse($response);

--- a/lib/Fhp/Action/GetDepotAufstellung.php
+++ b/lib/Fhp/Action/GetDepotAufstellung.php
@@ -111,7 +111,6 @@ class GetDepotAufstellung extends PaginateableAction
         return $this->depotWert;
     }
 
-    /** {@inheritdoc} */
     protected function createRequest(BPD $bpd, ?UPD $upd)
     {
         /** @var HIWPDS $hiwpds */
@@ -125,7 +124,6 @@ class GetDepotAufstellung extends PaginateableAction
         }
     }
 
-    /** {@inheritdoc} */
     public function processResponse(Message $response)
     {
         parent::processResponse($response);

--- a/lib/Fhp/Action/GetSEPAAccounts.php
+++ b/lib/Fhp/Action/GetSEPAAccounts.php
@@ -47,7 +47,6 @@ class GetSEPAAccounts extends PaginateableAction
         return $this->accounts;
     }
 
-    /** {@inheritdoc} */
     protected function createRequest(BPD $bpd, ?UPD $upd)
     {
         /** @var BaseSegment $hispas */
@@ -64,7 +63,6 @@ class GetSEPAAccounts extends PaginateableAction
         }
     }
 
-    /** {@inheritdoc} */
     public function processResponse(Message $response)
     {
         parent::processResponse($response);

--- a/lib/Fhp/Action/GetSEPADirectDebitParameters.php
+++ b/lib/Fhp/Action/GetSEPADirectDebitParameters.php
@@ -56,7 +56,6 @@ class GetSEPADirectDebitParameters extends BaseAction
         }
     }
 
-    /** {@inheritdoc} */
     protected function createRequest(BPD $bpd, ?UPD $upd)
     {
         $this->hidxes = $bpd->requireLatestSupportedParameters(static::getHixxesSegmentName($this->directDebitType, $this->singleDirectDebit));

--- a/lib/Fhp/Action/GetStatementOfAccount.php
+++ b/lib/Fhp/Action/GetStatementOfAccount.php
@@ -147,7 +147,6 @@ class GetStatementOfAccount extends PaginateableAction
         return $this->statement;
     }
 
-    /** {@inheritdoc} */
     protected function createRequest(BPD $bpd, ?UPD $upd)
     {
         $this->bankName = $bpd->getBankName();
@@ -171,7 +170,6 @@ class GetStatementOfAccount extends PaginateableAction
         }
     }
 
-    /** {@inheritdoc} */
     public function processResponse(Message $response)
     {
         parent::processResponse($response);

--- a/lib/Fhp/Action/GetStatementOfAccountXML.php
+++ b/lib/Fhp/Action/GetStatementOfAccountXML.php
@@ -115,7 +115,6 @@ class GetStatementOfAccountXML extends PaginateableAction
         return $this->xml;
     }
 
-    /** {@inheritdoc} */
     protected function createRequest(BPD $bpd, ?UPD $upd)
     {
         if ($upd === null) {
@@ -149,7 +148,6 @@ class GetStatementOfAccountXML extends PaginateableAction
         }
     }
 
-    /** {@inheritdoc} */
     public function processResponse(Message $response)
     {
         parent::processResponse($response);

--- a/lib/Fhp/Action/SendSEPARealtimeTransfer.php
+++ b/lib/Fhp/Action/SendSEPARealtimeTransfer.php
@@ -52,7 +52,6 @@ class SendSEPARealtimeTransfer extends BaseAction
         return $result;
     }
 
-    /** {@inheritdoc} */
     protected function createRequest(BPD $bpd, ?UPD $upd)
     {
         /** @var HIIPZSv1|HIIPZSv2 $hiipzs */
@@ -92,7 +91,6 @@ class SendSEPARealtimeTransfer extends BaseAction
         return $hkipz;
     }
 
-    /** {@inheritdoc} */
     public function processResponse(Message $response)
     {
         parent::processResponse($response);

--- a/lib/Fhp/Action/SendSEPATransfer.php
+++ b/lib/Fhp/Action/SendSEPATransfer.php
@@ -44,7 +44,6 @@ class SendSEPATransfer extends BaseAction
         return $result;
     }
 
-    /** {@inheritdoc} */
     protected function createRequest(BPD $bpd, ?UPD $upd)
     {
         //ANALYSE XML FOR RECEIPTS AND PAYMENT DATE
@@ -110,7 +109,6 @@ class SendSEPATransfer extends BaseAction
         return $segment;
     }
 
-    /** {@inheritdoc} */
     public function processResponse(Message $response)
     {
         parent::processResponse($response);

--- a/lib/Fhp/MT940/Dialect/PostbankMT940.php
+++ b/lib/Fhp/MT940/Dialect/PostbankMT940.php
@@ -8,7 +8,6 @@ class PostbankMT940 extends MT940
 {
     public const DIALECT_ID = 'https://hbci.postbank.de/banking/hbci.do';
 
-    /** {@inheritdoc} */
     public function extractStructuredDataFromRemittanceLines($descriptionLines, string &$gvc, array &$rawLines, array $transaction): array
     {
         // z.B bei Zinsen o.ä. ist alles leer

--- a/lib/Fhp/MT940/Dialect/SpardaMT940.php
+++ b/lib/Fhp/MT940/Dialect/SpardaMT940.php
@@ -8,7 +8,6 @@ class SpardaMT940 extends MT940
 {
     public const DIALECT_ID = 'https://fints.bankingonline.de/fints/FinTs30PinTanHttpGate';
 
-    /** {@inheritdoc} */
     public function extractStructuredDataFromRemittanceLines($descriptionLines, string &$gvc, array &$rawLines, array $transaction): array
     {
         $otherInfo = [];

--- a/lib/Fhp/Model/FlickerTan/StartCode.php
+++ b/lib/Fhp/Model/FlickerTan/StartCode.php
@@ -68,17 +68,11 @@ class StartCode extends DataElement
         $this->headerHighBit = '1';
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public function toHex(): string
     {
         return $this->getHeaderHex() . implode('', $this->controlBytes) . $this->getDataHex();
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public function getLuhnChecksum(): int
     {
         $luhn = 0;
@@ -89,9 +83,6 @@ class StartCode extends DataElement
         return $luhn;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public function __debugInfo(): ?array
     {
         return [

--- a/lib/Fhp/Model/NoPsd2TanMode.php
+++ b/lib/Fhp/Model/NoPsd2TanMode.php
@@ -16,13 +16,11 @@ final class NoPsd2TanMode implements TanMode
 {
     public const ID = -1;
 
-    /** {@inheritdoc} */
     public function getId(): int
     {
         return self::ID;
     }
 
-    /** {@inheritdoc} */
     public function getName(): string
     {
         return 'No PSD2/TANs supported';
@@ -33,91 +31,76 @@ final class NoPsd2TanMode implements TanMode
         return false;
     }
 
-    /** {@inheritdoc} */
     public function isDecoupled(): bool
     {
         return false;
     }
 
-    /** {@inheritdoc} */
     public function getChallengeLabel(): string
     {
         return '';
     }
 
-    /** {@inheritdoc} */
     public function getMaxChallengeLength(): int
     {
         return 0;
     }
 
-    /** {@inheritdoc} */
     public function getMaxTanLength(): int
     {
         return 0;
     }
 
-    /** {@inheritdoc} */
     public function getTanFormat(): int
     {
         return 0;
     }
 
-    /** {@inheritdoc} */
     public function needsTanMedium(): bool
     {
         return false;
     }
 
-    /** {@inheritdoc} */
     public function getSmsAbbuchungskontoErforderlich(): bool
     {
         return false;
     }
 
-    /** {@inheritdoc} */
     public function getAuftraggeberkontoErforderlich(): bool
     {
         return false;
     }
 
-    /** {@inheritdoc} */
     public function getChallengeKlasseErforderlich(): bool
     {
         return false;
     }
 
-    /** {@inheritdoc} */
     public function getAntwortHhdUcErforderlich(): bool
     {
         return false;
     }
 
-    /** {@inheritdoc} */
     public function getMaxDecoupledChecks(): int
     {
         throw new \RuntimeException('Only allowed for decoupled TAN modes');
     }
 
-    /** {@inheritdoc} */
     public function getFirstDecoupledCheckDelaySeconds(): int
     {
         throw new \RuntimeException('Only allowed for decoupled TAN modes');
     }
 
-    /** {@inheritdoc} */
     public function getPeriodicDecoupledCheckDelaySeconds(): int
     {
         throw new \RuntimeException('Only allowed for decoupled TAN modes');
     }
 
-    /** {@inheritdoc} */
     public function allowsManualConfirmation(): bool
     {
         throw new \RuntimeException('Only allowed for decoupled TAN modes');
     }
 
-    /** {@inheritdoc} */
     public function allowsAutomatedPolling(): bool
     {
         throw new \RuntimeException('Only allowed for decoupled TAN modes');

--- a/lib/Fhp/PaginateableAction.php
+++ b/lib/Fhp/PaginateableAction.php
@@ -34,8 +34,6 @@ abstract class PaginateableAction extends BaseAction
 
     /**
      * @deprecated Beginning from PHP7.4 __unserialize is used for new generated strings, then this method is only used for previously generated strings - remove after May 2023
-     *
-     * {@inheritdoc}
      */
     public function serialize(): string
     {
@@ -53,8 +51,6 @@ abstract class PaginateableAction extends BaseAction
 
     /**
      * @deprecated Beginning from PHP7.4 __unserialize is used for new generated strings, then this method is only used for previously generated strings - remove after May 2023
-     *
-     * {@inheritdoc}
      */
     public function unserialize($serialized)
     {
@@ -82,7 +78,6 @@ abstract class PaginateableAction extends BaseAction
         return !$this->isDone() && $this->paginationToken !== null;
     }
 
-    /** {@inheritdoc} */
     public function processResponse(Message $response)
     {
         if (($pagination = $response->findRueckmeldung(Rueckmeldungscode::PAGINATION)) !== null) {
@@ -97,7 +92,6 @@ abstract class PaginateableAction extends BaseAction
         }
     }
 
-    /** {@inheritdoc} */
     public function getNextRequest(?BPD $bpd, ?UPD $upd)
     {
         if ($this->requestSegments === null) {

--- a/lib/Fhp/Protocol/DialogInitialization.php
+++ b/lib/Fhp/Protocol/DialogInitialization.php
@@ -151,7 +151,6 @@ class DialogInitialization extends BaseAction
             parent::unserialize($parentSerialized);
     }
 
-    /** {@inheritdoc} */
     protected function createRequest(BPD $bpd, ?UPD $upd)
     {
         throw new \AssertionError('DialogInitialization::createRequest should not be used.');

--- a/lib/Fhp/Protocol/GetTanMedia.php
+++ b/lib/Fhp/Protocol/GetTanMedia.php
@@ -17,7 +17,6 @@ class GetTanMedia extends BaseAction
     /** @var TanMediumListe[]|null */
     private $tanMedia;
 
-    /** {@inheritdoc} */
     protected function createRequest(BPD $bpd, ?UPD $upd)
     {
         // Prepare the HKTAB request.
@@ -32,7 +31,6 @@ class GetTanMedia extends BaseAction
         }
     }
 
-    /** {@inheritdoc} */
     public function processResponse(Message $response)
     {
         parent::processResponse($response);

--- a/lib/Fhp/Segment/Common/Kik.php
+++ b/lib/Fhp/Segment/Common/Kik.php
@@ -19,7 +19,6 @@ class Kik extends BaseDeg
     /** Max length: 30 (Mandatory/absent depending on the country) */
     public ?string $kreditinstitutscode = null;
 
-    /** {@inheritdoc} */
     public function validate()
     {
         parent::validate();

--- a/lib/Fhp/Segment/Common/Kti.php
+++ b/lib/Fhp/Segment/Common/Kti.php
@@ -26,7 +26,6 @@ class Kti extends BaseDeg implements AccountInfo
     public ?string $unterkontomerkmal = null;
     public ?Kik $kreditinstitutskennung = null;
 
-    /** {@inheritdoc} */
     public function validate()
     {
         parent::validate();
@@ -58,13 +57,11 @@ class Kti extends BaseDeg implements AccountInfo
         return $result;
     }
 
-    /** {@inheritdoc} */
     public function getAccountNumber(): string
     {
         return $this->iban ?? $this->kontonummer;
     }
 
-    /** {@inheritdoc} */
     public function getBankIdentifier(): ?string
     {
         return $this->bic ?? $this->kreditinstitutskennung->kreditinstitutscode;

--- a/lib/Fhp/Segment/Common/Kto.php
+++ b/lib/Fhp/Segment/Common/Kto.php
@@ -31,13 +31,11 @@ class Kto extends BaseDeg implements AccountInfo
         return static::create($account->getAccountNumber(), Kik::create($account->getBlz()));
     }
 
-    /** {@inheritdoc} */
     public function getAccountNumber(): string
     {
         return $this->kontonummer;
     }
 
-    /** {@inheritdoc} */
     public function getBankIdentifier(): ?string
     {
         return $this->kik->kreditinstitutscode;

--- a/lib/Fhp/Segment/Common/KtvV3.php
+++ b/lib/Fhp/Segment/Common/KtvV3.php
@@ -37,13 +37,11 @@ class KtvV3 extends BaseDeg implements AccountInfo
         return static::create($account->getAccountNumber(), $account->getSubAccount(), Kik::create($account->getBlz()));
     }
 
-    /** {@inheritdoc} */
     public function getAccountNumber(): string
     {
         return $this->kontonummer ?: '';
     }
 
-    /** {@inheritdoc} */
     public function getBankIdentifier(): ?string
     {
         return $this->kik->kreditinstitutscode;

--- a/lib/Fhp/Segment/Common/Ktz.php
+++ b/lib/Fhp/Segment/Common/Ktz.php
@@ -24,13 +24,11 @@ class Ktz extends BaseDeg implements AccountInfo
     public ?string $unterkontomerkmal = null;
     public Kik $kreditinstitutskennung;
 
-    /** {@inheritdoc} */
     public function getAccountNumber(): string
     {
         return $this->iban ?? $this->kontonummer;
     }
 
-    /** {@inheritdoc} */
     public function getBankIdentifier(): ?string
     {
         return $this->bic ?? $this->kreditinstitutskennung->kreditinstitutscode;

--- a/lib/Fhp/Segment/HIUPD/ErlaubteGeschaeftsvorfaelleV1.php
+++ b/lib/Fhp/Segment/HIUPD/ErlaubteGeschaeftsvorfaelleV1.php
@@ -22,7 +22,6 @@ class ErlaubteGeschaeftsvorfaelleV1 extends BaseDeg implements ErlaubteGeschaeft
     /** If present, must be greater than 0 */
     public ?int $limitTage = null;
 
-    /** {@inheritdoc} */
     public function getGeschaeftsvorfall(): string
     {
         return $this->geschaeftsvorfall;

--- a/lib/Fhp/Segment/HIUPD/ErlaubteGeschaeftsvorfaelleV2.php
+++ b/lib/Fhp/Segment/HIUPD/ErlaubteGeschaeftsvorfaelleV2.php
@@ -22,7 +22,6 @@ class ErlaubteGeschaeftsvorfaelleV2 extends BaseDeg implements ErlaubteGeschaeft
     /** Only allowed for limitart==Z, must be greater than zero. */
     public ?int $limitTage = null;
 
-    /** {@inheritdoc} */
     public function getGeschaeftsvorfall(): string
     {
         return $this->geschaeftsvorfall;

--- a/lib/Fhp/Segment/HIUPD/HIUPDv4.php
+++ b/lib/Fhp/Segment/HIUPD/HIUPDv4.php
@@ -29,14 +29,12 @@ class HIUPDv4 extends BaseSegment implements HIUPD
     /** @var ErlaubteGeschaeftsvorfaelleV1[]|null @Max(98) */
     public ?array $erlaubteGeschaeftsvorfaelle = null;
 
-    /** {@inheritdoc} */
     public function matchesAccount(SEPAAccount $account): bool
     {
         return !is_null($this->kontoverbindung->kontonummer)
             && $this->kontoverbindung->kontonummer == $account->getAccountNumber();
     }
 
-    /** {@inheritdoc} */
     public function getErlaubteGeschaeftsvorfaelle(): array
     {
         return $this->erlaubteGeschaeftsvorfaelle ?? [];

--- a/lib/Fhp/Segment/HIUPD/HIUPDv6.php
+++ b/lib/Fhp/Segment/HIUPD/HIUPDv6.php
@@ -51,13 +51,11 @@ class HIUPDv6 extends BaseSegment implements HIUPD
      */
     public ?string $erweiterungKontobezogen = null;
 
-    /** {@inheritdoc} */
     public function matchesAccount(SEPAAccount $account): bool
     {
         return !is_null($this->iban) && $this->iban == $account->getIban();
     }
 
-    /** {@inheritdoc} */
     public function getErlaubteGeschaeftsvorfaelle(): array
     {
         return $this->erlaubteGeschaeftsvorfaelle ?? [];

--- a/lib/Fhp/Segment/TAB/HITABv4.php
+++ b/lib/Fhp/Segment/TAB/HITABv4.php
@@ -22,7 +22,6 @@ class HITABv4 extends BaseSegment implements HITAB
     /** @var TanMediumListeV4[]|null @Max(99) */
     public ?array $tanMediumListe = null;
 
-    /** {@inheritdoc} */
     public function getTanMediumListe(): array
     {
         return $this->tanMediumListe;

--- a/lib/Fhp/Segment/TAB/HITABv5.php
+++ b/lib/Fhp/Segment/TAB/HITABv5.php
@@ -22,7 +22,6 @@ class HITABv5 extends BaseSegment implements HITAB
     /** @var TanMediumListeV5[]|null @Max(99) */
     public ?array $tanMediumListe = null;
 
-    /** {@inheritdoc} */
     public function getTanMediumListe(): array
     {
         return $this->tanMediumListe;

--- a/lib/Fhp/Segment/TAB/TanMediumListeV4.php
+++ b/lib/Fhp/Segment/TAB/TanMediumListeV4.php
@@ -56,13 +56,11 @@ class TanMediumListeV4 extends BaseDeg implements TanMediumListe
     /** JJJJMMTT gemäß ISO 8601 */
     public ?string $freigeschaltetAm = null;
 
-    /** {@inheritdoc} */
     public function getName(): string
     {
         return $this->bezeichnungDesTanMediums;
     }
 
-    /** {@inheritdoc} */
     public function getPhoneNumber(): ?string
     {
         return $this->mobiltelefonnummer !== null ? $this->mobiltelefonnummer : $this->mobiltelefonnummerVerschleiert;

--- a/lib/Fhp/Segment/TAB/TanMediumListeV5.php
+++ b/lib/Fhp/Segment/TAB/TanMediumListeV5.php
@@ -59,13 +59,11 @@ class TanMediumListeV5 extends BaseDeg implements TanMediumListe
     /** JJJJMMTT gemäß ISO 8601 */
     public ?string $freigeschaltetAm = null;
 
-    /** {@inheritdoc} */
     public function getName(): string
     {
         return $this->bezeichnungDesTanMediums;
     }
 
-    /** {@inheritdoc} */
     public function getPhoneNumber(): ?string
     {
         return $this->mobiltelefonnummer !== null ? $this->mobiltelefonnummer : $this->mobiltelefonnummerVerschleiert;

--- a/lib/Fhp/Segment/TAN/HITANv6.php
+++ b/lib/Fhp/Segment/TAN/HITANv6.php
@@ -55,21 +55,18 @@ class HITANv6 extends BaseSegment implements HITAN
      */
     public ?string $bezeichnungDesTanMediums = null;
 
-    /** {@inheritdoc} */
     public function getProcessId(): string
     {
         // Note: This is non-null because tanProzess==4.
         return $this->auftragsreferenz;
     }
 
-    /** {@inheritdoc} */
     public function getChallenge(): ?string
     {
         // Note: This is non-null because tanProzess==4.
         return $this->challenge === static::DUMMY_CHALLENGE ? null : $this->challenge;
     }
 
-    /** {@inheritdoc} */
     public function getTanMediumName(): ?string
     {
         return $this->bezeichnungDesTanMediums;

--- a/lib/Fhp/Segment/TAN/VerfahrensparameterZweiSchrittVerfahrenV6.php
+++ b/lib/Fhp/Segment/TAN/VerfahrensparameterZweiSchrittVerfahrenV6.php
@@ -49,115 +49,96 @@ class VerfahrensparameterZweiSchrittVerfahrenV6 extends BaseDeg implements TanMo
     public bool $antwortHhdUcErforderlich;
     public ?int $anzahlUnterstuetzterAktiverTanMedien = null;
 
-    /** {@inheritdoc} */
     public function getId(): int
     {
         return $this->sicherheitsfunktion;
     }
 
-    /** {@inheritdoc} */
     public function getName(): string
     {
         return $this->nameDesZweiSchrittVerfahrens;
     }
 
-    /** {@inheritdoc} */
     public function isProzessvariante2(): bool
     {
         return $this->tanProzess === HKTAN::TAN_PROZESS_2;
     }
 
-    /** {@inheritdoc} */
     public function isDecoupled(): bool
     {
         return false;
     }
 
-    /** {@inheritdoc} */
     public function getSmsAbbuchungskontoErforderlich(): bool
     {
         return $this->smsAbbuchungskontoErforderlich === 2;
     }
 
-    /** {@inheritdoc} */
     public function getAuftraggeberkontoErforderlich(): bool
     {
         return $this->auftraggeberkontoErforderlich === 2;
     }
 
-    /** {@inheritdoc} */
     public function getChallengeKlasseErforderlich(): bool
     {
         return $this->challengeKlasseErforderlich;
     }
 
-    /** {@inheritdoc} */
     public function getAntwortHhdUcErforderlich(): bool
     {
         return $this->antwortHhdUcErforderlich;
     }
 
-    /** {@inheritdoc} */
     public function getChallengeLabel(): string
     {
         return $this->textZurBelegungDesRueckgabewertes;
     }
 
-    /** {@inheritdoc} */
     public function getMaxChallengeLength(): int
     {
         return $this->maximaleLaengeDesRueckgabewertes;
     }
 
-    /** {@inheritdoc} */
     public function getMaxTanLength(): int
     {
         return $this->maximaleLaengeDesTanEingabewertes;
     }
 
-    /** {@inheritdoc} */
     public function getTanFormat(): int
     {
         return $this->erlaubtesFormat;
     }
 
-    /** {@inheritdoc} */
     public function needsTanMedium(): bool
     {
         return $this->bezeichnungDesTanMediumsErforderlich === 2 && $this->anzahlUnterstuetzterAktiverTanMedien > 0;
     }
 
-    /** {@inheritdoc} */
     public function getMaxDecoupledChecks(): int
     {
         throw new \RuntimeException('Only allowed for decoupled TAN modes');
     }
 
-    /** {@inheritdoc} */
     public function getFirstDecoupledCheckDelaySeconds(): int
     {
         throw new \RuntimeException('Only allowed for decoupled TAN modes');
     }
 
-    /** {@inheritdoc} */
     public function getPeriodicDecoupledCheckDelaySeconds(): int
     {
         throw new \RuntimeException('Only allowed for decoupled TAN modes');
     }
 
-    /** {@inheritdoc} */
     public function allowsManualConfirmation(): bool
     {
         throw new \RuntimeException('Only allowed for decoupled TAN modes');
     }
 
-    /** {@inheritdoc} */
     public function allowsAutomatedPolling(): bool
     {
         throw new \RuntimeException('Only allowed for decoupled TAN modes');
     }
 
-    /** {@inheritdoc} */
     public function createHKTAN(): HKTAN
     {
         return HKTANv6::createEmpty();

--- a/lib/Fhp/Segment/TAN/VerfahrensparameterZweiSchrittVerfahrenV7.php
+++ b/lib/Fhp/Segment/TAN/VerfahrensparameterZweiSchrittVerfahrenV7.php
@@ -70,67 +70,56 @@ class VerfahrensparameterZweiSchrittVerfahrenV7 extends BaseDeg implements TanMo
     /** Maybe present if isDecoupled. */
     public ?bool $automatisierteStatusabfragenErlaubt = null;
 
-    /** {@inheritdoc} */
     public function getId(): int
     {
         return $this->sicherheitsfunktion;
     }
 
-    /** {@inheritdoc} */
     public function getName(): string
     {
         return $this->nameDesZweiSchrittVerfahrens;
     }
 
-    /** {@inheritdoc} */
     public function isProzessvariante2(): bool
     {
         return $this->tanProzess === HKTAN::TAN_PROZESS_2;
     }
 
-    /** {@inheritdoc} */
     public function isDecoupled(): bool
     {
         return $this->dkTanVerfahren === 'Decoupled' || $this->dkTanVerfahren === 'DecoupledPush';
     }
 
-    /** {@inheritdoc} */
     public function getSmsAbbuchungskontoErforderlich(): bool
     {
         return $this->smsAbbuchungskontoErforderlich === 2;
     }
 
-    /** {@inheritdoc} */
     public function getAuftraggeberkontoErforderlich(): bool
     {
         return $this->auftraggeberkontoErforderlich === 2;
     }
 
-    /** {@inheritdoc} */
     public function getChallengeKlasseErforderlich(): bool
     {
         return $this->challengeKlasseErforderlich;
     }
 
-    /** {@inheritdoc} */
     public function getAntwortHhdUcErforderlich(): bool
     {
         return $this->antwortHhdUcErforderlich;
     }
 
-    /** {@inheritdoc} */
     public function getChallengeLabel(): string
     {
         return $this->textZurBelegungDesRueckgabewertes;
     }
 
-    /** {@inheritdoc} */
     public function getMaxChallengeLength(): int
     {
         return $this->maximaleLaengeDesRueckgabewertes;
     }
 
-    /** {@inheritdoc} */
     public function getMaxTanLength(): int
     {
         if ($this->isDecoupled()) {
@@ -142,7 +131,6 @@ class VerfahrensparameterZweiSchrittVerfahrenV7 extends BaseDeg implements TanMo
         return $this->maximaleLaengeDesTanEingabewertes;
     }
 
-    /** {@inheritdoc} */
     public function getTanFormat(): int
     {
         if ($this->isDecoupled()) {
@@ -154,13 +142,11 @@ class VerfahrensparameterZweiSchrittVerfahrenV7 extends BaseDeg implements TanMo
         return $this->erlaubtesFormat;
     }
 
-    /** {@inheritdoc} */
     public function needsTanMedium(): bool
     {
         return $this->bezeichnungDesTanMediumsErforderlich === 2 && $this->anzahlUnterstuetzterAktiverTanMedien > 0;
     }
 
-    /** {@inheritdoc} */
     public function getMaxDecoupledChecks(): int
     {
         if (!$this->isDecoupled()) {
@@ -172,7 +158,6 @@ class VerfahrensparameterZweiSchrittVerfahrenV7 extends BaseDeg implements TanMo
         return $this->maximaleAnzahlStatusabfragen;
     }
 
-    /** {@inheritdoc} */
     public function getFirstDecoupledCheckDelaySeconds(): int
     {
         if (!$this->isDecoupled()) {
@@ -184,7 +169,6 @@ class VerfahrensparameterZweiSchrittVerfahrenV7 extends BaseDeg implements TanMo
         return $this->wartezeitVorErsterStatusabfrage;
     }
 
-    /** {@inheritdoc} */
     public function getPeriodicDecoupledCheckDelaySeconds(): int
     {
         if (!$this->isDecoupled()) {
@@ -196,7 +180,6 @@ class VerfahrensparameterZweiSchrittVerfahrenV7 extends BaseDeg implements TanMo
         return $this->wartezeitVorNaechsterStatusabfrage;
     }
 
-    /** {@inheritdoc} */
     public function allowsManualConfirmation(): bool
     {
         if (!$this->isDecoupled()) {
@@ -208,7 +191,6 @@ class VerfahrensparameterZweiSchrittVerfahrenV7 extends BaseDeg implements TanMo
         return $this->manuelleBestaetigungMoeglich;
     }
 
-    /** {@inheritdoc} */
     public function allowsAutomatedPolling(): bool
     {
         if (!$this->isDecoupled()) {
@@ -220,7 +202,6 @@ class VerfahrensparameterZweiSchrittVerfahrenV7 extends BaseDeg implements TanMo
         return $this->automatisierteStatusabfragenErlaubt;
     }
 
-    /** {@inheritdoc} */
     public function createHKTAN(): HKTAN
     {
         return HKTANv7::createEmpty();

--- a/lib/Tests/Fhp/FinTsPeer.php
+++ b/lib/Tests/Fhp/FinTsPeer.php
@@ -23,14 +23,12 @@ class FinTsPeer extends FinTs
         parent::__construct($options, $credentials);
     }
 
-    /** {@inheritdoc} */
     protected function newConnection(): Connection
     {
         return self::$mockConnection;
     }
 
     /**
-     * {@inheritdoc}
      * @throws ServerException
      */
     public function endDialog(bool $isAnonymous = false) // parent::endDialog() is protected


### PR DESCRIPTION
It's the latest PHP CS Fixer default: https://cs.symfony.com/doc/rules/phpdoc/no_superfluous_phpdoc_tags.html

The reasoning that it's not useful for any IDEs or for PHP doc generation: https://www.drupal.org/project/coding_standards/issues/3335320