### PR TITLE
Omit national Kti fields when BPD disallows them.

### DIFF
--- a/Tests/Unit/Integration/DKB/SendSEPATransferTest.php
+++ b/Tests/Unit/Integration/DKB/SendSEPATransferTest.php
@@ -85,8 +85,8 @@ class SendSEPATransferTest extends DKBIntegrationTestBase
     {
         // Note: strlen() is computed instead of hard-coded because it depends on the indentation in this file, which
         // may be changed by linters and other tools, and because it contains line breaks, which are different depending
-        // the platform where this test runs.
-        return 'HKCCS:3:1+DExxABCDEFGH1234567890:BYLADEM1001:1234567890::280:12030000+urn?:iso?:std?:iso?:20022?:tech?:xsd?:pain.001.003.03+@'
+        // on the platform where this test runs.
+        return 'HKCCS:3:1+DExxABCDEFGH1234567890:BYLADEM1001+urn?:iso?:std?:iso?:20022?:tech?:xsd?:pain.001.003.03+@'
             . strlen(self::PAIN_MESSAGE) . '@' . self::PAIN_MESSAGE . "'HKTAN:4:6+4+HKCCS+++++++++SomePhone1'";
     }
 

--- a/src/Action/GetBalance.php
+++ b/src/Action/GetBalance.php
@@ -8,7 +8,6 @@ use Fhp\Protocol\BPD;
 use Fhp\Protocol\Message;
 use Fhp\Protocol\UnexpectedResponseException;
 use Fhp\Protocol\UPD;
-use Fhp\Segment\BaseSegment;
 use Fhp\Segment\Common\Kti;
 use Fhp\Segment\Common\Kto;
 use Fhp\Segment\Common\KtvV3;
@@ -17,6 +16,7 @@ use Fhp\Segment\SAL\HKSALv4;
 use Fhp\Segment\SAL\HKSALv5;
 use Fhp\Segment\SAL\HKSALv6;
 use Fhp\Segment\SAL\HKSALv7;
+use Fhp\Segment\SPA\HISPAS;
 use Fhp\UnsupportedException;
 
 /**
@@ -98,7 +98,6 @@ class GetBalance extends PaginateableAction
 
     protected function createRequest(BPD $bpd, ?UPD $upd)
     {
-        /** @var BaseSegment $hisals */
         $hisals = $bpd->requireLatestSupportedParameters('HISALS');
         switch ($hisals->getVersion()) {
             case 4:
@@ -108,7 +107,10 @@ class GetBalance extends PaginateableAction
             case 6:
                 return HKSALv6::create(KtvV3::fromAccount($this->account), $this->allAccounts);
             case 7:
-                return HKSALv7::create(Kti::fromAccount($this->account), $this->allAccounts);
+                /** @var HISPAS $hispas */
+                $hispas = $bpd->requireLatestSupportedParameters('HISPAS');
+                $kti = Kti::fromAccount($this->account, $hispas->getParameter()->getNationaleKontoverbindungErlaubt());
+                return HKSALv7::create($kti, $this->allAccounts);
             default:
                 throw new UnsupportedException('Unsupported HKSAL version: ' . $hisals->getVersion());
         }

--- a/src/Action/GetStatementOfAccount.php
+++ b/src/Action/GetStatementOfAccount.php
@@ -24,6 +24,7 @@ use Fhp\Segment\KAZ\HKKAZv4;
 use Fhp\Segment\KAZ\HKKAZv5;
 use Fhp\Segment\KAZ\HKKAZv6;
 use Fhp\Segment\KAZ\HKKAZv7;
+use Fhp\Segment\SPA\HISPAS;
 use Fhp\UnsupportedException;
 
 /**
@@ -171,7 +172,10 @@ class GetStatementOfAccount extends PaginateableAction
                 case 6:
                     return HKKAZv6::create(KtvV3::fromAccount($this->account), $this->allAccounts, $this->from, $this->to);
                 case 7:
-                    return HKKAZv7::create(Kti::fromAccount($this->account), $this->allAccounts, $this->from, $this->to);
+                    /** @var HISPAS $hispas */
+                    $hispas = $bpd->requireLatestSupportedParameters('HISPAS');
+                    $kti = Kti::fromAccount($this->account, $hispas->getParameter()->getNationaleKontoverbindungErlaubt());
+                    return HKKAZv7::create($kti, $this->allAccounts, $this->from, $this->to);
                 default:
                     throw new UnsupportedException('Unsupported HKKAZ version: ' . $hikazs->getVersion());
             }

--- a/src/Action/GetStatementOfAccountXML.php
+++ b/src/Action/GetStatementOfAccountXML.php
@@ -16,6 +16,7 @@ use Fhp\Segment\CAZ\HKCAZv1;
 use Fhp\Segment\CAZ\UnterstuetzteCamtMessages;
 use Fhp\Segment\Common\Kti;
 use Fhp\Segment\HIRMS\Rueckmeldungscode;
+use Fhp\Segment\SPA\HISPAS;
 use Fhp\UnsupportedException;
 
 /**
@@ -139,10 +140,15 @@ class GetStatementOfAccountXML extends PaginateableAction
         if ($this->allAccounts && !$hicazs->getParameter()->getAlleKontenErlaubt()) {
             throw new \InvalidArgumentException('The bank do not permit the use of allAccounts=true');
         }
+
+        /** @var HISPAS $hispas */
+        $hispas = $bpd->requireLatestSupportedParameters('HISPAS');
+        $kti = Kti::fromAccount($this->account, $hispas->getParameter()->getNationaleKontoverbindungErlaubt());
+
         switch ($hicazs->getVersion()) {
             case 1:
                 $unterstuetzteCamtMessages = UnterstuetzteCamtMessages::create($camtURNs);
-                return HKCAZv1::create(Kti::fromAccount($this->account), $unterstuetzteCamtMessages, $this->allAccounts, $this->from, $this->to);
+                return HKCAZv1::create($kti, $unterstuetzteCamtMessages, $this->allAccounts, $this->from, $this->to);
             default:
                 throw new UnsupportedException('Unsupported HKCAZ version: ' . $hicazs->getVersion());
         }

--- a/src/Action/SendInternationalCreditTransfer.php
+++ b/src/Action/SendInternationalCreditTransfer.php
@@ -9,6 +9,7 @@ use Fhp\Protocol\UPD;
 use Fhp\Segment\AUB\HIAUBSv9;
 use Fhp\Segment\AUB\HKAUBv9;
 use Fhp\Segment\Common\Kti;
+use Fhp\Segment\SPA\HISPAS;
 use Fhp\Syntax\Bin;
 
 class SendInternationalCreditTransfer extends BaseAction
@@ -76,11 +77,16 @@ class SendInternationalCreditTransfer extends BaseAction
 
     protected function createRequest(BPD $bpd, ?UPD $upd)
     {
+        /** @var HISPAS $hispas */
+        $hispas = $bpd->requireLatestSupportedParameters('HISPAS');
         /** @var HIAUBSv9 $hiaubs */
         $hiaubs = $bpd->requireLatestSupportedParameters('HIAUBS');
 
         $hkaub = HKAUBv9::createEmpty();
-        $hkaub->kontoverbindungInternational = Kti::fromAccount($this->account);
+        $hkaub->kontoverbindungInternational = Kti::fromAccount(
+            $this->account,
+            $hispas->getParameter()->getNationaleKontoverbindungErlaubt()
+        );
         $hkaub->DTAZVHandbuch = $this->dtavzVersion ?? $hiaubs->parameter->DTAZVHandbuch;
         $hkaub->DTAZVDatensatz = new Bin($this->dtavzData);
         return $hkaub;

--- a/src/Action/SendSEPADirectDebit.php
+++ b/src/Action/SendSEPADirectDebit.php
@@ -130,6 +130,8 @@ class SendSEPADirectDebit extends BaseAction
             $useSingleDirectDebit = false;
         }
 
+        /** @var HISPAS $hispas */
+        $hispas = $bpd->requireLatestSupportedParameters('HISPAS');
         /* @var HIDXES|BaseSegment $hidxes */
         $hidxes = $bpd->requireLatestSupportedParameters(GetSEPADirectDebitParameters::getHixxesSegmentName($this->coreType, $useSingleDirectDebit));
 
@@ -142,8 +144,6 @@ class SendSEPADirectDebit extends BaseAction
 
         // If there are no SEPA formats available in the HIDXES Parameters, we look to the general formats
         if (!is_array($supportedPainNamespaces) || count($supportedPainNamespaces) === 0) {
-            /** @var HISPAS $hispas */
-            $hispas = $bpd->requireLatestSupportedParameters('HISPAS');
             $supportedPainNamespaces = $hispas->getParameter()->getUnterstuetzteSEPADatenformate();
         }
 
@@ -163,7 +163,10 @@ class SendSEPADirectDebit extends BaseAction
 
         /** @var HKDMEv2|HKDSEv2|HIDXES $hkdxe */
         $hkdxe = $hidxes->createRequestSegment();
-        $hkdxe->kontoverbindungInternational = Kti::fromAccount($this->account);
+        $hkdxe->kontoverbindungInternational = Kti::fromAccount(
+            $this->account,
+            $hispas->getParameter()->getNationaleKontoverbindungErlaubt()
+        );
         $hkdxe->sepaDescriptor = $this->painNamespace;
         $hkdxe->sepaPainMessage = new Bin($this->painMessage);
 

--- a/src/Action/SendSEPARealtimeTransfer.php
+++ b/src/Action/SendSEPARealtimeTransfer.php
@@ -13,6 +13,7 @@ use Fhp\Segment\HIRMS\Rueckmeldung;
 use Fhp\Segment\HIRMS\Rueckmeldungscode;
 use Fhp\Segment\IPZ\HIIPZSv1;
 use Fhp\Segment\IPZ\HIIPZSv2;
+use Fhp\Segment\IPZ\HKIPZv1;
 use Fhp\Segment\IPZ\HKIPZv2;
 use Fhp\Segment\SPA\HISPAS;
 use Fhp\Syntax\Bin;
@@ -95,6 +96,8 @@ class SendSEPARealtimeTransfer extends BaseAction
 
     protected function createRequest(BPD $bpd, ?UPD $upd)
     {
+        /** @var HISPAS $hispas */
+        $hispas = $bpd->requireLatestSupportedParameters('HISPAS');
         /** @var HIIPZSv1|HIIPZSv2 $hiipzs */
         $hiipzs = $bpd->requireLatestSupportedParameters('HIIPZS');
 
@@ -102,8 +105,6 @@ class SendSEPARealtimeTransfer extends BaseAction
 
         // If there are no SEPA formats available in the HIIPZS Parameters, we look to the general formats
         if (is_null($supportedSchemas)) {
-            /** @var HISPAS $hispas */
-            $hispas = $bpd->requireLatestSupportedParameters('HISPAS');
             $supportedSchemas = $hispas->getParameter()->getUnterstuetzteSEPADatenformate();
         }
 
@@ -123,7 +124,10 @@ class SendSEPARealtimeTransfer extends BaseAction
 
         /** @var HKIPZv1|HKIPZv2 $hkipz */
         $hkipz = $hiipzs->createRequestSegment();
-        $hkipz->kontoverbindungInternational = Kti::fromAccount($this->account);
+        $hkipz->kontoverbindungInternational = Kti::fromAccount(
+            $this->account,
+            $hispas->getParameter()->getNationaleKontoverbindungErlaubt()
+        );
         $hkipz->sepaDescriptor = $this->xmlSchema;
         $hkipz->sepaPainMessage = new Bin($this->painMessage);
         if ($hiipzs instanceof HIIPZSv2) {

--- a/src/Action/SendSEPATransfer.php
+++ b/src/Action/SendSEPATransfer.php
@@ -156,7 +156,10 @@ class SendSEPATransfer extends BaseAction
                 . implode(', ', $supportedSchemas));
         }
 
-        $segment->kontoverbindungInternational = Kti::fromAccount($this->account);
+        $segment->kontoverbindungInternational = Kti::fromAccount(
+            $this->account,
+            $hispas->getParameter()->getNationaleKontoverbindungErlaubt()
+        );
         $segment->sepaDescriptor = $this->xmlSchema;
         $segment->sepaPainMessage = new Bin($this->painMessage);
 

--- a/src/Segment/Common/Kti.php
+++ b/src/Segment/Common/Kti.php
@@ -48,12 +48,14 @@ class Kti extends BaseDeg implements AccountInfo
         return $result;
     }
 
-    public static function fromAccount(SEPAAccount $account): Kti
+    public static function fromAccount(SEPAAccount $account, bool $nationaleKontoverbindungErlaubt): Kti
     {
         $result = static::create($account->getIban(), $account->getBic());
-        $result->kontonummer = $account->getAccountNumber();
-        $result->unterkontomerkmal = $account->getSubAccount();
-        $result->kreditinstitutskennung = Kik::create($account->getBlz());
+        if ($nationaleKontoverbindungErlaubt) {
+            $result->kontonummer = $account->getAccountNumber();
+            $result->unterkontomerkmal = $account->getSubAccount();
+            $result->kreditinstitutskennung = Kik::create($account->getBlz());
+        }
         return $result;
     }
 

--- a/src/Segment/SPA/ParameterSepaKontoverbindungAnfordern.php
+++ b/src/Segment/SPA/ParameterSepaKontoverbindungAnfordern.php
@@ -10,4 +10,5 @@ use Fhp\Segment\UnterstuetzteSEPADatenformate;
  */
 interface ParameterSepaKontoverbindungAnfordern extends UnterstuetzteSEPADatenformate
 {
+    public function getNationaleKontoverbindungErlaubt(): bool;
 }

--- a/src/Segment/SPA/ParameterSepaKontoverbindungAnfordernV1.php
+++ b/src/Segment/SPA/ParameterSepaKontoverbindungAnfordernV1.php
@@ -21,4 +21,9 @@ class ParameterSepaKontoverbindungAnfordernV1 extends BaseDeg implements Paramet
     public bool $strukturierterVerwendungszweckErlaubt;
     /** @var string[] @Max(99) Max length each: 256 */
     public array $unterstuetzteSepaDatenformate;
+
+    public function getNationaleKontoverbindungErlaubt(): bool
+    {
+        return $this->nationaleKontoverbindungErlaubt;
+    }
 }

--- a/src/Segment/SPA/ParameterSepaKontoverbindungAnfordernV2.php
+++ b/src/Segment/SPA/ParameterSepaKontoverbindungAnfordernV2.php
@@ -22,4 +22,9 @@ class ParameterSepaKontoverbindungAnfordernV2 extends BaseDeg implements Paramet
     public bool $eingabeAnzahlEintraegeErlaubt;
     /** @var string[] @Max(99) Max length each: 256 */
     public array $unterstuetzteSepaDatenformate;
+
+    public function getNationaleKontoverbindungErlaubt(): bool
+    {
+        return $this->nationaleKontoverbindungErlaubt;
+    }
 }

--- a/src/Segment/SPA/ParameterSepaKontoverbindungAnfordernV3.php
+++ b/src/Segment/SPA/ParameterSepaKontoverbindungAnfordernV3.php
@@ -23,4 +23,9 @@ class ParameterSepaKontoverbindungAnfordernV3 extends BaseDeg implements Paramet
     public int $anzahlReservierterVerwendungszweckstellen;
     /** @var string[] @Max(99) Max length each: 256 */
     public array $unterstuetzteSepaDatenformate;
+
+    public function getNationaleKontoverbindungErlaubt(): bool
+    {
+        return $this->nationaleKontoverbindungErlaubt;
+    }
 }


### PR DESCRIPTION
Fixes #534

Per specification section "B.3.2 Kontoverbindung international":

> Ist der BPD-Parameter "Nationale Kontoverbindung erlaubt" in HISPAS mit "N" belegt, so darf nur die internationale Kontoverbindung durch IBAN und BIC verwendet werden.