### PR TITLE
Type-safety for action classes and use DateTimeInterface

### DIFF
--- a/src/Action/GetBalance.php
+++ b/src/Action/GetBalance.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Fhp\Action;
 
 use Fhp\Model\SEPAAccount;
@@ -25,14 +27,12 @@ use Fhp\UnsupportedException;
 class GetBalance extends PaginateableAction
 {
     // Request (if you add a field here, update __serialize() and __unserialize() as well).
-    /** @var SEPAAccount */
-    private $account;
-    /** @var bool */
-    private $allAccounts;
+    private SEPAAccount $account;
+    private bool $allAccounts;
 
     // Response
     /** @var HISAL[] */
-    private $response = [];
+    private array $response = [];
 
     /**
      * @param SEPAAccount $account The account to get the balance for. This can be constructed based on information

--- a/src/Action/GetDepotAufstellung.php
+++ b/src/Action/GetDepotAufstellung.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Fhp\Action;
 
 use Fhp\Model\SEPAAccount;
@@ -25,18 +27,14 @@ use Fhp\UnsupportedException;
 class GetDepotAufstellung extends PaginateableAction
 {
     // Request (if you add a field here, update __serialize() and __unserialize() as well).
-    /** @var SEPAAccount */
-    private $account;
+    private SEPAAccount $account;
 
     // Response
-    /** @var string */
-    private $rawMT535 = '';
+    private string $rawMT535 = '';
 
-    /** @var StatementOfHoldings */
-    private $statement;
+    private ?StatementOfHoldings $statement = null;
 
-    /** @var float */
-    private $depotWert;
+    private float $depotWert = 0.0;
 
     /**
      * @param SEPAAccount $account The account to get the statement for. This can be constructed based on information

--- a/src/Action/GetSEPAAccounts.php
+++ b/src/Action/GetSEPAAccounts.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Fhp\Action;
 
 use Fhp\Model\SEPAAccount;
@@ -28,7 +30,7 @@ class GetSEPAAccounts extends PaginateableAction
 
     // Response
     /** @var SEPAAccount[] */
-    private $accounts;
+    private array $accounts = [];
 
     /**
      * @return GetSEPAAccounts A new action instance.

--- a/src/Action/GetSEPADirectDebitParameters.php
+++ b/src/Action/GetSEPADirectDebitParameters.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Fhp\Action;
 
 use Fhp\BaseAction;
@@ -17,12 +19,9 @@ class GetSEPADirectDebitParameters extends BaseAction
     public const DIRECT_DEBIT_TYPES = ['CORE', 'COR1', 'B2B'];
 
     // Request (if you add a field here, update __serialize() and __unserialize() as well).
-    /** @var string */
-    private $directDebitType;
-    /** @var string */
-    private $seqType;
-    /** @var bool */
-    private $singleDirectDebit;
+    private string $directDebitType;
+    private string $seqType;
+    private bool $singleDirectDebit;
 
     /** @var HIDXES */
     private $hidxes;

--- a/src/Action/GetStatementOfAccount.php
+++ b/src/Action/GetStatementOfAccount.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Fhp\Action;
 
 use Fhp\CAMT\CAMT;
@@ -34,45 +36,35 @@ use Fhp\UnsupportedException;
 class GetStatementOfAccount extends PaginateableAction
 {
     // Request (if you add a field here, update __serialize() and __unserialize() as well).
-    /** @var SEPAAccount */
-    private $account;
-    /** @var \DateTime */
-    private $from;
-    /** @var \DateTime */
-    private $to;
-    /** @var bool */
-    private $allAccounts;
-    /** @var bool */
-    private $includeUnbooked;
+    private SEPAAccount $account;
+    private ?\DateTimeInterface $from = null;
+    private ?\DateTimeInterface $to = null;
+    private bool $allAccounts;
+    private bool $includeUnbooked;
 
     // Information from the BPD needed to interpret the response.
-    /** @var string */
-    private $bankName;
+    private ?string $bankName = null;
 
     // Internal action for XML fallback
-    /** @var GetStatementOfAccountXML|null */
-    private $xmlAction;
+    private ?GetStatementOfAccountXML $xmlAction = null;
 
     // Response
-    /** @var string */
-    private $rawMT940 = '';
+    private string $rawMT940 = '';
 
-    /** @var array */
-    protected $parsedMT940 = [];
+    protected array $parsedMT940 = [];
 
-    /** @var StatementOfAccount */
-    private $statement;
+    private ?StatementOfAccount $statement = null;
 
     /**
      * @param SEPAAccount $account The account to get the statement for. This can be constructed based on information
      *     that the user entered, or it can be {@link SEPAAccount} instance retrieved from {@link getAccounts()}.
-     * @param \DateTime|null $from If set, only transactions after this date (inclusive) are returned.
-     * @param \DateTime|null $to If set, only transactions before this date (inclusive) are returned.
+     * @param \DateTimeInterface|null $from If set, only transactions after this date (inclusive) are returned.
+     * @param \DateTimeInterface|null $to If set, only transactions before this date (inclusive) are returned.
      * @param bool $allAccounts If set to true, will return statements for all accounts of the user. You still need to
      *     pass one of the accounts into $account, though.
      * @return GetStatementOfAccount A new action instance.
      */
-    public static function create(SEPAAccount $account, ?\DateTime $from = null, ?\DateTime $to = null, bool $allAccounts = false, bool $includeUnbooked = false): GetStatementOfAccount
+    public static function create(SEPAAccount $account, ?\DateTimeInterface $from = null, ?\DateTimeInterface $to = null, bool $allAccounts = false, bool $includeUnbooked = false): GetStatementOfAccount
     {
         if ($from !== null && $to !== null && $from > $to) {
             throw new \InvalidArgumentException('From-date must be before to-date');

--- a/src/Action/GetStatementOfAccountXML.php
+++ b/src/Action/GetStatementOfAccountXML.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /** @noinspection PhpUnused */
 
 namespace Fhp\Action;
@@ -26,26 +28,21 @@ use Fhp\UnsupportedException;
 class GetStatementOfAccountXML extends PaginateableAction
 {
     // Request (if you add a field here, update __serialize() and __unserialize() as well).
-    /** @var SEPAAccount */
-    private $account;
-    /** @var \DateTime */
-    private $from;
-    /** @var \DateTime */
-    private $to;
-    /** @var string */
-    private $camtURN;
-    /** @var bool */
-    private $allAccounts;
+    private SEPAAccount $account;
+    private ?\DateTimeInterface $from = null;
+    private ?\DateTimeInterface $to = null;
+    private ?string $camtURN = null;
+    private bool $allAccounts;
 
     // Response
     /** @var string[] */
-    protected $xml = [];
+    protected array $xml = [];
 
     /**
      * @param SEPAAccount $account The account to get the statement for. This can be constructed based on information
      *     that the user entered, or it can be {@link SEPAAccount} instance retrieved from {@link getAccounts()}.
-     * @param \DateTime|null $from If set, only transactions after this date (inclusive) are returned.
-     * @param \DateTime|null $to If set, only transactions before this date (inclusive) are returned.
+     * @param \DateTimeInterface|null $from If set, only transactions after this date (inclusive) are returned.
+     * @param \DateTimeInterface|null $to If set, only transactions before this date (inclusive) are returned.
      * @param string|null $camtURN The URN/descriptor of the CAMT XML format you want the bank to return.
      *     Use null to just let the bank decide. Otherwise needs to be one of the reported URNs the bank supports.
      *     For example urn:iso:std:iso:20022:tech:xsd:camt.052.001.02
@@ -53,7 +50,7 @@ class GetStatementOfAccountXML extends PaginateableAction
      *     pass one of the accounts into $account, though.
      * @return GetStatementOfAccountXML A new action instance.
      */
-    public static function create(SEPAAccount $account, ?\DateTime $from = null, ?\DateTime $to = null, ?string $camtURN = null, bool $allAccounts = false): GetStatementOfAccountXML
+    public static function create(SEPAAccount $account, ?\DateTimeInterface $from = null, ?\DateTimeInterface $to = null, ?string $camtURN = null, bool $allAccounts = false): GetStatementOfAccountXML
     {
         if ($from !== null && $to !== null && $from > $to) {
             throw new \InvalidArgumentException('From-date must be before to-date');

--- a/src/Action/SendInternationalCreditTransfer.php
+++ b/src/Action/SendInternationalCreditTransfer.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Fhp\Action;
 
 use Fhp\BaseAction;
@@ -15,12 +17,9 @@ use Fhp\Syntax\Bin;
 class SendInternationalCreditTransfer extends BaseAction
 {
     // Request (if you add a field here, update __serialize() and __unserialize() as well).
-    /** @var SEPAAccount */
-    protected $account;
-    /** @var string */
-    protected $dtavzData;
-    /** @var string|null */
-    protected $dtavzVersion;
+    protected SEPAAccount $account;
+    protected string $dtavzData;
+    protected ?string $dtavzVersion = null;
 
     /**
      * @param SEPAAccount $account The account of the creditor (the sender of the money)

--- a/src/Action/SendSEPADirectDebit.php
+++ b/src/Action/SendSEPADirectDebit.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Fhp\Action;
 
 use Fhp\BaseAction;
@@ -25,20 +27,13 @@ use Fhp\UnsupportedException;
 class SendSEPADirectDebit extends BaseAction
 {
     // Request (if you add a field here, update __serialize() and __unserialize() as well).
-    /** @var SEPAAccount */
-    protected $account;
-    /** @var string */
-    protected $painMessage;
-    /** @var string */
-    protected $painNamespace;
-    /** @var float */
-    protected $ctrlSum;
-    /** @var bool */
-    protected $singleDirectDebit = false;
-    /** @var bool */
-    protected $tryToUseControlSumForSingleTransactions = false;
-    /** @var string */
-    private $coreType;
+    protected SEPAAccount $account;
+    protected string $painMessage;
+    protected string $painNamespace;
+    protected ?float $ctrlSum = null;
+    protected bool $singleDirectDebit = false;
+    protected bool $tryToUseControlSumForSingleTransactions = false;
+    private ?string $coreType = null;
     private bool $singleBookingRequested = false;
 
     // There are no result fields. This action is simply marked as done to indicate that the transfer was executed.
@@ -56,7 +51,7 @@ class SendSEPADirectDebit extends BaseAction
         $ctrlSum = null;
 
         if (preg_match('@<GrpHdr>.*?<CtrlSum>(?<ctrlsum>[0-9.]+)</CtrlSum>.*?</GrpHdr>@s', $painMessage, $matches) === 1) {
-            $ctrlSum = $matches['ctrlsum'];
+            $ctrlSum = (float) $matches['ctrlsum'];
         }
 
         if (preg_match('@<PmtTpInf>.*?<LclInstrm>.*?<Cd>(?<coretype>CORE|COR1|B2B)</Cd>.*?</LclInstrm>.*?</PmtTpInf>@s', $painMessage, $matches) === 1) {

--- a/src/Action/SendSEPARealtimeTransfer.php
+++ b/src/Action/SendSEPARealtimeTransfer.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Fhp\Action;
 
 use Fhp\BaseAction;
@@ -25,12 +27,9 @@ use Fhp\UnsupportedException;
 class SendSEPARealtimeTransfer extends BaseAction
 {
     // Request (if you add a field here, update __serialize() and __unserialize() as well).
-    /** @var SEPAAccount */
-    private $account;
-    /** @var string */
-    private $painMessage;
-    /** @var string */
-    private $xmlSchema;
+    private SEPAAccount $account;
+    private string $painMessage;
+    private string $xmlSchema;
     private bool $allowConversionToSEPATransfer = true;
 
     // There are no result fields. This action is simply marked as done to indicate that the transfer was executed.

--- a/src/Action/SendSEPATransfer.php
+++ b/src/Action/SendSEPATransfer.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Fhp\Action;
 
 use Fhp\BaseAction;
@@ -20,14 +22,10 @@ use Fhp\UnsupportedException;
 class SendSEPATransfer extends BaseAction
 {
     // Request (if you add a field here, update __serialize() and __unserialize() as well).
-    /** @var SEPAAccount */
-    private $account;
-    /** @var string */
-    private $painMessage;
-    /** @var string */
-    private $xmlSchema;
-    /** @var bool */
-    private $singleBookingRequested = false;
+    private SEPAAccount $account;
+    private string $painMessage;
+    private string $xmlSchema;
+    private bool $singleBookingRequested = false;
 
     // There are no result fields. This action is simply marked as done to indicate that the transfer was executed.
 


### PR DESCRIPTION
This is just a small first change to add type-safety to this project. This means property are now type-strict and php will for example complain about float operations on strings and not auto-cast.
Additionally I switched `DateTime` to `DateTimeInterface` to allow also `DateTimeImmutable` as input.