### PR TITLE
fix: parse all Ustrd tags

### DIFF
--- a/src/CAMT/CAMT.php
+++ b/src/CAMT/CAMT.php
@@ -337,7 +337,10 @@ class CAMT
         // Unstructured remittance info - this is the main "Verwendungszweck"
         $unstructured = $remittanceInfo->xpath('.//c:Ustrd');
         if ($unstructured !== false && !empty($unstructured)) {
-            $ustrd = (string) $unstructured[0];
+            $ustrd = '';
+            foreach ($unstructured as $tag) {
+                $ustrd .= (string) $tag;
+            }
 
             // Parse structured SEPA fields from unstructured text
             $structuredFields = $this->extractStructuredFieldsFromText($ustrd);


### PR DESCRIPTION
Currently only the first tag of `Ustrd` is parsed and the rest is ignored. For example if you have this payload (ING):
```xml
<RmtInf>
  <Ustrd>Beschreibung 1 un</Ustrd>
  <Ustrd>d diese geht hier weiter</Ustrd>
</RmtInf>
```
This change will parse all `Ustrd` tags