### PR TITLE
fix: namespaces for CLILogger

### DIFF
--- a/Samples/bpd.php
+++ b/Samples/bpd.php
@@ -8,11 +8,11 @@
  */
 require '../vendor/autoload.php';
 
-$options = new \Fhp\Options\FinTsOptions();
+$options = new Fhp\Options\FinTsOptions();
 $options->url = 'https://banking-dkb.s-fints-pt-dkb.de/fints30'; // HBCI / FinTS Url can be found here: https://www.hbci-zka.de/institute/institut_auswahl.htm (use the PIN/TAN URL)
 $options->bankCode = '12030000'; // Your bank code / Bankleitzahl
 $options->productName = 'Dummy'; // The number you receive after registration / FinTS-Registrierungsnummer. Not all banks require this just to retrieve the BPD.
 $options->productVersion = '1.0'; // Your own Software product version
-$bpd = \Fhp\FinTs::fetchBpd($options, new \Tests\Fhp\CLILogger());
+$bpd = Fhp\FinTs::fetchBpd($options, new Fhp\Tests\CLILogger());
 
 print_r($bpd); // Tip: Put a breakpoint on this line.

--- a/Samples/init.php
+++ b/Samples/init.php
@@ -10,14 +10,14 @@ require '../vendor/autoload.php';
 // The configuration options up here are considered static wrt. the library's internal state and its requests.
 // That is, even if you persist the FinTs instance, you need to be able to reproduce all this information from some
 // application-specific storage (e.g. your database) in order to use the phpFinTS library.
-$options = new \Fhp\Options\FinTsOptions();
+$options = new Fhp\Options\FinTsOptions();
 $options->url = ''; // HBCI / FinTS Url can be found here: https://www.hbci-zka.de/institute/institut_auswahl.htm (use the PIN/TAN URL)
 $options->bankCode = ''; // Your bank code / Bankleitzahl
 $options->productName = ''; // The number you receive after registration / FinTS-Registrierungsnummer
 $options->productVersion = '1.0'; // Your own Software product version
-$credentials = \Fhp\Options\Credentials::create('username', 'pin'); // This is NOT the PIN of your bank card!
-$fints = \Fhp\FinTs::new($options, $credentials);
-$fints->setLogger(new \Tests\Fhp\CLILogger());
+$credentials = Fhp\Options\Credentials::create('username', 'pin'); // This is NOT the PIN of your bank card!
+$fints = Fhp\FinTs::new($options, $credentials);
+$fints->setLogger(new Fhp\Tests\CLILogger());
 
 // Usage:
 // $fints = require_once 'init.php';


### PR DESCRIPTION
Fix broken test samples (relates to item 30 in #588 )