### PR TITLE
Add warning about non-UTF characters also to phpDoc

### DIFF
--- a/lib/Fhp/BaseAction.php
+++ b/lib/Fhp/BaseAction.php
@@ -77,6 +77,7 @@ abstract class BaseAction implements \Serializable
      * If a sub-class overrides this, it should call the parent function and include it in its result.
      *
      * @return array The serialized action, e.g. for storage in a database. This will not contain sensitive user data.
+     *   Note that this is not necessarily valid UTF-8, so you should store it as a BLOB column or raw bytes.
      */
     public function __serialize(): array
     {

--- a/lib/Fhp/FinTs.php
+++ b/lib/Fhp/FinTs.php
@@ -159,6 +159,7 @@ class FinTs
      *     carefully (not written to log files, only to a database or other storage system that would normally be used
      *     for user data). The returned string never contains highly sensitive information (not the user's password or
      *     PIN), so it probably does not need to be encrypted. Treat it like a session cookie of the same bank.
+     *     Note that this is not necessarily valid UTF-8, so you should store it as a BLOB column or raw bytes.
      */
     public function persist(bool $minimal = false): string
     {


### PR DESCRIPTION
There's already a warning in the login.php sample code about this.

(Motivated by discussion on #470.)