### PR TITLE
Add configurable single booking support for SEPA Direct Debits (Sammellastschrift)

### DIFF
--- a/src/Action/SendSEPADirectDebit.php
+++ b/src/Action/SendSEPADirectDebit.php
@@ -39,6 +39,7 @@ class SendSEPADirectDebit extends BaseAction
     protected $tryToUseControlSumForSingleTransactions = false;
     /** @var string */
     private $coreType;
+    private bool $singleBookingRequested = false;
 
     // There are no result fields. This action is simply marked as done to indicate that the transfer was executed.
 
@@ -83,6 +84,20 @@ class SendSEPADirectDebit extends BaseAction
     }
 
     /**
+     * Request individual bookings instead of a batch booking on the bank statement.
+     * Only applicable for batch direct debits (Sammellastschrift).
+     *
+     * @param bool $singleBookingRequested If true, each transaction appears separately on the statement.
+     * @return $this
+     */
+    public function setSingleBookingRequested(bool $singleBookingRequested): self
+    {
+        $this->singleBookingRequested = $singleBookingRequested;
+
+        return $this;
+    }
+
+    /**
      * @deprecated Beginning from PHP7.4 __unserialize is used for new generated strings, then this method is only used for previously generated strings - remove after May 2023
      */
     public function serialize(): string
@@ -94,7 +109,7 @@ class SendSEPADirectDebit extends BaseAction
     {
         return [
             parent::__serialize(),
-            $this->singleDirectDebit, $this->tryToUseControlSumForSingleTransactions, $this->ctrlSum, $this->coreType, $this->painMessage, $this->painNamespace, $this->account,
+            $this->singleDirectDebit, $this->tryToUseControlSumForSingleTransactions, $this->ctrlSum, $this->coreType, $this->painMessage, $this->painNamespace, $this->account, $this->singleBookingRequested,
         ];
     }
 
@@ -113,7 +128,7 @@ class SendSEPADirectDebit extends BaseAction
     {
         list(
             $parentSerialized,
-            $this->singleDirectDebit, $this->tryToUseControlSumForSingleTransactions, $this->ctrlSum, $this->coreType, $this->painMessage, $this->painNamespace, $this->account,
+            $this->singleDirectDebit, $this->tryToUseControlSumForSingleTransactions, $this->ctrlSum, $this->coreType, $this->painMessage, $this->painNamespace, $this->account, $this->singleBookingRequested,
         ) = $serialized;
 
         is_array($parentSerialized) ?
@@ -172,7 +187,7 @@ class SendSEPADirectDebit extends BaseAction
 
         if (!$useSingleDirectDebit) {
             if ($hidxes->getParameter()->einzelbuchungErlaubt) {
-                $hkdxe->einzelbuchungGewuenscht = false;
+                $hkdxe->einzelbuchungGewuenscht = $this->singleBookingRequested;
             }
 
             /* @var HIDMESv1 $hidxes */


### PR DESCRIPTION
This adds the ability to request individual bookings (`einzelbuchungGewuenscht`) for batch SEPA Direct Debits, matching the existing functionality already available in `SendSEPATransfer`.

Previously, `einzelbuchungGewuenscht` was hardcoded to `false` in `SendSEPADirectDebit`, meaning batch direct debits always appeared as a single aggregated entry on the bank statement — regardless of the caller's intent.

**Changes:**
- Added `$singleBookingRequested` property to `SendSEPADirectDebit`
- Added `setSingleBookingRequested(bool): self` setter method (consistent with `SendSEPATransfer` API)
- `einzelbuchungGewuenscht` now uses the configurable value instead of hardcoded `false`
- Updated `__serialize()` / `__unserialize()` to include the new property

**Usage:**
```php
$action = SendSEPADirectDebit::create($account, $painXml);
$action->setSingleBookingRequested(true);
```

The bank-side parameter `einzelbuchungErlaubt` is still respected — the flag is only sent when the bank advertises support for it.