### PR TITLE
Assume PSD2 is supported for any HITANS newer than v6

### DIFF
--- a/src/Protocol/BPD.php
+++ b/src/Protocol/BPD.php
@@ -139,6 +139,21 @@ class BPD
     }
 
     /**
+     * @param string $type A business transaction type, see above.
+     * @param int $minVersion The minimum segment version of the business transaction.
+     * @return bool If that version of the given transaction type or a newer one is supported by the bank.
+     */
+    public function supportsParametersOrNewer(string $type, int $minVersion): bool
+    {
+        foreach ($this->parameters[$type] as $segment) {
+            if ($segment->getVersion() >= $version) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
      * @param SegmentInterface[] $requestSegments The segments that shall be sent to the bank.
      * @return string|null Identifier of the (first) segment that requires a TAN according to HIPINS, or null if none of
      *     the segments require a TAN.
@@ -180,7 +195,7 @@ class BPD
      */
     public function supportsPsd2(): bool
     {
-        return $this->supportsParameters('HITANS', 6);
+        return $this->supportsParametersOrNewer('HITANS', 6);
     }
 
     /**

--- a/src/Protocol/BPD.php
+++ b/src/Protocol/BPD.php
@@ -146,7 +146,7 @@ class BPD
     public function supportsParametersOrNewer(string $type, int $minVersion): bool
     {
         foreach ($this->parameters[$type] as $segment) {
-            if ($segment->getVersion() >= $version) {
+            if ($segment->getVersion() >= $minVersion) {
                 return true;
             }
         }


### PR DESCRIPTION
Fixes #554

The logic was written when HITANSv6 was the newest version and also the only one that supported PSD2. Nowadays we have even newer versions and some banks support _only_ those (not anymore v6), so we need to be more lenient here.