### PR TITLE
Expose the credit card merchant as a separate field

### DIFF
--- a/Tests/Unit/Segment/DIKKUTest.php
+++ b/Tests/Unit/Segment/DIKKUTest.php
@@ -174,6 +174,10 @@ class DIKKUTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('2026-07-18', $domestic->getBookingDate()->format('Y-m-d'));
         $this->assertEquals('2026-07-17', $domestic->getValutaDate()->format('Y-m-d'));
         $this->assertEquals('EXAMPLE SHOP BERLIN 555500******2233', $domestic->getPurpose());
+        // getMerchant() returns just the first line, without the location and masked card number that
+        // getPurpose() carries, so the same merchant yields a stable name across bookings.
+        $this->assertEquals('EXAMPLE SHOP', $domestic->getMerchant());
+        $this->assertEquals(['EXAMPLE SHOP', 'BERLIN 555500******2233'], $domestic->getPurposeLines());
         $this->assertEquals('5411', $domestic->getMerchantCategoryCode());
         // No conversion took place, so no original amount is reported.
         $this->assertNull($domestic->getOriginalAmount());
@@ -189,6 +193,8 @@ class DIKKUTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(1000.0, $settlement->getAmount());
         $this->assertEquals(CreditCardTransaction::CD_CREDIT, $settlement->getCreditDebit());
         $this->assertNull($settlement->getMerchantCategoryCode());
+        // A booking without a real merchant still exposes its first line via getMerchant().
+        $this->assertEquals('Ausgleich Kreditkartenabrechnung', $settlement->getMerchant());
     }
 
     public function testEmptyStatement()

--- a/src/Model/CreditCardStatement/CreditCardTransaction.php
+++ b/src/Model/CreditCardStatement/CreditCardTransaction.php
@@ -29,6 +29,12 @@ class CreditCardTransaction
     /** The exchange rate applied, or null if no conversion took place. */
     protected ?float $exchangeRate = null;
     protected string $purpose = '';
+    /**
+     * The individual Verwendungszweck lines, in order, non-empty only. {@link $purpose} is these
+     * joined by spaces. Usually the first line is the merchant name and the second the merchant
+     * location followed by the masked card number.
+     */
+    protected array $purposeLines = [];
     protected ?string $reference = null;
     /** ISO 18245 merchant category code, e.g. 5411 for grocery stores. Null if the booking has no merchant. */
     protected ?string $merchantCategoryCode = null;
@@ -108,6 +114,41 @@ class CreditCardTransaction
     {
         $this->purpose = $purpose;
         return $this;
+    }
+
+    /**
+     * @return string[] The individual Verwendungszweck lines, in order, non-empty only. Usually the
+     *     first line is the merchant name and the second the merchant location followed by the masked
+     *     card number. {@link getPurpose()} returns these joined by spaces.
+     */
+    public function getPurposeLines(): array
+    {
+        return $this->purposeLines;
+    }
+
+    /**
+     * @param string[] $purposeLines
+     */
+    public function setPurposeLines(array $purposeLines): static
+    {
+        $this->purposeLines = $purposeLines;
+        return $this;
+    }
+
+    /**
+     * The merchant name, taken from the first Verwendungszweck line. Prefer this over
+     * {@link getPurpose()} when you need a stable counterparty name (e.g. to name an expense account),
+     * because the full purpose also contains the location and the masked card number, which vary
+     * between bookings of the same merchant.
+     *
+     * For bookings without a merchant, such as the monthly settlement, this returns whatever
+     * descriptive text the bank placed in the first line (e.g. "Ausgleich Kreditkartenabrechnung").
+     *
+     * @return string|null Null only if the record carries no Verwendungszweck at all.
+     */
+    public function getMerchant(): ?string
+    {
+        return $this->purposeLines[0] ?? null;
     }
 
     public function getReference(): ?string
@@ -193,7 +234,8 @@ class CreditCardTransaction
             $result->exchangeRate = $umsatz->umrechnungskurs;
         }
 
-        $result->purpose = trim(implode(' ', $umsatz->getVerwendungszweckLines()));
+        $result->purposeLines = $umsatz->getVerwendungszweckLines();
+        $result->purpose = trim(implode(' ', $result->purposeLines));
         $result->reference = $umsatz->referenz;
         $result->merchantCategoryCode = $umsatz->branchenschluessel;
         return $result;


### PR DESCRIPTION
Follow-up to #574. `GetCreditCardStatement` exposes the Verwendungszweck only through
`getPurpose()`, which joins all lines into a single string: the merchant name together with the
merchant location and the masked card number, e.g. `EXAMPLE SHOP BERLIN 555500******2233`.

That string is a poor counterparty name. The same merchant yields a different purpose per location
and per card, so anything that groups by counterparty — for instance naming an expense account in a
bookkeeping tool — fragments one merchant into many.

```php
$statement = $getTransactions->getStatement();
foreach ($statement->getTransactions() as $tx) {
    $tx->getMerchant();      // "EXAMPLE SHOP"
    $tx->getPurpose();       // "EXAMPLE SHOP BERLIN 555500******2233"
    $tx->getPurposeLines();  // ["EXAMPLE SHOP", "BERLIN 555500******2233"]
}
```

**Changes:**
- Keep the individual Verwendungszweck lines on `CreditCardTransaction` instead of discarding them
  after joining
- Add `getPurposeLines()` (the lines) and `getMerchant()` (the first line, usually the merchant)
- `getPurpose()` is unchanged, so this is backwards compatible

`getMerchant()` returns the first line verbatim. For bookings without a merchant, such as the monthly
settlement, that is the descriptive text the bank places there (e.g. `Ausgleich
Kreditkartenabrechnung`); it is null only when the record carries no Verwendungszweck at all. The
existing `testMapsToModel` fixture is extended to cover both the merchant and the settlement case.

Developed with the assistance of Claude Code. The field semantics above were checked against the
DKKKU test fixtures introduced in #574, which mirror real BW-Bank/LBBW responses.
