### PR TITLE
Fix: Add missing control sum (Summenfeld) to HKCCM/HKCME for SEPA batch transfers

### DIFF
--- a/src/Action/SendSEPATransfer.php
+++ b/src/Action/SendSEPATransfer.php
@@ -168,7 +168,7 @@ class SendSEPATransfer extends BaseAction
             // Fix for strict banks (e.g. Atruvia): Extract the batch control sum from the PAIN XML and set it on the segment
             if (isset($xmlAsObject->CstmrCdtTrfInitn->GrpHdr->CtrlSum)) {
                 $ctrlSum = (float) $xmlAsObject->CstmrCdtTrfInitn->GrpHdr->CtrlSum;
-                $segment->summenfeld = \Fhp\Segment\Common\Btg::create($ctrlSum ?: 0);
+                $segment->summenfeld = \Fhp\Segment\Common\Btg::create($ctrlSum);
             }
 
             $paramSegmentId = $hasReqdExDates ? 'HICMES' : 'HICCMS';

--- a/src/Action/SendSEPATransfer.php
+++ b/src/Action/SendSEPATransfer.php
@@ -165,6 +165,13 @@ class SendSEPATransfer extends BaseAction
 
         // For batch transfers: set einzelbuchungGewuenscht if bank allows it
         if ($numberOfTransactions > 1) {
+
+            // Fix for strict banks (e.g. Atruvia): Extract the batch control sum from the PAIN XML and set it on the segment
+            if (isset($xmlAsObject->CstmrCdtTrfInitn->GrpHdr->CtrlSum)) {
+                $ctrlSum = (float) $xmlAsObject->CstmrCdtTrfInitn->GrpHdr->CtrlSum;
+                $segment->summenfeld = \Fhp\Segment\Common\Btg::create($ctrlSum ?: 0);
+            }
+
             $paramSegmentId = $hasReqdExDates ? 'HICMES' : 'HICCMS';
             $paramSegment = $bpd->getLatestSupportedParameters($paramSegmentId);
             if ($paramSegment !== null && $paramSegment->getParameter()->einzelbuchungErlaubt) {

--- a/src/Action/SendSEPATransfer.php
+++ b/src/Action/SendSEPATransfer.php
@@ -165,7 +165,6 @@ class SendSEPATransfer extends BaseAction
 
         // For batch transfers: set einzelbuchungGewuenscht if bank allows it
         if ($numberOfTransactions > 1) {
-
             // Fix for strict banks (e.g. Atruvia): Extract the batch control sum from the PAIN XML and set it on the segment
             if (isset($xmlAsObject->CstmrCdtTrfInitn->GrpHdr->CtrlSum)) {
                 $ctrlSum = (float) $xmlAsObject->CstmrCdtTrfInitn->GrpHdr->CtrlSum;


### PR DESCRIPTION
When initiating a SEPA batch transfer (Sammelüberweisung) using the HKCCM or HKCME segments, some strict bank servers (e.g., Atruvia data centers for Volksbanken/Raiffeisenbanken) reject the request with the error:
HIRMS:5:2:3+9010::Summenfeld nicht vorhanden.

While some banks parse the total sum directly from the PAIN XML payload, others strictly enforce the HBCI specification, which requires the control sum to be explicitly declared in the segment parameters (e.g., HKCCM:3:1+...). Currently, SendSEPATransfer leaves this field empty.

Changes made:

Updated SendSEPATransfer::createRequest() to extract the <CtrlSum> from the provided PAIN XML (GrpHdr).

Initialized the $segment->summenfeld property using \Fhp\Segment\Common\Btg::create().