### PR TITLE
VoP: only reject stepwise report delivery when it actually happens

### DIFF
--- a/Tests/Unit/Integration/Atruvia/AtruviaIntegrationTestBase.php
+++ b/Tests/Unit/Integration/Atruvia/AtruviaIntegrationTestBase.php
@@ -49,7 +49,7 @@ class AtruviaIntegrationTestBase extends FinTsTestCase
      */
     protected function InitAnonymous()
     {
-        $this->expectMessage(static::ANONYMOUS_INIT_REQUEST, mb_convert_encoding(static::ANONYMOUS_INIT_RESPONSE, 'ISO-8859-1', 'UTF-8'));
+        $this->expectMessage(static::ANONYMOUS_INIT_REQUEST, mb_convert_encoding(static::anonymousInitResponse(), 'ISO-8859-1', 'UTF-8'));
         $this->expectMessage(static::ANONYMOUS_END_REQUEST, mb_convert_encoding(static::ANONYMOUS_END_RESPONSE, 'ISO-8859-1', 'UTF-8'));
 
         $this->fints->getBpd();
@@ -62,7 +62,7 @@ class AtruviaIntegrationTestBase extends FinTsTestCase
     protected function initDialog()
     {
         // We already know the TAN mode, so it will only fetch the BPD (anonymously) to verify it.
-        $this->expectMessage(static::ANONYMOUS_INIT_REQUEST, mb_convert_encoding(static::ANONYMOUS_INIT_RESPONSE, 'ISO-8859-1', 'UTF-8'));
+        $this->expectMessage(static::ANONYMOUS_INIT_REQUEST, mb_convert_encoding(static::anonymousInitResponse(), 'ISO-8859-1', 'UTF-8'));
         $this->expectMessage(static::ANONYMOUS_END_REQUEST, mb_convert_encoding(static::ANONYMOUS_END_RESPONSE, 'ISO-8859-1', 'UTF-8'));
 
         // Then when we initialize a dialog, it's going to request a Kundensystem-ID and UPD.
@@ -76,6 +76,15 @@ class AtruviaIntegrationTestBase extends FinTsTestCase
         $login = $this->fints->login();
         $login->ensureDone(); // No TAN required upon login.*/
         $this->assertAllMessagesSeen();
+    }
+
+    /**
+     * The response that carries the BPD. Subclasses can override this to test with different bank parameters, without
+     * having to duplicate the (very long) message.
+     */
+    protected static function anonymousInitResponse(): string
+    {
+        return static::ANONYMOUS_INIT_RESPONSE;
     }
 
     protected function getTestAccount(): SEPAAccount

--- a/Tests/Unit/Integration/Atruvia/SendTransferVoPStepwiseTest.php
+++ b/Tests/Unit/Integration/Atruvia/SendTransferVoPStepwiseTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Fhp\Tests\Unit\Integration\Atruvia;
+
+use Fhp\UnsupportedException;
+
+/**
+ * Runs the same Verification of Payee scenarios as {@link SendTransferVoPTest}, but against a bank that announces
+ * "schrittweise Lieferung" (S) of the payment status report in HIVPPS, as e.g. comdirect does.
+ *
+ * That parameter only describes how the bank splits the pain.002 message *if* it uses the Aufsetzpunkt mechanism, so
+ * all of the inherited scenarios have to work just the same. Only when the bank actually delivers a partial report do
+ * we have to give up, because stitching the deltas back together is not implemented.
+ */
+class SendTransferVoPStepwiseTest extends SendTransferVoPTest
+{
+    protected static function anonymousInitResponse(): string
+    {
+        $stepwise = str_replace(
+            'HIVPPS:78:1:3+1+1+1+999:J:V:J:J:',
+            'HIVPPS:78:1:3+1+1+1+999:J:S:J:J:',
+            parent::anonymousInitResponse()
+        );
+        if ($stepwise === parent::anonymousInitResponse()) {
+            throw new \AssertionError('Failed to patch HIVPPS in the test BPD');
+        }
+        return $stepwise;
+    }
+
+    /**
+     * With "schrittweise Lieferung" (S) an intermediate delivery only contains the delta, so the client would have to
+     * stitch the deliveries together. That is not implemented, and we expect a clear error instead of a wrong result.
+     * @throws \Throwable
+     */
+    public function testIntermediateReportDelivery(): void
+    {
+        $this->initDialog();
+        $action = $this->createAction();
+
+        $response = static::buildVopReportResponse(
+            static::SEND_TRANSFER_RESPONSE_POLLING_NEEDED,
+            static::VOP_REPORT_PARTIAL_MATCH_XML_PAYLOAD
+        );
+        $this->expectMessage(static::SEND_TRANSFER_REQUEST, $response);
+
+        $this->expectException(UnsupportedException::class);
+        $this->expectExceptionMessage('The stepwise transfer of VOP reports is not yet supported');
+        $this->fints->execute($action);
+    }
+}

--- a/Tests/Unit/Integration/Atruvia/SendTransferVoPTest.php
+++ b/Tests/Unit/Integration/Atruvia/SendTransferVoPTest.php
@@ -282,6 +282,29 @@ class SendTransferVoPTest extends AtruviaIntegrationTestBase
         $this->assertNull($action->getVopConfirmationRequest()->getDifferingPayeeName());
     }
 
+    /**
+     * The bank tells us that it needs more time (Aufsetzpunkt) and already sends a first part of the report. With
+     * "vollstaendige Lieferung" (V) every delivery contains all data accumulated so far, so we can simply discard the
+     * intermediate one and keep polling for the final report.
+     * @throws \Throwable
+     */
+    public function testIntermediateReportDelivery(): void
+    {
+        $this->initDialog();
+        $action = $this->createAction();
+
+        $response = static::buildVopReportResponse(
+            static::SEND_TRANSFER_RESPONSE_POLLING_NEEDED,
+            static::VOP_REPORT_PARTIAL_MATCH_XML_PAYLOAD
+        );
+        $this->expectMessage(static::SEND_TRANSFER_REQUEST, $response);
+        $this->fints->execute($action);
+
+        $this->assertTrue($action->needsPollingWait());
+        $this->assertFalse($action->needsVopConfirmation());
+        $this->assertFalse($action->isDone());
+    }
+
     protected function createAction(): SendSEPATransfer
     {
         return SendSEPATransfer::create($this->getTestAccount(), self::XML_PAYLOAD);

--- a/src/FinTs.php
+++ b/src/FinTs.php
@@ -408,7 +408,7 @@ class FinTs
 
         // Detect if the bank needs us to do something for Verification of Payee.
         if ($hkvpp != null) {
-            if ($pollingInfo = VopHelper::checkPollingRequired($response, $hkvpp->getSegmentNumber())) {
+            if ($pollingInfo = VopHelper::checkPollingRequired($response, $hkvpp->getSegmentNumber(), $this->bpd)) {
                 $action->setPollingInfo($pollingInfo);
                 if ($action->needsTan()) {
                     throw new UnexpectedResponseException('Unexpected polling and TAN request in the same response.');

--- a/src/Segment/VPP/VopHelper.php
+++ b/src/Segment/VPP/VopHelper.php
@@ -28,9 +28,11 @@ class VopHelper
         /** @var HIVPPSv1 $hivpps */
         $hivpps = $bpd->getLatestSupportedParameters('HIVPPS');
         $supportedFormats = explode(';', $hivpps->parameter->unterstuetztePaymentStatusReportDatenformate);
-        if ($hivpps->parameter->artDerLieferungPaymentStatusReport !== 'V') {
-            throw new UnsupportedException('The stepwise transfer of VOP reports is not yet supported');
-        }
+
+        // Note: The "Art der Lieferung Payment Status Report" (V/S) parameter only describes how the bank splits the
+        // pain.002 message *if* it uses the Aufsetzpunkt mechanism, which it typically only does for large batches.
+        // So we can always send the initial request and only need to look at the parameter once the bank actually
+        // sends us a partial report, see checkPollingRequired().
 
         $hkvpp = HKVPPv1::createEmpty();
         $hkvpp->unterstuetztePaymentStatusReports->paymentStatusReportDescriptor = $supportedFormats;
@@ -53,12 +55,16 @@ class VopHelper
     /**
      * @param Message $response The response we just received from the server.
      * @param int $hkvppSegmentNumber The number of the HKVPP segment in the request we had sent.
+     * @param BPD $bpd The BPD, which tells us how the bank splits the report across multiple deliveries.
      * @return ?VopPollingInfo If the response indicates that the Verification of Payee is still ongoing, such that the
      *     client should keep polling the server to (actively) wait until the result is available, this function returns
      *     a corresponding polling info object. If no polling is required, it returns null.
      */
-    public static function checkPollingRequired(Message $response, int $hkvppSegmentNumber): ?VopPollingInfo
-    {
+    public static function checkPollingRequired(
+        Message $response,
+        int $hkvppSegmentNumber,
+        BPD $bpd,
+    ): ?VopPollingInfo {
         // Note: We determine whether polling is required purely based on the presence of the primary polling token (
         // the Aufsetzpunkt is mandatory, the polling ID is optional).
         // The specification also contains the code "3093 Namensabgleich ist noch in Bearbeitung", which could also be
@@ -70,9 +76,20 @@ class VopHelper
         }
         /** @var HIVPPv1 $hivpp */
         $hivpp = $response->findSegment(HIVPPv1::class);
-        if ($hivpp->vopId !== null || $hivpp->paymentStatusReport !== null) {
-            // Implementation note: If this ever happens, it could be related to $artDerLieferungPaymentStatusReport.
-            throw new UnexpectedResponseException('Got response with Aufsetzpunkt AND vopId/paymentStatusReport.');
+        if ($hivpp->vopId !== null) {
+            // The specification says that the VOP ID is only present in the final HIVPP of an Aufsetzpunkt sequence.
+            throw new UnexpectedResponseException('Got response with Aufsetzpunkt AND vopId.');
+        }
+        if ($hivpp->paymentStatusReport !== null) {
+            // This is an intermediate delivery of the report. With "vollstaendige Lieferung" (V) each delivery
+            // contains all data accumulated so far, so the final one is enough and we can discard this one. With
+            // "schrittweise Lieferung" (S) the bank only sends the delta, so the client would have to stitch the
+            // deliveries together, which is not implemented.
+            /** @var HIVPPSv1 $hivpps */
+            $hivpps = $bpd->getLatestSupportedParameters('HIVPPS');
+            if ($hivpps->parameter->artDerLieferungPaymentStatusReport !== 'V') {
+                throw new UnsupportedException('The stepwise transfer of VOP reports is not yet supported');
+            }
         }
         return new VopPollingInfo(
             $aufsetzpunkt->rueckmeldungsparameter[0],


### PR DESCRIPTION
I have implementes SEPA transaction in my "Finanzmanager" Software thanks to nemiah/phpFinTS. Here is my solution for some missing details with comdirect german bank including following PR#585:

The HIVPPS parameter "Art der Lieferung Payment Status Report" (V/S) describes how the bank
splits the pain.002 message *if* it uses the Aufsetzpunkt mechanism, which it typically only
does for large batches:

> Der BPD-Parameter gibt an, ob die pain.002-Nachricht **bei einer Aufsetzpunktbehandlung**
> vollständig oder schrittweise übertragen wird.
>
> — FinTS_3.0_Messages_Geschaeftsvorfaelle_VOP_1.01_2025_06_27_FV.pdf, chapter D

Rejecting `S` while building the very first HKVPP is therefore too early: it makes *every*
transfer fail for banks that announce stepwise delivery, even for a single transfer where the
result comes back right away and no Aufsetzpunkt is involved at all.

comdirect is such a bank. Its BPD says:

```
HIVPPS:7:1:3+1+1+0+20:J:S:N:N:sepade.pain.002.001.10.xsd:HKIPZ:HKCUI:HKCCS:HKCDE:HKCDN:HKCSE:HKCSA:HKIPM:HKCCM
```

So every transfer ended in `UnsupportedException: The stepwise transfer of VOP reports is not
yet supported`, although the bank returns the VOP result in a single response.

### What this changes

The check moves to where it matters, `VopHelper::checkPollingRequired()`:

* If the bank sends an **intermediate delivery** of the report, "vollständige Lieferung" (`V`)
  means each delivery contains all data accumulated so far, so the intermediate one can be
  discarded and we keep polling for the final report. Previously this raised
  `UnexpectedResponseException`.
* Only for "schrittweise Lieferung" (`S`) would the client have to stitch the deltas together.
  That is still not implemented and still raises `UnsupportedException`, just at the point
  where it is actually true.
* An Aufsetzpunkt together with a `vopId` remains an unexpected response, since the
  specification says the VOP ID is only set in the final HIVPP of such a sequence.

`checkPollingRequired()` needs the BPD for this, so it takes it as a third parameter now. The
only caller is `FinTs::processServerResponse()`.

### Tests

`SendTransferVoPStepwiseTest` runs all existing VOP scenarios against a bank that announces
stepwise delivery, by overriding the BPD in the test base (new `anonymousInitResponse()` hook,
so the very long message does not have to be duplicated). Both variants additionally cover an
intermediate report delivery: discarded for `V`, rejected for `S`.

Verified against comdirect: with this change a single transfer completes through VOP
confirmation and TAN.

Related: #477
