### PR TITLE
BC-XX Add Docker environment for local development on isolated contai…

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.git
+.gitignore
+vendor
+.env
+xdebug.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM php:8.4-cli
+
+RUN apt-get update && apt-get install -y \
+    libcurl4-openssl-dev \
+    libonig-dev \
+    unzip \
+    && docker-php-ext-install mbstring curl
+
+RUN pecl install xdebug && docker-php-ext-enable xdebug
+
+COPY --from=composer:latest /usr/bin/composer /usr/bin/composer
+
+WORKDIR /var/www/html
+
+COPY src src
+COPY Tests Tests
+COPY Samples Samples
+COPY composer.json composer.json
+COPY phpunit.xml.dist phpunit.xml.dist
+COPY .php-cs-fixer.php .php-cs-fixer.php
+COPY php.ini /usr/local/etc/php/php.ini
+
+RUN composer install --no-interaction

--- a/README.md
+++ b/README.md
@@ -15,6 +15,27 @@ A PHP library implementing the following functions of the FinTS/HBCI protocol:
 
 Forked from [mschindler83/fints-hbci-php](https://github.com/mschindler83/fints-hbci-php), but then mostly reimplemented.
 
+## Docker
+
+A Docker environment with PHP 8.4, xDebug, and all dependencies is available.
+
+```bash
+docker compose up -d
+docker compose exec app composer install
+```
+
+Run tests inside the container:
+
+```bash
+docker compose exec app composer test
+```
+
+Work inside the container:
+
+```bash
+docker compose exec app composer bash
+```
+
 ## Getting Started
 
 Before using this library (or any other FinTS library), you have to register your application with

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+services:
+  app:
+    build: .
+    volumes:
+      - .:/var/www/html:rw
+    stdin_open: true
+    tty: true

--- a/php.ini
+++ b/php.ini
@@ -1,0 +1,12 @@
+[PHP]
+memory_limit = 256M
+display_errors = On
+display_startup_errors = On
+error_reporting = E_ALL
+
+[xdebug]
+xdebug.mode = debug
+xdebug.start_with_request = yes
+xdebug.client_host = host.docker.internal
+xdebug.client_port = 9003
+xdebug.log = /var/www/html/xdebug.log


### PR DESCRIPTION
…ners.

This will allow developers to work in isolated containers rather than individual systems. 

Can be easily adapted to run on PHP8.3, etc to meet developers needs. Its not a good idea however to provide all possible PHP Versions directly, as the usage is rather low. 

Later, the Github Actions can use these to spin up containers individually. This ensures high consistency and unifies the process of development. 